### PR TITLE
feat(fame): add Slipstream CL replay snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,4 +212,5 @@ $RECYCLE.BIN/
 node_modules
 .layers
 .aws-sam
-.env
+.env.worktrees
+.worktrees

--- a/deploy/lib/fame-pool-state.ts
+++ b/deploy/lib/fame-pool-state.ts
@@ -109,6 +109,7 @@ export class FamePoolState extends Construct {
       sortKey: { name: "sk", type: dynamodb.AttributeType.STRING },
       tableClass: dynamodb.TableClass.STANDARD,
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: "expiresAt",
     });
 
     const commonEnvironment = {

--- a/deploy/test/fame-pool-state.test.ts
+++ b/deploy/test/fame-pool-state.test.ts
@@ -66,6 +66,10 @@ describe("FamePoolState infrastructure", () => {
         },
       ],
       GlobalSecondaryIndexes: Match.absent(),
+      TimeToLiveSpecification: {
+        AttributeName: "expiresAt",
+        Enabled: true,
+      },
     });
     template.resourceCountIs("AWS::Lambda::Function", 3);
     template.hasResourceProperties("AWS::Events::Rule", {

--- a/docs/brainstorms/2026-05-20-slipstream-usdc-weth-100-cl-replay-snapshot-proof-requirements.md
+++ b/docs/brainstorms/2026-05-20-slipstream-usdc-weth-100-cl-replay-snapshot-proof-requirements.md
@@ -1,0 +1,145 @@
+---
+date: 2026-05-20
+topic: slipstream-usdc-weth-100-cl-replay-snapshot-proof
+---
+
+# Slipstream USDC/WETH CL Replay Snapshot Proof
+
+## Summary
+
+Build a snapshot-first proof that makes `slipstream-usdc-weth-100` locally replayable in shadow mode. `society-bots` will produce complete same-block replay state for this one pool; `www` will compare local replay against the live Slipstream quoter before any user-facing quote path can use indexed CL replay.
+
+---
+
+## Problem Frame
+
+FAME quoting is moving toward faster, richer market-state indexing, but concentrated-liquidity pools still require live quoter calls for correct output. The current `society-bots` CL head snapshot surface is useful for diagnostics because it exposes current price, tick, active liquidity, fee metadata, freshness, and provenance. It is not enough to replay swaps that cross initialized ticks.
+
+The high-impact candidate is `slipstream-usdc-weth-100`, because USDC routes often depend on that connector and `www` already validates it through the live Slipstream quoter. The immediate risk is false confidence: a partial CL index could look fresh while still producing plausible but wrong quotes because it missed dynamic fee state, initialized tick data, block consistency, or exact rounding behavior.
+
+---
+
+## Actors
+
+- A1. `society-bots` pool-state indexer: Captures and serves block-attributed indexed state for the reviewed pool universe.
+- A2. `www` quote system: Owns quote math, route attribution, live fallback, route-lab validation, and public quote behavior.
+- A3. Operator/reviewer: Uses logs, route-lab output, and smoke checks to decide whether indexed replay is trustworthy.
+- A4. FAME swap user: Benefits indirectly through faster quotes only after shadow parity proves correctness.
+
+---
+
+## Key Flows
+
+- F1. Snapshot state is captured
+  - **Trigger:** The pool-state indexer reaches a safe Base block.
+  - **Actors:** A1
+  - **Steps:** The indexer captures all replay primitives for `slipstream-usdc-weth-100` at one block, verifies completeness, records block identity, and publishes only complete state.
+  - **Outcome:** A replay snapshot is either fresh and complete or unavailable for replay; partial state is not served as replay-capable.
+  - **Covered by:** R1, R2, R3, R4
+
+- F2. Shadow replay is evaluated
+  - **Trigger:** `www` has a quote context that includes `slipstream-usdc-weth-100`.
+  - **Actors:** A2
+  - **Steps:** `www` requests replay-capable state, validates freshness and provenance, runs local replay if eligible, compares with the live Slipstream quoter at the same block, and serves the live quote while shadow mode is active.
+  - **Outcome:** The system records parity, latency, and fallback evidence without changing user-facing quote behavior.
+  - **Covered by:** R5, R6, R7, R8, R9
+
+- F3. Promotion is considered
+  - **Trigger:** Route-lab and shadow telemetry show stable parity.
+  - **Actors:** A2, A3
+  - **Steps:** The operator reviews exact-match parity, fallback reasons, snapshot freshness, and payload cost, then enables indexed replay only for this pool when the gate is satisfied.
+  - **Outcome:** Indexed replay can enter the hot path behind a server-side control, with live quoter fallback preserved.
+  - **Covered by:** R10, R11, R12
+
+---
+
+## Requirements
+
+**Snapshot state**
+
+- R1. The first replayable CL scope is exactly `slipstream-usdc-weth-100`; other CL pools remain observational, unsupported, or live-quoted.
+- R2. The replay snapshot must include enough same-block state for exact-input replay across initialized tick crossings: head price, current tick, active liquidity, tick spacing, initialized tick bitmap data, initialized tick liquidity data, exact dynamic fee, pool identity, token order, and block identity.
+- R3. Replay state must be captured against one safe block. Mixed-block state, missing block identity, missing dynamic fee, missing tick data, or incomplete chunk reads must make the replay state unavailable.
+- R4. The initial milestone uses periodic safe-block full snapshots, not event-driven tick maintenance. Event maintenance may be explored later only after snapshot parity is proven.
+
+**API and consumption contract**
+
+- R5. `society-bots` exposes replay state as raw indexed state, not as a quote endpoint. It must not decide route selection, output amount, slippage, or user-facing quote readiness.
+- R6. Existing reserve and CL head snapshot behavior must remain safe for current clients; clients that do not opt into replay-capable state must not accidentally treat CL head state as replay authority.
+- R7. `www` validates replay state before use: source registry match, pool identity, token direction, freshness, not observed ahead of the quote context, replay model support, complete tick state, exact fee presence, and parser validity.
+- R8. Any failed validation in `www` must fall back to the live Slipstream quoter and emit one structured fallback reason suitable for route-lab or operator telemetry.
+
+**Replay and parity**
+
+- R9. `www` owns local Slipstream replay math and compares it against the live Slipstream quoter in shadow mode before serving indexed replay results.
+- R10. Production promotion requires exact same-block parity for exposed comparison fields, especially `amountOut` and post-swap price when the live quoter exposes it. Tolerance-based production matching is out of scope.
+- R11. Shadow validation must cover both WETH to USDC and USDC to WETH, across tiny, common, larger, and tick-crossing amount bands.
+- R12. While shadow mode is active, user-facing quote behavior remains live-quoter-backed even when local replay succeeds.
+
+**Telemetry and handoff quality**
+
+- R13. The proof must expose enough evidence for an operator to answer whether indexed replay is currently safe for this pool: snapshot age, observed block, state completeness, dynamic fee freshness, fallback reasons, parity result, and live-vs-replay latency.
+- R14. The requirements and release evidence must make the first milestone clear: fresh replay state plus shadow parity, not broad CL indexing or user-facing indexed CL quotes.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R3.** Given the indexer captures all required replay primitives for `slipstream-usdc-weth-100` at one safe block, when the state is served to a replay-capable client, the response is replay-eligible and carries block identity and completeness evidence.
+- AE2. **Covers R3, R8.** Given one tick chunk or the dynamic fee read is missing, when `www` evaluates the replay state, it skips local replay, records the corresponding fallback reason, and uses the live Slipstream quoter.
+- AE3. **Covers R5, R9, R12.** Given local replay matches the live quoter in shadow mode, when a user requests a quote, `www` still serves the live-quoter result until promotion is explicitly enabled.
+- AE4. **Covers R7, R8.** Given replay state is observed through a block greater than the quote context block, when `www` evaluates freshness, it treats the state as unusable for that quote and falls back live.
+- AE5. **Covers R10, R11.** Given the route-lab matrix runs both directions and representative amount bands, when any deterministic comparison field mismatches, the pool is not eligible for hot-path indexed replay.
+- AE6. **Covers R13, R14.** Given the proof is ready for review, when an operator reads the route-lab or smoke output, they can see snapshot freshness, parity status, latency comparison, and every live fallback reason.
+
+---
+
+## Success Criteria
+
+- `society-bots` can produce complete same-block replay state for `slipstream-usdc-weth-100` without weakening existing reserve or CL head behavior.
+- `www` can locally replay representative exact-input Slipstream quotes in shadow mode and compare them to the live quoter at the same block.
+- Route-lab or smoke evidence shows both directions, representative amount bands, exact-match parity where expected, and typed fallback where replay is unsafe.
+- Planning can proceed without re-deciding the first milestone, quote authority boundary, parity threshold, or event-driven maintenance scope.
+
+---
+
+## Scope Boundaries
+
+- No event-driven tick maintenance in the first milestone.
+- No generic replay for other Slipstream, Slipstream2, Uniswap V3, or Uniswap V4 pools.
+- No `society-bots` quote endpoint or route authority.
+- No user-facing indexed CL quote results before shadow parity is proven and explicitly enabled.
+- No tolerance-based production parity for deterministic fields.
+- No stable-pool math, native-wrap changes, router changes, or exotic route promotion.
+- No dashboards beyond the structured evidence needed to validate and operate this first proof.
+
+---
+
+## Key Decisions
+
+- Snapshot-first proof: Full safe-block snapshots are the first milestone because they are easier to verify than an event reducer.
+- One-pool scope: Limiting replay to `slipstream-usdc-weth-100` lets completeness and parity be binary.
+- Raw state contract: `society-bots` serves replay primitives; `www` owns output quotes and fallback.
+- Exact parity: A deterministic local replay mismatch is treated as a bug or incomplete state, not an acceptable tolerance.
+- Shadow before promotion: Local replay must prove itself beside live quotes before it can replace the hot-path quoter call.
+
+---
+
+## Dependencies / Assumptions
+
+- The live Slipstream quoter remains the validation oracle for this pool during the proof.
+- `www` can obtain or retain a quote context suitable for same-block comparison.
+- The full initialized tick state for this one `tickSpacing: 100` pool is small enough to snapshot and serve within acceptable provider and payload limits, or else the proof will report that limit explicitly.
+- The exact dynamic fee used by Slipstream at the snapshot block can be read and represented as an integer replay input.
+- Existing server-only helper authentication and fallback discipline remain the baseline for this work.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R2, R3][Needs research] What is the measured initialized tick count, bitmap word count, provider call count, payload size, and snapshot duration for `slipstream-usdc-weth-100` at a recent safe block?
+- [Affects R2, R10][Needs research] Which exact fee read path and integer units should be used for Slipstream replay parity?
+- [Affects R9, R10][Technical] Should the first local replay implementation port only the needed V3 math into `www`, or reuse a package where it can still preserve exact Slipstream fee and rounding behavior?
+- [Affects R13][Technical] Which existing route-lab or API debug surface should carry shadow parity evidence without exposing helper secrets or raw RPC details?

--- a/docs/fame-pool-state-handoff.md
+++ b/docs/fame-pool-state-handoff.md
@@ -5,8 +5,9 @@ This repo now owns the `society-bots` side of the FAME pool-state read model use
 ## Cross-Repo Contract
 
 - `www` remains authoritative for reviewed pool metadata, route candidates, venue capability, and quote parity.
-- `society-bots` consumes a generated registry artifact from `www` and indexes current Base reserve state for quote-model-capable pools plus CL head snapshots for reviewed CL pools in that artifact.
+- `society-bots` consumes a generated registry artifact from `www` and indexes current Base reserve state for quote-model-capable pools, CL head snapshots for reviewed CL pools, and one complete `cl-replay-v1` snapshot for `slipstream-usdc-weth-100`.
 - `www` calls the authenticated `society-bots` API from server-side quote paths. If indexed state is stale, unknown, unsupported, malformed, or not a quote model the caller can replay, `www` falls back to its existing live quote adapter.
+- `society-bots` exposes raw replay primitives only. `www` owns Slipstream exact-input math, same-block live-quoter parity, route attribution, shadow mode, and any later promotion from live fallback to local CL quotes.
 
 Primary `www` references:
 
@@ -40,10 +41,13 @@ The `society-bots` implementation adds a new `src/fame-swap-pool-state` module p
 - An authenticated HTTP API route, `POST /fame/pool-state`, for bounded batch latest-state reads, protected by both API Gateway Lambda authorizer and API Lambda token checks.
 - Structured indexer/API logs for freshness, status counts, registry id, and block coverage.
 - Passive operational health signals: SQS-backed async failure destinations plus no-action CloudWatch alarms for indexer Lambda errors, indexer Lambda throttles, missed invocations, and failure queue depth.
+- A replay snapshot lane for `slipstream-usdc-weth-100`: slot0, current liquidity, dynamic fee, full initialized tick bitmap words, initialized tick liquidity records, block identity, chunk counts, and state hash.
 
 The indexed quote-model pool set covers Uniswap V2 constant-product pools plus volatile Solidly/Equalizer and volatile Aerodrome V2 pools. Stable pools, native wrapping, pools missing reviewed CL metadata, and unknown invariants stay visible as tracked-only or unsupported.
 
 Slipstream, Slipstream2, Uniswap V3, and Uniswap V4 pools with reviewed metadata now have complete CL head snapshots: identity, fee metadata, tick spacing, state-view address where relevant, `sqrtPriceX96`, current tick, active liquidity, source, registry provenance, and `observedThroughBlock`. These rows are not local CL replay authority, do not carry tick-boundary warnings, and must not make `www` skip live reads for CL quote math.
+
+`slipstream-usdc-weth-100` is the sole exception for replay state. It can publish a complete `cl-replay-v1` capsule, but the capsule is still indexed market-state evidence, not quote authority. `www` must reject stale, future-block, incomplete, malformed, mismatched-registry, mismatched-token-order, outside-range, replay-failed, or parity-failed state and serve the live quoter result while shadow mode is active.
 
 ## Final Review Notes
 
@@ -157,6 +161,9 @@ The scheduled indexer failure destination and passive alarms are intended for in
 - Unknown Sync logs are treated as fatal before cursor advancement.
 - API freshness fails safe: if an indexed row is somehow observed through a block greater than the caller's `currentBlock`, the response is `stale`.
 - CL head snapshots are complete head-state rows, but they intentionally stop before boundary-window indexing, tick bitmap reads, or local CL quote replay. Fallback remains a normal client decision based on state kind, freshness, helper availability, and parser validity rather than a boundary warning bit.
+- `cl-replay-v1` snapshots are latest-pointer plus chunk rows. The indexer writes chunks before publishing the pointer, and the API only returns replay state when every expected bitmap/tick chunk matches snapshot id, block identity, source registry id, and state hash.
+- The replay snapshot intentionally uses periodic safe-block full scans first. Event-driven tick maintenance is deferred until this one-pool full-state proof has exact same-block parity against the live Slipstream quoter.
+- Replay state includes the pool's dynamic `fee()` value at the snapshot block. Registry fee labels are not enough for local Slipstream replay.
 - API requests accept exactly one key shape per pool: `{ poolId }` or `{ chainId, poolAddress }`. Mixed key shapes are rejected.
 - API transport errors and malformed indexed quote responses are expected to make `www` fall back to live reads, not to produce a best-effort quote from bad state.
 - DynamoDB `UnprocessedKeys` are treated as incomplete helper reads, not as missing pool state.
@@ -182,6 +189,7 @@ Run from `www` when proving consumption:
 ```sh
 bun test src/features/fame-swap/solver/poolStateRegistry.test.ts src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts src/features/fame-swap/solver/quotes/indexedReserveAdapter.test.ts src/features/fame-swap/solver/quotes/rankRoutes.test.ts src/features/fame-swap/solver/quoteWire.test.ts src/app/api/fame/swap/quote/route.test.ts scripts/fame-swap-route-lab.test.ts
 BASE_RPC_URL=<rpc> FAME_POOL_STATE_API_URL=<url> FAME_POOL_STATE_SERVICE_TOKEN=<token> bun scripts/fame-swap-route-lab.ts --indexed
+BASE_RPC_URL=<rpc> FAME_POOL_STATE_API_URL=<url> FAME_POOL_STATE_SERVICE_TOKEN=<token> bun scripts/fame-swap-cl-replay-parity.ts
 ```
 
 Attach durable release evidence before enabling `www` production helper env:
@@ -189,6 +197,7 @@ Attach durable release evidence before enabling `www` production helper env:
 - Smoke: authenticated helper call, valid response shape, at least one `fresh` quote-model pool, and returned `observedThroughBlock`.
 - Soak: at least five scheduled indexer intervals with recent success logs, non-regressing `observedThroughBlock`, no unexpected errors/throttles, and failure queue depth `0`.
 - Route lab: indexed success plus fallback-relevant stale, unknown, unsupported, malformed, and unavailable-helper cases.
+- CL replay parity: exact same-block local-vs-live `amountOut` equality for representative WETH -> USDC and USDC -> WETH amounts, with snapshot id, block, state hash, bitmap word count, and initialized tick count attached.
 - Evidence location: PR comment, checklist section, or linked artifact that reviewers can inspect without reconstructing the process from chat.
 
 ## Durable Follow-Ups
@@ -196,10 +205,11 @@ Attach durable release evidence before enabling `www` production helper env:
 - Fix PR cleanup so `BotCert-PR-<number>` is deleted in `us-east-1`, and stop swallowing unexpected CloudFormation delete/wait failures with blanket `|| true`.
 - Make malformed V4 registry rows impossible or explicitly rejected when they contain both `poolAddress` and `poolKey`; V4 CL head state should remain pool-key keyed instead of address keyed.
 - Parallelize the independent reserve-state and CL head-state DynamoDB `BatchGet` calls if helper latency from CL opt-in becomes material.
+- Use the first full replay capsule to decide whether event-driven tick maintenance, bounded tick windows, or hybrid safe-block snapshot plus event replay is worth the complexity.
 
 ## Next Safe Extensions
 
 - Add SPX/FAME and cbBTC/FAME only after the authoritative `www` route metadata includes those pools.
 - Add stricter freshness or faster ingestion only after scheduled indexing proves useful in route-lab evidence.
-- Add stable or concentrated-liquidity local replay only after `www` owns the math and parity tests.
-- Extend CL indexing toward tick windows or boundary-adjacent quote assistance only after the current complete head snapshot surface proves useful.
+- Add stable or additional concentrated-liquidity local replay only after `www` proves the one-pool Slipstream math and parity harness.
+- Extend CL indexing toward tick windows, event-driven updates, or boundary-adjacent quote assistance only after the current complete replay snapshot surface proves useful.

--- a/docs/fame-pool-state-index.md
+++ b/docs/fame-pool-state-index.md
@@ -6,13 +6,15 @@
 
 - Quote-model reserve pools: Uniswap V2, volatile Solidly/Equalizer, and volatile Aerodrome V2.
 - Concentrated-liquidity head snapshots: Slipstream, Slipstream2, Uniswap V3, and Uniswap V4 pools with reviewed fee metadata.
+- Concentrated-liquidity replay snapshots: exactly `slipstream-usdc-weth-100` with complete safe-block `cl-replay-v1` state for the first proof.
 - Tracked-only pools: stable Solidly, native wrap, pools missing reviewed CL metadata, and unknown unsupported invariants.
-- No factory discovery, stable math, concentrated-liquidity replay, tick bitmap/window indexing, notifier behavior, or public solver routing is owned here.
+- No factory discovery, stable math, broad concentrated-liquidity replay, event-driven tick maintenance, notifier behavior, or public solver routing is owned here.
 
 ## Runtime
 
 - `FamePoolState` CDK creates one DynamoDB table keyed by `pk` and `sk`, a scheduled indexer Lambda, and an authenticated read API Lambda.
-- The indexer scans Base `Sync` logs for quote-model pools, reconciles every quote-model pool with `getReserves` at the safe block, writes monotonic latest rows when reserves drift or rows are missing, updates `observedThroughBlock`, records complete CL head snapshots at the same safe block, and advances a cursor only after reserve reconciliation succeeds.
+- The indexer scans Base `Sync` logs for quote-model pools, reconciles every quote-model pool with `getReserves` at the safe block, writes monotonic latest rows when reserves drift or rows are missing, updates `observedThroughBlock`, records complete CL head snapshots at the same safe block, captures a full `cl-replay-v1` Slipstream snapshot for `slipstream-usdc-weth-100`, and advances a cursor only after reserve reconciliation succeeds.
+- The replay snapshot lane reads slot0, current liquidity, dynamic pool fee, the full initialized tick bitmap word range, and initialized tick liquidity records at one safe block. It writes bitmap/tick chunks first, then publishes the latest replay pointer so the API never returns a partial snapshot as fresh replay state.
 - The API serves bounded batch reads to server-side `www` callers. API Gateway uses a Lambda authorizer for the same service token before invoking the API Lambda, and the API Lambda keeps its own token check as defense in depth. The token must be supplied through `Authorization: Bearer <token>`.
 - The indexer has SQS-backed async failure destinations plus passive CloudWatch alarms for Lambda errors, Lambda throttles, missed invocations, and non-empty failure queue depth. These alarms have no notification action by default; they are an inspectable health surface for a free community service.
 
@@ -25,6 +27,8 @@ Freshness is based on `observedThroughBlock`, not `lastReserveChangeBlock`.
 - Quiet pools can be fresh even when `lastReserveChangeBlock` is old.
 - CL head snapshots use the same `observedThroughBlock` freshness rule. A complete CL head snapshot includes identity, fee metadata, tick spacing, state-view address where relevant, `sqrtPriceX96`, current tick, active liquidity, source, and registry provenance.
 - CL head snapshots intentionally do not include tick boundary warnings. They are a head state surface, not local CL replay authority; clients still fall back to live reads whenever they cannot use indexed state.
+- `cl-replay-v1` snapshots use the same freshness rule, but they are a separate opt-in state surface. A complete replay response includes block hash, parent hash, state hash, dynamic fee, head state, bitmap word range, initialized tick range, chunk counts, bitmap words, and initialized tick liquidity data.
+- Missing chunks, mismatched block/hash/provenance, malformed fee or liquidity strings, stale/future block state, or a source registry mismatch make replay state unavailable to `www`; `www` must fall back to its live quoter.
 - The producer default is `FAME_POOL_STATE_DEFAULT_MAX_FRESHNESS_BLOCKS`, currently deployed as `120` unless overridden.
 - Callers may request stricter freshness; they cannot loosen the producer default.
 
@@ -37,7 +41,7 @@ Freshness is based on `observedThroughBlock`, not `lastReserveChangeBlock`.
 
 ## Logs
 
-Indexer logs use `event: "fame-pool-state-indexed"` with chain id, block range, event counts, seeded pool count, reconciled pool count, observed pool count, duration, and registry id.
+Indexer logs use `event: "fame-pool-state-indexed"` with chain id, block range, event counts, seeded pool count, reconciled pool count, observed pool count, replay snapshot success/failure counts, replay sizing metrics, duration, and registry id.
 
 API logs use `event: "fame-pool-state-api-batch"` with registry id, current block, effective freshness, batch size, and status counts.
 
@@ -81,6 +85,7 @@ Do not add email, pager, or chat notification actions for the first release unle
 - request `currentBlock`;
 - at least one `fresh` quote-model pool;
 - returned `observedThroughBlock`.
+- for the replay proof, a `fresh` `cl-replay-v1` row for `slipstream-usdc-weth-100` with state hash, dynamic fee, bitmap word count, initialized tick count, block hash, and matching source registry id.
 
 12. Capture short soak evidence across at least five scheduled intervals:
 
@@ -91,13 +96,15 @@ Do not add email, pager, or chat notification actions for the first release unle
 - failure queue depth;
 - any RPC timeout, throttle, or cursor-lag notes.
 
-13. Run `www` route lab with `--indexed`, `BASE_RPC_URL` or `FAME_POOL_STATE_CURRENT_BLOCK`, and production-like helper env.
-14. Run a `www` quote API smoke check.
-15. Record route-lab evidence location in the PR or release checklist. Evidence must cover indexed success plus fallback-relevant stale, unknown, unsupported, malformed, and unavailable-helper cases.
-16. Enable `www` server env `FAME_POOL_STATE_API_URL` and `FAME_POOL_STATE_SERVICE_TOKEN` only after route-lab proof is attached. Do not create `NEXT_PUBLIC_` variants.
+13. Run `www` route lab with `--indexed`, `BASE_RPC_URL` or `FAME_POOL_STATE_CURRENT_BLOCK`, and production-like helper env. Confirm the indexed summary reports `cl replay slipstream-usdc-weth-100 ...` while selected CL quotes remain live or recorded in shadow mode.
+14. Run `www` CL replay parity with `bun scripts/fame-swap-cl-replay-parity.ts` and production-like helper/RPC env. Promotion requires exact same-block `amountOut` equality for both WETH -> USDC and USDC -> WETH amount bands.
+15. Run a `www` quote API smoke check.
+16. Record route-lab and parity evidence locations in the PR or release checklist. Evidence must cover indexed success plus fallback-relevant stale, unknown, unsupported, malformed, incomplete replay, and unavailable-helper cases.
+17. Enable `www` server env `FAME_POOL_STATE_API_URL` and `FAME_POOL_STATE_SERVICE_TOKEN` only after route-lab and parity proof are attached. Do not create `NEXT_PUBLIC_` variants.
 
 ## Durable Follow-Ups
 
 - Fix PR cleanup so `BotCert-PR-<number>` is deleted in `us-east-1`, and stop swallowing unexpected CloudFormation delete/wait failures with blanket `|| true`.
 - Make malformed V4 registry rows impossible or explicitly rejected when they contain both `poolAddress` and `poolKey`; V4 CL head state should remain pool-key keyed instead of address keyed.
 - Parallelize the independent reserve-state and CL head-state DynamoDB `BatchGet` calls if helper latency from CL opt-in becomes material.
+- After exact same-block parity is proven for `slipstream-usdc-weth-100`, evaluate event-driven tick maintenance, bounded tick-window snapshots, shared CL math extraction, cached route pruning, quote heatmaps, historical liquidity charts, and route-level market-state dashboards.

--- a/docs/ideation/2026-05-20-slipstream-usdc-weth-100-cl-replay-ideation.md
+++ b/docs/ideation/2026-05-20-slipstream-usdc-weth-100-cl-replay-ideation.md
@@ -1,0 +1,416 @@
+---
+date: 2026-05-20
+topic: slipstream-usdc-weth-100-cl-replay
+focus: first fully indexed replayable Slipstream CL pool for FAME quoting
+mode: repo-grounded
+---
+
+# Ideation: Replayable Slipstream USDC/WETH Pool
+
+## Grounding Context
+
+`society-bots` now owns the server-side FAME pool-state read model. Its current concentrated-liquidity lane is intentionally a head snapshot: pool identity, fee metadata, tick spacing, `sqrtPriceX96`, current tick, active liquidity, source, source registry id, and `observedThroughBlock`. The docs explicitly say this is not local CL replay authority and does not include tick bitmap/window data.
+
+`slipstream-usdc-weth-100` is already present in `society-bots` as an address-backed Slipstream pool at `0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59`, with WETH as `token0`, USDC as `token1`, `tickSpacing: 100`, and `stateSurface: "cl-head-snapshot"`.
+
+`www` is behind the `society-bots` registry contract: its generator still emits schema v1, marks CL pools as tracked-only with `unsupportedReason: "concentrated-liquidity"`, does not request `stateSurfaces`, and its indexed client/parser only accepts constant-product reserve rows. Its live Slipstream adapter already has the right execution authority: it reads `slot0`, reads active liquidity as evidence, calls the live Slipstream quoter, and owns route attribution and fallback.
+
+External grounding points to a clear replay shape. Slipstream is Uniswap V3-like enough to use the V3 swap loop model: find next initialized tick from bitmap, run exact integer `SwapMath`, cross ticks by applying `liquidityNet`, and produce `amountOut`, `sqrtPriceX96After`, and initialized ticks crossed. The important Slipstream-specific wrinkle is dynamic fee: the replay state must include the exact fee value and source observed at the same block, not just the registry `feeBps` float.
+
+Relevant sources:
+
+- Uniswap V3 whitepaper: https://blog.uniswap.org/whitepaper-v3.pdf
+- Uniswap V3 pool data guide: https://developers.uniswap.org/docs/sdks/v3/guides/pool-data
+- Uniswap concentrated-liquidity concepts: https://developers.uniswap.org/docs/get-started/concepts/liquidity-providers/concentrated-liquidity
+- Uniswap V3 core source: https://github.com/Uniswap/v3-core
+- Uniswap V3 quoting guide: https://developers.uniswap.org/docs/sdks/v3/guides/swapping/quoting
+- Aerodrome Slipstream source/spec: https://github.com/aerodrome-finance/slipstream
+- DynamoDB sort-key versioning: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-sort-keys.html
+
+## Topic Axes
+
+- Indexed CL state acquisition and maintenance
+- DynamoDB and API contract
+- Quote replay math ownership
+- Freshness, invalidation, and fallback
+- Validation, rollout, and telemetry
+
+## Recommendation
+
+Build one production-safe vertical slice: a same-block full replay capsule for `slipstream-usdc-weth-100`, served as raw `cl-replay-v1` state from `society-bots`, consumed by a `www`-owned Slipstream replay adapter in shadow mode first, then promoted only after exact same-block parity against the live Slipstream quoter.
+
+The first implementation should use periodic safe-block full snapshots for this one pool, not event-driven tick maintenance. With `tickSpacing: 100`, scanning the full compressed bitmap space is plausibly cheap enough to measure and run for one high-impact pool. It is also much easier to verify than a birth-to-head event reducer. Event-driven maintenance becomes a later optimization after the full snapshot, state shape, and replay math prove parity.
+
+## Ranked Ideas
+
+### 1. Same-Block Full Replay Capsule For One Pool
+
+**Description:** Add a dedicated `cl-replay-v1` snapshot path for only `slipstream-usdc-weth-100`. Each capsule is captured at one safe block and contains pool identity, token order, current `slot0.sqrtPriceX96`, current tick, active liquidity, exact dynamic fee in protocol units, fee source, initialized tick bitmap words, initialized tick records, block number, block hash, parent hash, source registry id, and a deterministic `stateHash`.
+
+**Axis:** Indexed CL state acquisition and maintenance
+
+**Basis:** `direct:` current CL head snapshots intentionally stop before tick bitmap/window indexing and local CL replay. `external:` Uniswap V3-style replay requires head state, bitmap, initialized ticks, liquidity changes, and exact integer math. `reasoned:` for one pool with tick spacing 100, a periodic full safe-block snapshot is simpler to prove correct than an event-only reducer.
+
+**Rationale:** This is the smallest state that can support exact-input replay across tick crossings without a live quoter call. The full initialized-tick snapshot also answers the key "outside indexed range" problem by making the initial range all initialized ticks for the pool, while still allowing `www` to fail if a quote reaches min/max tick or missing data.
+
+**DynamoDB shape:**
+
+```text
+pk = pool:8453:address:0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59
+sk = cl-replay-v1:latest
+sk = cl-replay-v1:block:<blockNumber>:<blockHash>:manifest
+sk = cl-replay-v1:block:<blockNumber>:<blockHash>:bitmap:<wordPosition>
+sk = cl-replay-v1:block:<blockNumber>:<blockHash>:ticks:<chunkIndex>
+```
+
+The manifest row should carry:
+
+```json
+{
+  "stateKind": "cl-replay-v1",
+  "replayModel": "slipstream-cl-replay-v1",
+  "poolId": "slipstream-usdc-weth-100",
+  "chainId": 8453,
+  "poolAddress": "0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59",
+  "token0": "0x4200000000000000000000000000000000000006",
+  "token1": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  "tickSpacing": 100,
+  "sqrtPriceX96": "<decimal string>",
+  "tick": 0,
+  "liquidity": "<decimal string>",
+  "swapFeePips": "<integer protocol fee units>",
+  "feeSource": {
+    "kind": "slipstream-pool-or-factory",
+    "address": "0x..."
+  },
+  "observedThroughBlock": 0,
+  "observedBlockHash": "0x...",
+  "parentBlockHash": "0x...",
+  "bitmapWordCount": 0,
+  "initializedTickCount": 0,
+  "tickChunkCount": 0,
+  "stateHash": "0x...",
+  "sourceRegistryId": "<poolsHash>:<routesHash>",
+  "updatedAt": "2026-05-20T00:00:00.000Z"
+}
+```
+
+Tick chunk rows should store ticks as ordered arrays with `tick`, `liquidityGross`, and `liquidityNet` decimal strings. Bitmap rows should store `wordPosition` and the exact `uint256` word as a decimal or hex string. All rows for one capsule must share block number, block hash, source registry id, and state hash.
+
+**Downsides:** Full snapshot reads may be heavier than head snapshots and need chunked Dynamo writes because of item-size limits. The first task must measure bitmap word count, initialized tick count, total payload size, snapshot duration, and provider throttling before any production promotion.
+
+**Confidence:** 88%
+
+**Complexity:** High
+
+**Status:** Unexplored
+
+### 2. Raw `cl-replay-v1` API Surface, Not A Quote Endpoint
+
+**Description:** Extend `POST /fame/pool-state` with an opt-in state surface such as `stateSurfaces: ["cl-replay-v1"]`. The API returns replay primitives and eligibility metadata, not `amountOut`. `www` remains quote authority and decides whether to replay locally or call the live Slipstream quoter.
+
+**Axis:** DynamoDB and API contract
+
+**Basis:** `direct:` the existing helper already uses authenticated server-only access, `sourceRegistryId`, freshness status, and normal fallback statuses. `direct:` `www` owns live Slipstream adapter behavior and route attribution today. `reasoned:` a raw state contract can power quotes, route pruning, heatmaps, charts, and dashboards without creating a second quote engine in `society-bots`.
+
+**Rationale:** The API should expose enough state for replay while avoiding route/business logic drift. A quote endpoint in `society-bots` would hide important route-level behavior from `www`, make attribution harder, and create two places where quote bugs can live.
+
+**API request shape:**
+
+```json
+{
+  "currentBlock": 46200000,
+  "currentBlockHash": "0x...",
+  "maxFreshnessBlocks": 25,
+  "stateSurfaces": ["cl-replay-v1"],
+  "pools": [{ "poolId": "slipstream-usdc-weth-100" }]
+}
+```
+
+`currentBlockHash` can be optional for old surfaces, but `www` should supply it for CL replay once its quote context captures block hashes.
+
+**API response shape:**
+
+```json
+{
+  "sourceRegistryId": "<poolsHash>:<routesHash>",
+  "currentBlock": 46200000,
+  "effectiveMaxFreshnessBlocks": 25,
+  "pools": [
+    {
+      "status": "fresh",
+      "stateKind": "cl-replay-v1",
+      "replayModel": "slipstream-cl-replay-v1",
+      "poolId": "slipstream-usdc-weth-100",
+      "chainId": 8453,
+      "poolAddress": "0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59",
+      "token0": "0x4200000000000000000000000000000000000006",
+      "token1": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+      "tickSpacing": 100,
+      "sqrtPriceX96": "<decimal string>",
+      "tick": 0,
+      "liquidity": "<decimal string>",
+      "swapFeePips": "<integer protocol fee units>",
+      "feeSource": {
+        "kind": "slipstream-pool-or-factory",
+        "address": "0x..."
+      },
+      "observedThroughBlock": 46199998,
+      "observedBlockHash": "0x...",
+      "stateHash": "0x...",
+      "bitmapWords": [
+        { "wordPosition": 0, "word": "0x..." }
+      ],
+      "initializedTicks": [
+        {
+          "tick": -100,
+          "liquidityGross": "<decimal string>",
+          "liquidityNet": "<decimal string>"
+        }
+      ],
+      "completeness": {
+        "bitmapWordCount": 0,
+        "initializedTickCount": 0,
+        "tickChunkCount": 0
+      },
+      "maxFreshnessBlocks": 25
+    }
+  ]
+}
+```
+
+Malformed, missing, stale, incomplete, unsupported, registry-mismatched, or future-observed state should keep using the existing normal status vocabulary where possible. Add specific machine-readable reasons for CL replay misses.
+
+**Downsides:** Returning full tick state through the API may hit payload or latency limits. The first smoke should enforce a maximum payload size and fall back live if the bundle is too large, while keeping the indexed Dynamo state intact.
+
+**Confidence:** 86%
+
+**Complexity:** Medium-High
+
+**Status:** Unexplored
+
+### 3. `www`-Owned Slipstream Replay Adapter And Exact Math Module
+
+**Description:** Implement `slipstreamClReplay.ts` in `www` as a pure deterministic module: `quoteExactInputFromSlipstreamState(state, tokenIn, amountIn, sqrtPriceLimitX96?)`. It should use only `bigint`, port Solidity rounding semantics exactly, handle direction-specific tick crossing, dynamic fee, price impact, final tick, `sqrtPriceX96After`, and initialized ticks crossed. Then wrap it in an indexed adapter that only activates for `slipstream-usdc-weth-100`.
+
+**Axis:** Quote replay math ownership
+
+**Basis:** `direct:` `www` already owns route solving, live adapters, route-lab, quote wire serialization, and fallback. `external:` Uniswap V3 replay has tricky exact math: `FullMath`, `SqrtPriceMath`, `SwapMath`, negative tick compression, and boundary semantics. `reasoned:` keeping the first math owner in `www` avoids packaging overhead until a second consumer proves the need for a shared package.
+
+**Rationale:** `society-bots` should produce state; `www` should produce quotes. A shared package is a good later extraction once the first pool is stable, but the first production-safe milestone should keep the quote bug, parity harness, and route attribution in the same repo.
+
+**Parity threshold:** exact equality. For production use, require `amountOut`, `sqrtPriceX96After`, and initialized ticks crossed to match the live Slipstream quoter at the same block when the quoter exposes those fields. A one-wei mismatch is a bug to investigate, not a tolerance to accept. Shadow mode can record deltas, but hot-path indexed replay should require exact deterministic parity.
+
+**Downsides:** Exact math is the hardest part of the slice. Pulling in `@uniswap/v3-sdk` may help with data types, but the implementation still needs careful review against Slipstream fee behavior and Solidity rounding.
+
+**Confidence:** 82%
+
+**Complexity:** High
+
+**Status:** Unexplored
+
+### 4. Strict Replay Eligibility And Fallback Matrix
+
+**Description:** Add one typed gate before `www` uses indexed replay. The gate checks source registry id, pool identity, token direction, freshness, `observedThroughBlock <= currentBlock`, block hash when comparable, complete chunks, exact fee presence, parser validity, supported replay model, and state hash. Any failure delegates to the existing live Slipstream quoter and records one fallback reason.
+
+**Axis:** Freshness, invalidation, and fallback
+
+**Basis:** `direct:` existing indexed reserve behavior already falls back for stale, malformed, mismatched, or unavailable helper state. `external:` replayable CL state is more fragile than reserve state because a missing tick or wrong fee can produce a plausible but wrong quote. `reasoned:` explicit failure reasons turn safety behavior into operational learning.
+
+**Rationale:** This keeps user-facing quote correctness boring. It also tells the team whether indexed CL misses are due to stale snapshots, provider limits, payload limits, missing fee state, parity failure, or out-of-range math.
+
+**Fallback reasons to standardize in `www`:**
+
+- `not_configured`
+- `source_registry_mismatch`
+- `missing_replay_state`
+- `stale_replay_state`
+- `future_observed_block`
+- `block_hash_mismatch`
+- `incomplete_tick_state`
+- `invalid_replay_payload`
+- `unsupported_replay_model`
+- `unsupported_direction`
+- `missing_dynamic_fee`
+- `math_error`
+- `zero_or_invalid_output`
+- `parity_check_failed`
+- `payload_too_large`
+
+**Invalidation model in `society-bots`:**
+
+- Reject or mark stale on parent-hash mismatch while advancing snapshots.
+- Do not write fresh partial capsules.
+- Do not serve replay state if any chunk for the manifest is missing.
+- Treat registry source changes as a new state lineage.
+- Treat fee-source read failure as not replayable.
+- Keep old `cl-head-snapshot` behavior separate so diagnostic state is not confused with replay authority.
+
+**Downsides:** More status vocabulary increases client/parser/test work. The payoff is worth it because generic live fallback would hide the most important rollout blockers.
+
+**Confidence:** 90%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 5. Shadow Parity Harness And Route-Lab Rollout Gate
+
+**Description:** Before hot-path use, add a validation harness that requests the indexed replay state, runs local replay in `www`, and compares it to the live Slipstream quoter at the same block. Cover both USDC->WETH and WETH->USDC with tiny, normal, large, and boundary-seeking amount buckets. Include route-lab shadow mode and optional production shadow telemetry, but keep served quotes live until gates pass.
+
+**Axis:** Validation, rollout, and telemetry
+
+**Basis:** `direct:` `www` route-lab already has recorded/live/indexed modes and documents this pool as an enabled USDC/WETH Slipstream connector. `external:` Uniswap QuoterV2-style static calls are the validation oracle pattern. `reasoned:` a first CL replay slice should graduate by evidence, not confidence.
+
+**Rationale:** This defines "fully replayable" as a measurable property. It also keeps the first production milestone safe: the system can gather parity data, latency data, and fallback reasons without changing user-facing quotes.
+
+**Validation matrix:**
+
+- Directions: WETH -> USDC and USDC -> WETH.
+- Amounts: dust, common UI amounts, current route-lab representative buckets, large amounts likely to cross ticks, and one stress amount expected to fail or reach coverage limits.
+- Comparison fields: `amountOut`, `sqrtPriceX96After`, initialized ticks crossed, final tick if available locally, fee value, block number, block hash, snapshot age, replay latency, live quoter latency.
+- Expected result: exact match for fields exposed by live quoter; otherwise live fallback.
+
+**Rollout gates:**
+
+1. Direct helper smoke returns fresh `cl-replay-v1` for the pool.
+2. Route-lab shadow matrix passes both directions at the same block.
+3. No parser/schema drift between `society-bots` and `www`.
+4. Production shadow shows exact parity for representative traffic.
+5. Only then enable indexed replay for this pool behind a server-side flag.
+
+**Downsides:** Shadow mode adds more work before visible speedup. That delay is the right price for not shipping a plausible but wrong CL quote.
+
+**Confidence:** 91%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 6. Pool Index Health And Replay Telemetry
+
+**Description:** Add operator-facing telemetry for the pool index: last observed block, snapshot age, block hash, initialized tick count, bitmap word count, dynamic fee value/source, payload size, snapshot duration, provider read counts, replay attempts, indexed-used count, live fallback count by reason, parity failures, and replay/live latency deltas.
+
+**Axis:** Validation, rollout, and telemetry
+
+**Basis:** `direct:` existing helper debug already reports status counts and source registry matching. `reasoned:` one-pool observability becomes the template for more CL pools, cached route pruning, quote heatmaps, historical charts, and market-state dashboards.
+
+**Rationale:** This converts the pool from a hidden backend cache into a market-state index with a health signal. It also makes later expansion much cheaper because each new pool gets the same freshness, parity, and route-attribution vocabulary.
+
+**Downsides:** Dashboards can sprawl if built before the core state and parity are stable. Start with structured logs and route-lab markdown/JSON output, then promote to a dashboard after the signal is useful.
+
+**Confidence:** 84%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+## Concrete Next Implementation Plan
+
+1. Fix cross-repo registry drift first.
+   - Update `www` registry generation to emit the current pool-state schema fields: `stateSurface`, `tickSpacing`, `stateViewAddress`, and explicit CL replay capability for only `slipstream-usdc-weth-100`.
+   - Keep all other CL pools as head snapshot or tracked-only until they are intentionally promoted.
+
+2. Add `society-bots` `cl-replay-v1` state storage.
+   - Add manifest, bitmap, and tick chunk item types.
+   - Add parser and writer tests that reject partial, mixed-block, or malformed state.
+   - Add ABI reads for `tickBitmap`, `ticks`, and exact dynamic fee at the same safe block as `slot0` and `liquidity`.
+   - Scan full bitmap space for this pool at first. With tick spacing 100, the compressed bitmap word count is small enough to measure directly; if initialized tick count or payload size is unexpectedly high, keep Dynamo chunking and make the API return `payload_too_large` until a windowed API is designed.
+
+3. Extend `POST /fame/pool-state`.
+   - Add `stateSurfaces: ["cl-replay-v1"]`.
+   - Return full replay state only for this pool.
+   - Preserve existing reserve and CL head behavior for current clients.
+   - Add freshness and completeness reasons for CL replay.
+
+4. Add `www` parser and adapter without changing served quotes.
+   - Update `indexedPoolStateClient.ts` to request and parse `cl-replay-v1`.
+   - Add a new indexed Slipstream replay adapter that activates only for `slipstream-usdc-weth-100`.
+   - In shadow mode, always compare replay to live quoter and serve live results.
+
+5. Implement exact replay math in `www`.
+   - Port or wrap the V3 swap math with strict `bigint` semantics.
+   - Handle dynamic Slipstream fee from indexed state.
+   - Return `amountOut`, `sqrtPriceX96After`, final tick, initialized ticks crossed, price-impact evidence, and a typed failure reason.
+
+6. Add validation and smoke checks.
+   - Add a route-lab flag or mode for `slipstream-usdc-weth-100` shadow replay.
+   - Compare local replay against live Slipstream quoter at the same block across both directions and amount buckets.
+   - Gate hot-path use behind exact parity and structured telemetry.
+
+## Tests And Smoke Checks
+
+### `society-bots`
+
+- Registry parser accepts `cl-replay-v1` only for the explicit pool and rejects replay capability without fee, tick spacing, pool address, or supported venue.
+- Snapshot reader uses one safe block for `slot0`, `liquidity`, fee, bitmap, and ticks.
+- Snapshot writer refuses mixed block numbers, missing block hash, missing fee, missing bitmap words, missing tick chunks, or inconsistent state hash.
+- Dynamo helpers store and batch-read manifest, bitmap rows, and tick chunks; unprocessed keys remain an incomplete read error.
+- API parser accepts `stateSurfaces: ["cl-replay-v1"]` without breaking `cl-head-snapshot`.
+- API returns `fresh`, `stale`, `unknown`, or `unsupported` correctly for current block, future observed block, stale observed block, missing chunks, and registry mismatch.
+- Indexer result logs include replay snapshot counts, tick count, bitmap word count, dynamic fee, provider read count, payload size, and failures.
+- Live smoke: authenticated helper request for `slipstream-usdc-weth-100` returns fresh `cl-replay-v1`, non-empty bitmap/tick data, exact fee, and a matching `sourceRegistryId`.
+
+### `www`
+
+- Registry generator emits schema-compatible replay metadata for `slipstream-usdc-weth-100` and does not promote other CL pools.
+- Indexed pool-state client sends `stateSurfaces: ["cl-replay-v1"]` when CL replay shadow mode is enabled.
+- Parser accepts CL replay rows and rejects malformed addresses, non-decimal integer strings, missing fee, missing chunks, or unsupported replay model.
+- Pure replay math golden tests cover both directions, exact tick boundary behavior, negative tick compression, fee rounding, zero output, and at least one tick crossing.
+- Indexed Slipstream adapter falls back live for each standardized fallback reason.
+- Route API debug reports shadow replay parity without leaking helper URL, token, calldata, or raw RPC errors.
+- Route-lab shadow matrix compares live quoter and indexed replay at the same block for representative USDC/WETH amounts.
+- Public quote wire tests ensure mixed indexed/live routes do not claim fully indexed route context.
+
+## Rejected Alternatives
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Event-driven tick maintenance first | Correct long-term, but too much hidden state-machine risk before a same-block full snapshot proves quote parity. |
+| 2 | Bounded active tick window as the first and only state | Useful as a payload optimization, but weaker than the requested one-pool "boil the ocean" slice. Full bitmap scan for tick spacing 100 should be measured first. |
+| 3 | `society-bots` quote endpoint | Reduces client payload, but creates a second quote authority and makes route attribution, slippage, and fallback behavior harder to reason about. |
+| 4 | Shared package before first parity proof | Likely useful after the second consumer exists, but it adds packaging and versioning overhead before the math is proven. Start in `www`, then extract. |
+| 5 | Approximate parity threshold | Rejected for production. Deterministic same-block replay should exactly match live quoter output fields; mismatches are bugs or incomplete state. |
+| 6 | Generic CL replay for all Slipstream/V3/V4 pools | Scope overrun. This slice should make one high-impact pool boringly correct before broad coverage. |
+| 7 | Historical charts in the first milestone | Unlocked by capsules, but not required for hot-path quote proof. Keep sampled history as follow-on work. |
+| 8 | Route-level cached quote receipts instead of pool state | Useful for repeated exact requests, but it does not create a replayable market-state index or teach the system CL math. |
+
+## Risks
+
+- Stale tick state: mitigated by same-block snapshots, no partial writes, strict freshness, and live fallback.
+- Provider limits: full bitmap plus initialized tick reads may hit RPC/multicall limits. Measure word count, tick count, call count, and duration before enabling production cadence.
+- Block consistency: all state reads and live parity calls must use the same block. Store block hash and parent hash; reject reorg/mismatch.
+- Dynamic fee drift: registry `feeBps` is not enough. Store the exact fee integer and source at block; missing fee means no replay.
+- Quote parity: rounding and tick-boundary semantics are the highest-risk math areas. Require exact amount and post-price parity before hot-path use.
+- Route attribution: mixed replay/live routes must not claim fully indexed context. Attribution remains per selected leg.
+- API payload size: full tick state may exceed comfortable response size. Dynamo chunking is required; API fallback on oversized response is safer than truncation.
+- Registry drift: include schema/state-surface compatibility in tests so `sourceRegistryId` is not the only cross-repo contract.
+
+## Unlocks
+
+- More CL pools can reuse the capsule, eligibility, and parity harness once the first pool is proven.
+- Cached route pruning can use fresh price/liquidity/tick coverage before expensive live quote calls.
+- Quote heatmaps can replay many amounts from one capsule.
+- Historical liquidity and price charts can sample capsule manifests over time.
+- Route-level performance telemetry can distinguish live-quoter bottlenecks from index freshness or math coverage.
+- Market-state dashboards can expose pool health, fee movement, tick density, freshness, and fallback reasons.
+
+## First Production-Safe Milestone
+
+The first production-safe milestone is not "serve indexed CL quotes." It is:
+
+1. `society-bots` serves fresh `cl-replay-v1` full replay state for `slipstream-usdc-weth-100`.
+2. `www` can parse it and run local replay in shadow mode.
+3. Route-lab proves exact same-block parity across both directions and representative amounts.
+4. Production shadow telemetry shows exact parity and useful fallback reasons.
+5. A server-side flag can then enable hot-path indexed replay for only this pool, with live quoter fallback on every failure path.
+
+## Explicitly Out Of Scope
+
+- Generic CL replay for all Slipstream, Slipstream2, Uniswap V3, or Uniswap V4 pools.
+- Event-driven birth-to-head reconstruction as the first implementation.
+- `society-bots` owning final quote output or route selection.
+- Approximate CL math, floating-point math, or tolerance-based production matching.
+- Public exposure of raw helper diagnostics, helper credentials, calldata, or RPC errors.
+- Stable-pool math, native-wrap changes, exotic route promotion, or router contract changes.
+- Historical dashboards and quote heatmaps beyond telemetry needed to validate this first pool.

--- a/docs/plans/2026-05-20-001-feat-slipstream-cl-replay-snapshot-proof-plan.md
+++ b/docs/plans/2026-05-20-001-feat-slipstream-cl-replay-snapshot-proof-plan.md
@@ -1,0 +1,577 @@
+---
+title: "feat: Add Slipstream CL Replay Snapshot Proof"
+type: feat
+status: completed
+date: 2026-05-20
+origin: docs/brainstorms/2026-05-20-slipstream-usdc-weth-100-cl-replay-snapshot-proof-requirements.md
+---
+
+# feat: Add Slipstream CL Replay Snapshot Proof
+
+**Target repos:** `society-bots` and sibling `www`. Paths below are repo-relative within the repo named in each file list.
+
+## Summary
+
+Make `slipstream-usdc-weth-100` the first replay-capable concentrated-liquidity pool in the FAME quote stack. `society-bots` will publish a complete safe-block replay snapshot as raw indexed state, while `www` owns local Slipstream exact-input replay, shadow parity against the live quoter, fallback behavior, and promotion evidence.
+
+---
+
+## Problem Frame
+
+FAME USDC routes often bottleneck through `slipstream-usdc-weth-100`, but concentrated-liquidity amount-out still depends on live quoter calls. The current CL head snapshot lane proves current price and active liquidity, yet it cannot replay swaps that cross initialized ticks because the initialized tick bitmap, per-tick liquidity deltas, and exact dynamic swap fee are missing.
+
+This plan deliberately over-indexes one high-impact pool so correctness can become binary before broadening coverage. The milestone is not "all CL pools are locally quoteable"; it is "one pool has complete replay state, exact same-block shadow parity, and safe live fallback whenever replay is not trustworthy" (see origin: `docs/brainstorms/2026-05-20-slipstream-usdc-weth-100-cl-replay-snapshot-proof-requirements.md`).
+
+---
+
+## Requirements
+
+- R1. Limit replayable CL scope to exactly `slipstream-usdc-weth-100`; every other CL pool remains observational, unsupported, or live-quoted.
+- R2. Capture all same-block state needed for exact-input replay across initialized tick crossings: head price, current tick, active liquidity, tick spacing, initialized tick bitmap words, initialized tick liquidity records, exact dynamic fee, pool identity, token order, and block identity.
+- R3. Publish replay state only when it is complete for one safe block. Mixed-block reads, missing block identity, missing dynamic fee, missing tick data, incomplete chunks, or inconsistent snapshot hashes make replay state unavailable.
+- R4. Use periodic safe-block full snapshots for the first milestone, not event-driven tick maintenance.
+- R5. Expose raw replay state from `society-bots`; do not add route selection, output amount, slippage, or quote readiness authority there.
+- R6. Preserve existing reserve and CL head behavior. Clients that do not opt into replay state must not accidentally treat CL head rows as replay authority.
+- R7. In `www`, validate source registry, pool identity, token direction, freshness, quote block ordering, replay model support, tick completeness, dynamic fee presence, and parser validity before replay.
+- R8. On any validation failure, `www` falls back to the live Slipstream quoter and emits one structured fallback reason.
+- R9. Keep Slipstream replay math in `www` for the first implementation and compare local replay against the live quoter in shadow mode.
+- R10. Require exact same-block parity for deterministic comparison fields, especially `amountOut` and post-swap price where exposed. Tolerance-based production matching is out of scope.
+- R11. Validate both WETH -> USDC and USDC -> WETH across tiny, common, larger, and tick-crossing amount bands.
+- R12. While shadow mode is active, public/user-facing quote behavior remains live-quoter-backed even when local replay succeeds.
+- R13. Surface operator evidence for snapshot age, observed block, state completeness, dynamic fee freshness, fallback reasons, parity result, and live-vs-replay latency.
+- R14. Keep the milestone clear: fresh replay state plus shadow parity, not broad CL indexing or public indexed CL quotes.
+
+**Origin actors:** A1 `society-bots` pool-state indexer, A2 `www` quote system, A3 operator/reviewer, A4 FAME swap user.
+**Origin flows:** F1 snapshot state is captured, F2 shadow replay is evaluated, F3 promotion is considered.
+**Origin acceptance examples:** AE1 complete safe-block replay state is replay-eligible; AE2 missing tick or fee state falls back live; AE3 shadow success still serves live quote; AE4 future-block replay state is unusable; AE5 parity matrix blocks promotion on any deterministic mismatch; AE6 operator output shows freshness, parity, latency, and fallback reasons.
+
+---
+
+## Scope Boundaries
+
+- No event-driven tick maintenance in the first milestone.
+- No generic replay for other Slipstream, Slipstream2, Uniswap V3, or Uniswap V4 pools.
+- No `society-bots` quote endpoint, route authority, slippage logic, or output amount service.
+- No user-facing indexed CL quote result before shadow parity is proven and explicitly enabled in later work.
+- No tolerance-based production parity for deterministic fields.
+- No stable-pool math, native-wrap changes, router changes, candidate generation changes, or exotic route promotion.
+- No dashboards beyond route-lab, logs, and smoke evidence needed to validate this first proof.
+
+### Deferred to Follow-Up Work
+
+- Event-driven tick maintenance after snapshot parity is proven.
+- Shared package extraction for CL math after `www` proves the replay engine and call contract.
+- Cached route pruning, quote heatmaps, historical liquidity/price charts, market-state dashboards, and route-level performance telemetry beyond the operator evidence in this plan.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `society-bots` `src/fame-swap-pool-state/types.ts` already models schema v2, `stateSurface`, `tickSpacing`, quote-model capability, and CL head snapshot eligibility.
+- `society-bots` `src/fame-swap-pool-state/registry/base-v1-pools.json` already contains `slipstream-usdc-weth-100` with pool address `0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59`, WETH as `token0`, USDC as `token1`, and `tickSpacing: 100`.
+- `society-bots` `src/fame-swap-pool-state/indexer.ts` already chooses a safe block, reads `slot0` and `liquidity`, writes complete CL head snapshots, and records per-pool failures without publishing partial CL head rows.
+- `society-bots` `src/fame-swap-pool-state/dynamodb/pool-state.ts` uses explicit latest-state row types, monotonic writes, strict item parsing, and incomplete batch read errors.
+- `society-bots` `src/fame-swap-pool-state/api.ts` already supports opt-in state surfaces and separates success statuses (`fresh`, `stale`, `unknown`, `unsupported`) from request/transport errors.
+- `society-bots` `src/wagmi.generated.ts` already includes ABI surface for `tickBitmap` and `ticks`, including `liquidityGross` and `liquidityNet`.
+- `www` `src/features/fame-swap/solver/poolStateRegistry.ts` is behind the `society-bots` registry schema and currently treats CL pools as tracked-only unsupported.
+- `www` `src/features/fame-swap/solver/quotes/indexedPoolStateClient.ts` currently requests pool ids and parses reserve rows only.
+- `www` `src/features/fame-swap/solver/quotes/indexedReserveAdapter.ts` demonstrates the fallback shape: replay only fresh model-compatible rows and delegate stale, malformed, mismatched, or unsupported state to the fallback adapter.
+- `www` `src/features/fame-swap/solver/quotes/liveAdapters.ts` currently reads Slipstream `slot0`, reads active liquidity as evidence, and calls the live Slipstream quoter for amount-out.
+- `www` `scripts/fame-swap-route-lab.ts` already has an indexed mode, indexed status counts, fallback reason summaries, and public-output redaction discipline.
+
+### Institutional Learnings
+
+- `www` `docs/solutions/architecture-patterns/fame-swap-indexed-pool-state-quote-helper-2026-05-19.md` says helper reachability is not proof of indexed quoting. Provenance, freshness, model compatibility, and selected-leg attribution decide whether indexed state is usable.
+- The same learning requires route attribution to reflect actual selected leg quote sources; mixed indexed/live routes must not claim fully indexed context.
+- `docs/fame-pool-state-index.md` and `docs/fame-pool-state-handoff.md` state the current authority split: `society-bots` indexes state, while `www` owns quote math, fallback, route-lab, and public quote behavior.
+
+### External References
+
+- Uniswap V3 pool data guidance describes full offchain pool construction as `slot0`, `liquidity`, `tickBitmap`, and `ticks` reads, with multicall used to keep large tick reads same-block.
+- Aerodrome Slipstream is a V3-derived CL implementation; its core pool exposes `slot0`, `liquidity`, `ticks`, `tickBitmap`, and a dynamic `fee()` that delegates swap fee lookup to the factory.
+
+---
+
+## Key Technical Decisions
+
+- **Full safe-block snapshot first:** Snapshotting all initialized tick state for one pool is easier to verify than an event reducer. The indexer can recover from any missed run by taking a new complete snapshot.
+- **Raw replay state API:** `society-bots` should expose replay primitives and eligibility evidence, not a quote endpoint. This preserves the existing cross-repo contract and keeps route attribution in `www`.
+- **Chunked DynamoDB snapshot rows:** Store a latest replay capsule pointer plus deterministic bitmap/tick chunk rows. This avoids item-size risk and lets the API prove completeness before returning replay-capable state.
+- **Chunks written before latest pointer:** Write chunk rows first, then publish the latest capsule pointer last. If a run dies midway, old complete state remains the latest replay state and orphan chunks are ignored.
+- **Exact dynamic fee from pool state:** Replay must use the dynamic fee read from the pool at the snapshot block, not registry `feeBps` labels. The implementation must verify integer units against the live quoter during parity work.
+- **`www` math ownership first:** The initial replay module lives in `www` because quote context, fallback, route attribution, and parity tests already live there. A shared package is follow-up work after the engine proves itself.
+- **Exact parity threshold:** Deterministic comparisons must match exactly at the same block. Any mismatch means the state, math, fee units, rounding, or comparison harness is wrong.
+- **Shadow before hot path:** Local replay can run beside the live quoter and emit evidence, but live quoter output remains the served result until a later explicit promotion switch.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should milestone one use event-driven tick maintenance or full snapshots? Use full safe-block snapshots first; event maintenance is deferred until complete-snapshot parity is proven.
+- Should `society-bots` expose raw state or a quote endpoint? Expose raw state only; `www` remains quote authority.
+- Which side owns CL math first? `www`, with shared package extraction deferred.
+- What parity threshold is acceptable? Exact deterministic parity for production promotion; no tolerance threshold.
+
+### Deferred to Implementation
+
+- Measured initialized tick count, bitmap word count, provider call count, payload size, and snapshot duration for `slipstream-usdc-weth-100`: this depends on live chain reads and should be captured as a gating metric in the snapshot unit.
+- Exact dynamic fee units for Slipstream replay: read `fee()` at the snapshot block and validate units against live quoter parity before any promotion.
+- Final chunk size and maximum response payload guard: choose after measuring actual tick count and DynamoDB item sizes, while preserving the plan's chunked-completeness model.
+- Exact route-lab amount corpus: pick concrete tiny/common/large/tick-crossing amounts during implementation using current route-lab corpus conventions.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant Indexer as society-bots indexer
+    participant Chain as Base RPC
+    participant Table as DynamoDB
+    participant API as society-bots API
+    participant Client as www indexed client
+    participant Replay as www local replay
+    participant Live as www live quoter
+    participant Lab as route-lab / logs
+
+    Indexer->>Chain: read safe-block slot0, liquidity, fee, bitmap words
+    Indexer->>Chain: read initialized tick liquidity records
+    Indexer->>Table: write replay chunks
+    Indexer->>Table: publish latest complete capsule pointer
+    Client->>API: request cl-replay-v1 for reviewed pool
+    API->>Table: read pointer and expected chunks
+    API-->>Client: fresh/stale/unknown replay state with completeness evidence
+    Client->>Replay: validate and locally replay exact input
+    Client->>Live: quote same pool at replay snapshot block for parity
+    Replay-->>Lab: parity, fallback, latency, and state evidence
+    Live-->>Client: served quote while shadow mode is active
+```
+
+### Replay Snapshot State Shape
+
+The intended DynamoDB shape uses the existing table and identity conventions, with a new replay lane:
+
+- Latest pointer row: pool identity key plus `sk: "cl-replay-v1"`. It contains pool identity, token order, observed block, block hash, parent hash, source registry id, state hash, tick spacing, head state, dynamic fee, bitmap/tick counts, word range, tick range, and chunk counts.
+- Bitmap chunk rows: same pool identity key plus snapshot-specific sort keys. Each chunk stores ordered `{ wordPosition, bitmap }` records and repeats snapshot id, block hash, source registry id, and state hash.
+- Tick chunk rows: same pool identity key plus snapshot-specific sort keys. Each chunk stores ordered `{ tick, liquidityGross, liquidityNet }` records and repeats snapshot id, block hash, source registry id, and state hash.
+
+The API reads the latest pointer, then batch-reads exactly the chunks named by the pointer, splitting reads into bounded batches if the expected chunk count exceeds one DynamoDB batch. Missing chunks, mismatched snapshot identity, mismatched state hash, mismatched block identity, or unprocessed DynamoDB keys make replay state unavailable.
+
+### API Response Shape
+
+The replay API remains `POST /fame/pool-state` with an explicit opt-in surface such as `cl-replay-v1`. A replay entry should be a distinct `stateKind` from `cl-head-snapshot`, carry `status: "fresh" | "stale"` only when a complete capsule exists, and inline the replay arrays for this one-pool proof. The response must include enough evidence for `www` to decide eligibility without a second helper call: block identity, source registry id, state hash, completeness counts, dynamic fee source, head state, bitmap words, initialized ticks, and freshness bounds.
+
+### Freshness and Invalidation Model
+
+- Producer freshness uses `observedThroughBlock`, the same rule as reserve and CL head rows.
+- Replay state observed ahead of the `www` quote context block is stale for that quote.
+- Registry id mismatch, unsupported pool id, missing dynamic fee, malformed decimal strings, missing chunks, chunk hash mismatch, unsupported direction, replay outside the indexed word range, replay exceptions, or shadow parity mismatch all invalidate local replay for that request.
+- There is no event-driven invalidation in milestone one. A newer complete snapshot replaces the latest pointer; stale or invalid state falls back live.
+
+---
+
+## Implementation Units
+
+### U1. Registry and Capability Contract
+
+**Goal:** Align both repos on a replay-capable state surface for exactly `slipstream-usdc-weth-100` while preserving existing reserve and CL head behavior.
+
+**Requirements:** R1, R5, R6, R14.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `society-bots` `src/fame-swap-pool-state/types.ts`
+- Modify: `society-bots` `src/fame-swap-pool-state/registry/index.ts`
+- Modify: `society-bots` `src/fame-swap-pool-state/registry/index.test.ts`
+- Modify: `society-bots` `src/fame-swap-pool-state/registry/base-v1-pools.json`
+- Modify: `www` `src/features/fame-swap/solver/poolStateRegistry.ts`
+- Modify: `www` `src/features/fame-swap/solver/poolStateRegistry.test.ts`
+- Modify: `www` `scripts/fame-swap-pool-state-registry.ts`
+
+**Approach:**
+- Add a replay-capable marker or state surface that can only apply to `slipstream-usdc-weth-100` in this milestone.
+- Keep `cl-head-snapshot` separate from `cl-replay-v1`; head snapshots remain diagnostic state, not replay authority.
+- Generate the replay marker from `www` metadata and copy it into `society-bots` through the existing registry export path, rather than hand-curating the pool in `society-bots`.
+- Preserve unsupported/tracked-only status for every other CL pool, including nearby Slipstream alternatives.
+
+**Patterns to follow:**
+- Existing registry generation and `sourceRegistryId` derivation in `www` `src/features/fame-swap/solver/poolStateRegistry.ts`.
+- Existing strict runtime registry validation in `society-bots` `src/fame-swap-pool-state/registry/index.ts`.
+
+**Test scenarios:**
+- Covers AE1. Happy path: `slipstream-usdc-weth-100` is generated and parsed as the only replay-capable CL pool.
+- Edge case: other Slipstream, Slipstream2, Uniswap V3, and Uniswap V4 rows remain CL head, tracked-only, or unsupported but not replay-capable.
+- Error path: a replay-capable row missing pool address, token order, tick spacing, or Slipstream venue identity fails registry validation.
+- Integration: regenerated `base-v1-pools.json` preserves the same source registry id inputs and adds no hand-authored metadata.
+
+**Verification:**
+- Both repos agree that exactly one pool can request `cl-replay-v1`, and old reserve/head clients keep their current behavior.
+
+---
+
+### U2. Replay Snapshot Persistence Model
+
+**Goal:** Add typed DynamoDB state for complete CL replay capsules, including latest pointer and chunk rows.
+
+**Requirements:** R2, R3, R6, R13.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `society-bots` `src/fame-swap-pool-state/dynamodb/pool-state.ts`
+- Modify: `society-bots` `src/fame-swap-pool-state/dynamodb/pool-state.test.ts`
+
+**Approach:**
+- Add types and parsers for a replay latest pointer row, bitmap chunk rows, and tick chunk rows.
+- Store bigint values as decimal strings or canonical hex strings consistently with existing DynamoDB parser style; do not use lossy numbers for fee, liquidity, bitmap, or tick liquidity values.
+- Include block number, block hash, parent hash, snapshot id, state hash, source registry id, and updated timestamp on all replay rows.
+- Make `batchGetLatestReplayStates` read the pointer and expected chunks, returning only complete, internally consistent capsules.
+- Treat DynamoDB `UnprocessedKeys` as incomplete batch reads, matching existing helper fail-fast behavior.
+- Keep reserve `latest` rows and `cl-head-snapshot-v1` rows unchanged.
+
+**Execution note:** Start with storage parser and completeness tests before indexer/API wiring.
+
+**Patterns to follow:**
+- Existing latest reserve and CL head row serialization in `society-bots` `src/fame-swap-pool-state/dynamodb/pool-state.ts`.
+- Existing malformed-item and incomplete-batch tests in `society-bots` `src/fame-swap-pool-state/dynamodb/pool-state.test.ts`.
+
+**Test scenarios:**
+- Happy path: a complete replay capsule with multiple bitmap and tick chunks round-trips through typed parsers with exact string preservation.
+- Happy path: chunks written before the latest pointer are read as one complete capsule once the pointer exists.
+- Edge case: reserve and CL head rows for the same pool identity still parse and batch-read exactly as before.
+- Error path: a missing expected chunk returns no replay-capable capsule for that pool.
+- Error path: a chunk whose block hash, snapshot id, source registry id, or state hash differs from the pointer invalidates the capsule.
+- Error path: malformed fee, bitmap, tick, liquidity gross, or liquidity net values fail parsing instead of silently falling back to partial state.
+
+**Verification:**
+- The table can hold reserve, CL head, and CL replay state without key collisions, and replay state cannot be returned unless every expected chunk matches the latest pointer.
+
+---
+
+### U3. Safe-Block Full Snapshot Indexer
+
+**Goal:** Capture full replay state for `slipstream-usdc-weth-100` at one safe block and publish only complete capsules.
+
+**Requirements:** R1, R2, R3, R4, R13.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `society-bots` `src/fame-swap-pool-state/indexer.ts`
+- Modify: `society-bots` `src/fame-swap-pool-state/indexer.test.ts`
+- Modify: `society-bots` `src/fame-swap-pool-state/lambdas/indexer.ts`
+
+**Approach:**
+- Extend the indexer client abstraction with one-pool replay snapshot reads: `slot0`, `liquidity`, dynamic `fee()`, block identity, full tick bitmap word range, and initialized tick records.
+- Compute the bitmap word range from Slipstream tick spacing and the CL tick bounds; use the measured full range for milestone one unless provider limits prove it infeasible.
+- Read bitmap words and tick records at the same safe block. Prefer multicall/batched reads where the local viem setup supports same-block calls. If generated ABI coverage is missing, refresh the ABI artifact through the repo's existing generation path rather than hand-editing generated output.
+- Derive initialized ticks from nonzero bitmap words, then read `ticks` only for initialized tick indices.
+- Measure and log bitmap word count, initialized tick count, tick chunk count, snapshot duration, provider read count, state hash, and failure reason.
+- Write chunks first and publish the latest pointer last. If any read or write fails, leave the previous complete pointer intact.
+- Keep current reserve and CL head indexing lanes intact. Replay snapshot failure should not corrupt reserve freshness or CL head snapshots.
+
+**Execution note:** Add characterization coverage around the existing safe-block and CL head behavior before adding replay snapshot reads.
+
+**Patterns to follow:**
+- Safe-block selection and fake-client tests in `society-bots` `src/fame-swap-pool-state/indexer.ts`.
+- Current CL head failure aggregation in `society-bots` `src/fame-swap-pool-state/indexer.test.ts`.
+
+**Test scenarios:**
+- Covers AE1. Happy path: fake bitmap words with initialized ticks produce a complete replay capsule observed through the safe block.
+- Edge case: zero initialized ticks in a fixture produces a complete empty-tick capsule only if head state and fee are still present.
+- Edge case: full snapshot failure for `slipstream-usdc-weth-100` does not prevent reserve reconciliation or CL head snapshot writes for other pools.
+- Error path: dynamic fee read failure writes no replay pointer and records a replay failure reason.
+- Error path: one tick read fails after bitmap reads; chunks are not published as latest replay state.
+- Error path: block identity changes within the read set; the snapshot is rejected as mixed-block state.
+- Integration: repeated runs publish newer complete snapshots monotonically and ignore older or partial attempts.
+
+**Verification:**
+- Indexer logs and result objects show replay snapshot success or explicit failure, plus sizing metrics needed to decide whether full snapshots are cheap enough.
+
+---
+
+### U4. Replay API Surface
+
+**Goal:** Serve complete `cl-replay-v1` state to opt-in callers without breaking reserve or CL head clients.
+
+**Requirements:** R3, R5, R6, R7, R8, R13.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `society-bots` `src/fame-swap-pool-state/api.ts`
+- Modify: `society-bots` `src/fame-swap-pool-state/api.test.ts`
+- Modify: `society-bots` `src/fame-swap-pool-state/lambdas/api.ts`
+- Modify: `society-bots` `src/fame-swap-pool-state/lambdas/api.test.ts`
+
+**Approach:**
+- Extend request parsing to accept `cl-replay-v1` as an explicit state-surface opt-in.
+- Return replay entries only for replay-capable registry rows and only when the persistence layer returns a complete capsule that matches the current source registry id.
+- Apply the existing freshness policy to replay capsules, including stale when `observedThroughBlock` is ahead of `currentBlock`.
+- Return per-pool `unknown` for missing or incomplete replay state, while preserving transport-level failure for malformed requests and DynamoDB unprocessed keys.
+- Include state completeness evidence in success entries: observed block, block hash, state hash, dynamic fee source, word/tick/chunk counts, and freshness bounds.
+- Keep `cl-head-snapshot` responses unchanged and do not include replay arrays unless the caller opts into replay.
+
+**Execution note:** Start with request/response contract tests because this is the cross-repo compatibility boundary.
+
+**Patterns to follow:**
+- Existing state-surface parser and freshness handling in `society-bots` `src/fame-swap-pool-state/api.ts`.
+- Current Lambda sanitized batch logging in `society-bots` `src/fame-swap-pool-state/lambdas/api.ts`.
+
+**Test scenarios:**
+- Covers AE1. Happy path: an opt-in replay request for `slipstream-usdc-weth-100` returns a fresh `cl-replay-v1` entry with full replay arrays and completeness metadata.
+- Covers AE2. Error path: a missing tick chunk returns replay-unavailable status instead of a fresh partial entry.
+- Covers AE4. Edge case: a capsule observed through a future block relative to the caller is stale.
+- Edge case: a caller that requests only reserves or `cl-head-snapshot` does not receive replay arrays.
+- Edge case: another CL pool requested with `cl-replay-v1` returns unsupported or unknown according to registry/state, not replay-capable data.
+- Error path: malformed `stateSurfaces` still returns the existing invalid-request response class.
+- Integration: Lambda batch logs include replay status counts and no raw tick payloads or secrets.
+
+**Verification:**
+- `POST /fame/pool-state` can serve replay state only to opt-in clients, and all incomplete or stale conditions are distinguishable enough for `www` fallback telemetry.
+
+---
+
+### U5. `www` Client Validation and Fallback Contract
+
+**Goal:** Teach `www` to request, parse, validate, and attribute replay state without changing served quote behavior.
+
+**Requirements:** R5, R6, R7, R8, R12, R13.
+
+**Dependencies:** U1, U4.
+
+**Files:**
+- Modify: `www` `src/features/fame-swap/solver/quotes/indexedPoolStateClient.ts`
+- Modify: `www` `src/features/fame-swap/solver/quotes/indexedPoolStateClient.test.ts`
+- Create: `www` `src/features/fame-swap/solver/quotes/indexedSlipstreamReplayState.ts`
+- Create: `www` `src/features/fame-swap/solver/quotes/indexedSlipstreamReplayState.test.ts`
+- Modify: `www` `src/app/api/fame/swap/quote/handler.ts`
+- Modify: `www` `src/app/api/fame/swap/quote/route.test.ts`
+- Modify: `www` `src/features/fame-swap/solver/quotes/quoteContext.ts`
+
+**Approach:**
+- Add an explicit client request option for replay state so normal indexed reserve calls do not suddenly receive large CL replay payloads.
+- Parse `cl-replay-v1` entries as a distinct state kind with strict decimal/hex validation for all replay primitives.
+- Add a pure validator that converts parsed replay state into a `www` replay input only when source registry id, pool id, pool address, token order, direction, freshness, block ordering, dynamic fee, chunk completeness, and indexed tick range are valid.
+- Emit one structured fallback reason for each rejected replay attempt. Reasons should distinguish stale/future state, missing state, incomplete state, malformed state, unsupported direction, source registry mismatch, outside indexed range, replay error, and parity mismatch.
+- Wire the quote API only in shadow mode behind a server-side control. Public served quotes continue to use the live adapter while shadow evidence is recorded.
+- Keep helper URL and service token server-only and preserve current sanitized helper failure logging.
+
+**Patterns to follow:**
+- Strict parser style in `www` `src/features/fame-swap/solver/quotes/indexedPoolStateClient.ts`.
+- Fallback-only reserve adapter discipline in `www` `src/features/fame-swap/solver/quotes/indexedReserveAdapter.ts`.
+- Server-only helper env and sanitized logging in `www` `src/app/api/fame/swap/quote/handler.ts`.
+
+**Test scenarios:**
+- Covers AE2. Error path: missing dynamic fee or tick data produces the matching fallback reason and delegates to the live adapter.
+- Covers AE4. Edge case: replay state observed ahead of the quote context block is rejected before replay.
+- Happy path: parsed fresh replay state for `slipstream-usdc-weth-100` validates for both token directions.
+- Edge case: a replay response for the right pool but mismatched token order is rejected with a typed reason.
+- Edge case: state with a valid pointer but outside the indexed word range is rejected before quote output is used.
+- Error path: malformed bitmap, liquidity, fee, or tick strings fail parsing and trigger helper fallback without leaking raw payloads.
+- Integration: quote API shadow mode records replay validation evidence while the served quote remains live.
+
+**Verification:**
+- `www` can safely hold replay state beside live quotes, with every unusable state path mapped to a single operator-readable fallback reason.
+
+---
+
+### U6. Slipstream Local Replay Engine and Shadow Adapter
+
+**Goal:** Implement deterministic exact-input Slipstream replay in `www` and compare it against the live quoter at the same block.
+
+**Requirements:** R2, R7, R8, R9, R10, R11, R12.
+
+**Dependencies:** U5.
+
+**Files:**
+- Create: `www` `src/features/fame-swap/solver/quotes/slipstreamClReplay.ts`
+- Create: `www` `src/features/fame-swap/solver/quotes/slipstreamClReplay.test.ts`
+- Create: `www` `src/features/fame-swap/solver/quotes/indexedSlipstreamReplayAdapter.ts`
+- Create: `www` `src/features/fame-swap/solver/quotes/indexedSlipstreamReplayAdapter.test.ts`
+- Modify: `www` `src/features/fame-swap/solver/quotes/liveAdapters.ts`
+- Modify: `www` `src/features/fame-swap/solver/quotes/adapters.ts` if protocol evidence needs replay/parity fields
+- Modify: `www` `src/features/fame-swap/solver/quotes/rankRoutes.ts`
+- Modify: `www` `src/features/fame-swap/solver/quotes/rankRoutes.test.ts`
+
+**Approach:**
+- Implement a pure bigint replay module for exact-input Slipstream swaps over the provided state: direction, amount in, optional price limit, current sqrt price, current tick, active liquidity, dynamic fee, bitmap words, and tick liquidity net.
+- Port or adapt only the required V3-style math: tick bitmap traversal, next initialized tick selection, swap step math, fee application, tick crossing, liquidity net updates, and rounding semantics.
+- Fail fast on violated replay assumptions such as unsupported direction, missing next initialized tick, liquidity underflow, price limit outside allowed bounds, or amount/output overflow.
+- Wrap the replay module in a shadow adapter that runs local replay against the snapshot block and calls the live Slipstream quoter at that same snapshot block for parity. Shadow mode still returns the normal live quote result for the quote request while attaching sanitized parity evidence.
+- Treat local replay mismatch as a fallback/parity failure, not as a tolerated production difference.
+- Keep route-level quote context tied to the served live result while shadow mode is active.
+
+**Execution note:** Implement the pure math module test-first with small deterministic fixtures before wiring live shadow comparison.
+
+**Patterns to follow:**
+- Current live Slipstream quoter behavior in `www` `src/features/fame-swap/solver/quotes/liveAdapters.ts`.
+- Existing bigint reserve replay and price-impact style in `www` `src/features/fame-swap/solver/quotes/snapshotAdapter.ts` and `www` `src/features/fame-swap/solver/quotes/routeMath.ts`.
+- Existing route attribution rules in `www` `src/features/fame-swap/solver/quotes/rankRoutes.ts`.
+
+**Test scenarios:**
+- Happy path: a swap that stays inside the current tick interval produces deterministic amount-out and post-swap price.
+- Happy path: a swap crossing one initialized tick applies `liquidityNet` in the correct direction.
+- Happy path: a swap crossing multiple initialized ticks traverses bitmap words and updates active liquidity after each crossing.
+- Edge case: exact tick boundary behavior uses the same tick crossing convention as the Slipstream quoter.
+- Edge case: tiny amount input handles fee rounding and nonzero/zero output exactly according to the replay math.
+- Error path: missing bitmap word or missing initialized tick record before swap completion fails with a typed replay error.
+- Error path: liquidity net crossing would underflow active liquidity and is rejected.
+- Covers AE3. Integration: shadow adapter returns the live quoter result even when local replay matches exactly.
+- Covers AE5. Integration: shadow adapter records a parity mismatch and keeps serving live when local `amountOut` or post-swap price differs.
+
+**Verification:**
+- The pure replay engine is deterministic, bigint-only, and strict; the adapter can compare local and live outputs without changing public quote behavior.
+
+---
+
+### U7. Parity Harness, Route-Lab Evidence, and Documentation
+
+**Goal:** Prove the snapshot proof with same-block live-quoter comparisons, route-lab output, smoke checks, and updated handoff docs.
+
+**Requirements:** R10, R11, R12, R13, R14.
+
+**Dependencies:** U3, U4, U5, U6.
+
+**Files:**
+- Create: `www` `scripts/fame-swap-slipstream-replay-parity.ts`
+- Create: `www` `scripts/fame-swap-slipstream-replay-parity.test.ts`
+- Modify: `www` `scripts/fame-swap-route-lab.ts`
+- Modify: `www` `scripts/fame-swap-route-lab.test.ts`
+- Modify: `www` `docs/fame-swap-route-lab.md`
+- Modify: `society-bots` `docs/fame-pool-state-index.md`
+- Modify: `society-bots` `docs/fame-pool-state-handoff.md`
+
+**Approach:**
+- Add a focused parity harness that fetches replay state and compares local replay against the live Slipstream quoter at the same block for both WETH -> USDC and USDC -> WETH.
+- Cover tiny, common, large, and tick-crossing amount bands. The harness should report amount in, direction, live amount out, local amount out, post-swap price where available, initialized ticks crossed where available, latency, observed block, state hash, and fallback/parity status.
+- Extend indexed route-lab output with replay-state summary and shadow parity evidence without exposing helper credentials, provider URLs, raw RPC errors, calldata, or executable payloads.
+- Update `society-bots` docs to describe replay snapshot storage, freshness, invalidation, provider-limit measurement, and smoke evidence.
+- Update `www` route-lab docs to explain shadow replay, exact parity, live fallback, and promotion criteria.
+- Define production-safe milestone evidence: complete fresh helper snapshot, both-direction parity corpus, typed fallback cases, route attribution still live in shadow mode, and measured snapshot cost within acceptable limits.
+
+**Patterns to follow:**
+- Existing route-lab indexed mode and markdown redaction in `www` `scripts/fame-swap-route-lab.ts`.
+- Existing operational rollout checklists in `society-bots` `docs/fame-pool-state-index.md` and `docs/fame-pool-state-handoff.md`.
+
+**Test scenarios:**
+- Covers AE5. Happy path: parity harness reports exact match across both directions for fixture-backed local/live comparison doubles.
+- Covers AE2. Error path: parity harness reports missing replay state, incomplete state, stale state, and live fallback reasons without crashing the whole matrix.
+- Covers AE3. Integration: route-lab shadow output shows live-served quote attribution even when replay parity passes.
+- Covers AE6. Integration: route-lab markdown includes snapshot age, observed block, state hash, parity status, latency comparison, and fallback reasons.
+- Edge case: route-lab output strips helper secrets, provider URLs, raw RPC details, and executable transaction payloads.
+- Documentation check: docs state that the first production-safe milestone is shadow parity, not hot-path indexed CL quotes.
+
+**Verification:**
+- A reviewer can inspect one route-lab/parity artifact and answer whether `slipstream-usdc-weth-100` replay is fresh, complete, exact, fast enough, and still safely live-fallback-backed.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `www` registry generation marks one replay-capable pool; `society-bots` indexes and serves complete replay state; `www` requests, validates, locally replays, compares live, and reports evidence.
+- **Error propagation:** Invalid helper requests and incomplete DynamoDB batch reads remain transport errors. Per-pool stale, unknown, unsupported, incomplete, and parity-failed states become typed fallback reasons in `www`.
+- **State lifecycle risks:** Replay chunks and latest pointers must avoid exposing partial snapshots. State hash, block identity, and chunk counts are the guardrails.
+- **API surface parity:** Existing reserve and CL head clients must keep working. Replay state is opt-in, versioned, and distinct from `cl-head-snapshot`.
+- **Integration coverage:** Unit tests cover registry, storage, indexer, API, parser, replay math, fallback, and route attribution. The parity harness covers same-block local-vs-live behavior that unit tests cannot prove.
+- **Unchanged invariants:** `society-bots` still does not pick routes or quote amounts. `www` still serves live CL quotes in shadow mode. Public quote payloads still sanitize helper and protocol evidence.
+
+```mermaid
+flowchart TB
+    U1["U1 Registry contract"]
+    U2["U2 Persistence model"]
+    U3["U3 Snapshot indexer"]
+    U4["U4 Replay API"]
+    U5["U5 www validation"]
+    U6["U6 Replay engine"]
+    U7["U7 Parity and docs"]
+
+    U1 --> U2
+    U1 --> U3
+    U2 --> U3
+    U2 --> U4
+    U1 --> U5
+    U4 --> U5
+    U5 --> U6
+    U3 --> U7
+    U4 --> U7
+    U5 --> U7
+    U6 --> U7
+```
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Full tick scan is too large or slow for the pool | Measure word count, initialized tick count, payload size, provider calls, and duration in U3; do not promote if cost is unacceptable. |
+| Tick state is stale relative to quote context | Use observed-through freshness, reject future-block state, and serve live when stale. |
+| Provider limits or multicall limits truncate bitmap/tick reads | Chunk reads, record expected counts, require complete chunks, and fail closed on any missing/unprocessed read. |
+| Mixed-block state creates plausible but wrong quotes | Read at one safe block and include block hash/state hash across all rows; reject mismatched chunks. |
+| Dynamic fee units are misunderstood | Read dynamic `fee()` at the snapshot block and validate units through exact same-block live-quoter parity before promotion. |
+| Replay math diverges from Slipstream rounding | Keep exact parity as the gate, use bigint-only math, and treat mismatches as bugs or invalid state. |
+| Route attribution claims indexed quotes while shadow still serves live | Keep served quote context tied to the live adapter in shadow mode and add route-level tests. |
+| API response becomes too large for normal helper use | Require explicit `cl-replay-v1` opt-in and keep replay scope to one pool; add payload metrics before promotion. |
+| Registry drift between repos makes state untrustworthy | Preserve `sourceRegistryId` and reject mismatches in both helper API and `www`. |
+| Partial writes expose incomplete replay state | Write chunks before latest pointer and validate chunk counts/hash before API response. |
+
+---
+
+## Alternative Approaches Considered
+
+- **Event-driven tick maintenance first:** Rejected for milestone one. It is more efficient long-term, but it requires a correct baseline, log ordering, reorg handling, missed-log recovery, fee event semantics, and reducer verification before we know local replay matches the live quoter.
+- **Bounded tick-window snapshot first:** Rejected as the first replay milestone because it creates an "outside indexed range" failure mode before we have proved exact math. It remains useful later for cheaper multi-pool coverage.
+- **`society-bots` quote endpoint:** Rejected because quote authority, route attribution, slippage, and public fallback already live in `www`.
+- **Shared CL math package first:** Rejected as premature. A shared package is valuable after one concrete engine proves exact Slipstream parity.
+- **Tolerance-based parity:** Rejected for deterministic fields. Any nonzero difference in same-block amount-out or post-swap price indicates incomplete state or wrong math.
+- **Immediate hot-path local quotes:** Rejected until shadow parity and operator evidence are durable.
+
+---
+
+## Success Metrics
+
+- `society-bots` serves a fresh, complete `cl-replay-v1` response for `slipstream-usdc-weth-100` with non-empty bitmap/tick evidence, dynamic fee, state hash, block identity, and matching source registry id.
+- `www` locally replays both WETH -> USDC and USDC -> WETH representative exact-input amounts from the indexed state.
+- The parity harness reports exact same-block `amountOut` parity and post-swap price parity where the live quoter exposes it.
+- Route-lab output shows live-served quotes in shadow mode, replay parity evidence, fallback reasons, and live-vs-replay latency.
+- Existing reserve indexed quoting, CL head snapshots, helper auth, and public quote sanitization continue to pass their focused tests.
+
+---
+
+## Phased Delivery
+
+- **Phase 1: Contract and storage:** Land registry capability, DynamoDB replay rows, and helper API parsing behind opt-in state surface tests.
+- **Phase 2: Snapshot production:** Land safe-block full snapshot reads and publish complete capsules with sizing metrics.
+- **Phase 3: Shadow consumption:** Land `www` parser, validator, local replay engine, and shadow adapter while keeping live output served.
+- **Phase 4: Evidence and rollout:** Land parity harness, route-lab evidence, docs, smoke checks, and promotion gate criteria.
+
+---
+
+## Documentation / Operational Notes
+
+- Update `society-bots` docs before rollout so operators know `cl-head-snapshot` and `cl-replay-v1` are different state surfaces.
+- Keep helper secrets server-only in `www`; do not add public env variants or expose raw helper payloads in public quote responses.
+- Live smoke evidence should include an authenticated helper call for `slipstream-usdc-weth-100`, snapshot block/hash, state hash, dynamic fee, bitmap/tick counts, and source registry id.
+- Soak evidence should cover multiple scheduled indexer intervals with non-regressing observed blocks, successful replay snapshot logs, no Lambda errors/throttles, and no failure queue growth.
+- Promotion evidence should live in a PR comment, release checklist, or linked artifact that includes the parity matrix and fallback cases.
+
+---
+
+## Sources & References
+
+- Origin document: `docs/brainstorms/2026-05-20-slipstream-usdc-weth-100-cl-replay-snapshot-proof-requirements.md`
+- Prior ideation: `docs/ideation/2026-05-20-slipstream-usdc-weth-100-cl-replay-ideation.md`
+- Prior CL head plan: `docs/plans/2026-05-19-001-feat-fame-cl-head-snapshot-plan.md`
+- Existing helper docs: `docs/fame-pool-state-index.md`, `docs/fame-pool-state-handoff.md`
+- `www` indexed helper learning: `docs/solutions/architecture-patterns/fame-swap-indexed-pool-state-quote-helper-2026-05-19.md`
+- Uniswap V3 pool data guide: https://developers.uniswap.org/docs/sdks/v3/guides/pool-data
+- Aerodrome Slipstream repository: https://github.com/aerodrome-finance/slipstream
+- Aerodrome Slipstream CL pool source: https://github.com/aerodrome-finance/slipstream/blob/main/contracts/core/CLPool.sol

--- a/src/fame-swap-pool-state/api.test.ts
+++ b/src/fame-swap-pool-state/api.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, test } from "@jest/globals";
+import { BatchGetCommand } from "@aws-sdk/lib-dynamodb";
 import type { Address } from "viem";
 import { handleFamePoolStateBatchRequest } from "./api.ts";
 import { poolStateRequestAuthorized } from "./auth.ts";
 import {
+  clReplayStateRowsFromSnapshot,
   latestClHeadStateFromSnapshot,
   latestPoolStateKey,
   latestStateFromReserves,
   sourceRegistryIdFor,
   type FameClHeadLatestState,
   type FameClHeadSnapshotRegistryEntry,
+  type FameClReplayBitmapChunkState,
+  type FameClReplayLatestState,
+  type FameClReplayRegistryEntry,
+  type FameClReplayTickChunkState,
   type FamePoolLatestState,
   type PoolStateDocumentClient,
   type PoolStateDynamoResponse,
@@ -20,23 +26,41 @@ type SentCommand = Parameters<PoolStateDocumentClient["send"]>[0];
 
 class BatchStateDb implements PoolStateDocumentClient {
   public readCount = 0;
+  private readonly items = new Map<string, Record<string, unknown>>();
 
   constructor(
-    private readonly states: readonly (
+    states: readonly (
       | FameClHeadLatestState
+      | FameClReplayBitmapChunkState
+      | FameClReplayLatestState
+      | FameClReplayTickChunkState
       | FamePoolLatestState
     )[],
-  ) {}
+  ) {
+    for (const state of states) {
+      const record = recordFromState(state);
+      this.items.set(keyFromRecord(record), record);
+    }
+  }
 
   async send(command: SentCommand): Promise<PoolStateDynamoResponse> {
-    if (command.constructor.name !== "BatchGetCommand") {
+    if (!(command instanceof BatchGetCommand)) {
       throw new Error(`Unexpected command ${command.constructor.name}.`);
     }
     this.readCount += 1;
+    const requestItems = parseObject(command.input.RequestItems);
+    const responses: Record<string, Record<string, unknown>[]> = {};
+    for (const [tableName, request] of Object.entries(requestItems)) {
+      const keys = parseObject(request).Keys;
+      if (!Array.isArray(keys)) {
+        throw new Error("BatchGetCommand keys must be an array.");
+      }
+      responses[tableName] = keys
+        .map((key) => this.items.get(keyFromRecord(parseObject(key))))
+        .filter((item): item is Record<string, unknown> => item !== undefined);
+    }
     return {
-      Responses: {
-        PoolState: this.states.map(recordFromState),
-      },
+      Responses: responses,
     };
   }
 }
@@ -65,9 +89,30 @@ class IncompleteBatchStateDb implements PoolStateDocumentClient {
 }
 
 function recordFromState(
-  state: FameClHeadLatestState | FamePoolLatestState,
+  state:
+    | FameClHeadLatestState
+    | FameClReplayBitmapChunkState
+    | FameClReplayLatestState
+    | FameClReplayTickChunkState
+    | FamePoolLatestState,
 ): Record<string, unknown> {
   return { ...state };
+}
+
+function parseObject(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Expected object.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function keyFromRecord(record: Record<string, unknown>): string {
+  const pk = record.pk;
+  const sk = record.sk;
+  if (typeof pk !== "string" || typeof sk !== "string") {
+    throw new Error("Expected DynamoDB item key.");
+  }
+  return `${pk}\u0000${sk}`;
 }
 
 function quotePool(
@@ -96,6 +141,30 @@ function clHeadPool(id: string): FameClHeadSnapshotRegistryEntry {
     ...entry,
     stateSurface: entry.stateSurface,
     tickSpacing: entry.tickSpacing,
+  };
+}
+
+function clReplayPool(): FameClReplayRegistryEntry {
+  const entry = famePoolStateRegistry.pools.find(
+    (pool) => pool.id === "slipstream-usdc-weth-100",
+  );
+  if (
+    !entry ||
+    entry.replaySurface !== "cl-replay-v1" ||
+    entry.stateSurface !== "cl-head-snapshot" ||
+    entry.poolAddress === null ||
+    entry.tickSpacing === null ||
+    entry.venue !== "aerodrome-slipstream"
+  ) {
+    throw new Error("Missing CL replay pool.");
+  }
+  return {
+    ...entry,
+    replaySurface: entry.replaySurface,
+    stateSurface: entry.stateSurface,
+    poolAddress: entry.poolAddress,
+    tickSpacing: entry.tickSpacing,
+    venue: entry.venue,
   };
 }
 
@@ -134,6 +203,36 @@ function clHeadStateForPool(
     source: pool.venue === "uniswap-v4" ? "v4-state-view" : "pool-slot0-liquidity",
     sourceRegistryId,
     updatedAt: "2026-05-19T00:00:00.000Z",
+  });
+}
+
+function clReplayRowsForPool(pool: FameClReplayRegistryEntry) {
+  return clReplayStateRowsFromSnapshot({
+    pool,
+    sqrtPriceX96: 2n ** 96n,
+    tick: 199_900,
+    liquidity: 1_000n,
+    fee: 100n,
+    observedThroughBlock: 120,
+    blockHash:
+      "0x1111111111111111111111111111111111111111111111111111111111111111",
+    parentHash:
+      "0x2222222222222222222222222222222222222222222222222222222222222222",
+    snapshotId: "unit-cl-replay",
+    stateHash:
+      "0x3333333333333333333333333333333333333333333333333333333333333333",
+    sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    bitmapWords: [
+      { wordPosition: 7, bitmap: 1n },
+      { wordPosition: 8, bitmap: 2n },
+    ],
+    initializedTicks: [
+      { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      { tick: 200_000, liquidityGross: 50n, liquidityNet: -15n },
+    ],
+    bitmapChunkSize: 1,
+    tickChunkSize: 1,
   });
 }
 
@@ -237,6 +336,113 @@ describe("FAME pool-state API contract", () => {
       sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
       maxFreshnessBlocks: 120,
     });
+  });
+
+  test("returns fresh CL replay state only when explicitly requested", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayRowsForPool(pool);
+    const response = await handleFamePoolStateBatchRequest({
+      request: {
+        currentBlock: 125,
+        stateSurfaces: ["cl-replay-v1"],
+        pools: [{ poolId: pool.id }],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([
+        rows.latest,
+        ...rows.bitmapChunks,
+        ...rows.tickChunks,
+      ]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.pools[0]).toMatchObject({
+      status: "fresh",
+      stateKind: "cl-replay-v1",
+      poolId: pool.id,
+      poolAddress: pool.poolAddress,
+      sqrtPriceX96: (2n ** 96n).toString(),
+      tick: 199_900,
+      liquidity: "1000",
+      fee: "100",
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      snapshotId: "unit-cl-replay",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
+      bitmapWordCount: 2,
+      initializedTickCount: 2,
+      bitmapChunkCount: 2,
+      tickChunkCount: 2,
+      maxFreshnessBlocks: 120,
+    });
+    expect(response.pools[0]).toMatchObject({
+      bitmapWords: [
+        {
+          wordPosition: 7,
+          bitmap:
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+        },
+        {
+          wordPosition: 8,
+          bitmap:
+            "0x0000000000000000000000000000000000000000000000000000000000000002",
+        },
+      ],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: "25", liquidityNet: "15" },
+        { tick: 200_000, liquidityGross: "50", liquidityNet: "-15" },
+      ],
+    });
+  });
+
+  test("returns unknown for incomplete CL replay capsules", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayRowsForPool(pool);
+    const response = await handleFamePoolStateBatchRequest({
+      request: {
+        currentBlock: 125,
+        stateSurfaces: ["cl-replay-v1"],
+        pools: [{ poolId: pool.id }],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([rows.latest, ...rows.bitmapChunks]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.pools[0]).toEqual({
+      status: "unknown",
+      requested: { poolId: pool.id },
+      reason: "missing-indexed-state",
+    });
+  });
+
+  test("does not expose CL replay arrays without replay opt-in", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayRowsForPool(pool);
+    const response = await handleFamePoolStateBatchRequest({
+      request: {
+        currentBlock: 125,
+        stateSurfaces: ["cl-head-snapshot"],
+        pools: [{ poolId: pool.id }],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([
+        clHeadStateForPool(pool, 120),
+        rows.latest,
+        ...rows.bitmapChunks,
+        ...rows.tickChunks,
+      ]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.pools[0]).toMatchObject({
+      status: "fresh",
+      stateKind: "cl-head-snapshot",
+      poolId: pool.id,
+    });
+    expect(response.pools[0]).not.toHaveProperty("bitmapWords");
+    expect(response.pools[0]).not.toHaveProperty("initializedTicks");
   });
 
   test("returns unknown for CL head state from a different registry source", async () => {

--- a/src/fame-swap-pool-state/api.test.ts
+++ b/src/fame-swap-pool-state/api.test.ts
@@ -200,7 +200,8 @@ function clHeadStateForPool(
     tick: -11,
     liquidity: 555n,
     observedThroughBlock,
-    source: pool.venue === "uniswap-v4" ? "v4-state-view" : "pool-slot0-liquidity",
+    source:
+      pool.venue === "uniswap-v4" ? "v4-state-view" : "pool-slot0-liquidity",
     sourceRegistryId,
     updatedAt: "2026-05-19T00:00:00.000Z",
   });
@@ -415,6 +416,62 @@ describe("FAME pool-state API contract", () => {
       requested: { poolId: pool.id },
       reason: "missing-indexed-state",
     });
+  });
+
+  test("returns stale CL replay metadata without loading tick chunks", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayRowsForPool(pool);
+    const db = new BatchStateDb([rows.latest]);
+    const response = await handleFamePoolStateBatchRequest({
+      request: {
+        currentBlock: 500,
+        stateSurfaces: ["cl-replay-v1"],
+        pools: [{ poolId: pool.id }],
+      },
+      tableName: "PoolState",
+      db,
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.pools[0]).toMatchObject({
+      status: "stale",
+      stateKind: "cl-replay-v1",
+      poolId: pool.id,
+      observedThroughBlock: 120,
+      bitmapWordCount: 2,
+      initializedTickCount: 2,
+    });
+    expect(response.pools[0]).not.toHaveProperty("bitmapWords");
+    expect(response.pools[0]).not.toHaveProperty("initializedTicks");
+    expect(db.readCount).toBe(1);
+  });
+
+  test("returns future CL replay metadata as stale without loading tick chunks", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayRowsForPool(pool);
+    const db = new BatchStateDb([
+      { ...rows.latest, observedThroughBlock: 130 },
+    ]);
+    const response = await handleFamePoolStateBatchRequest({
+      request: {
+        currentBlock: 125,
+        stateSurfaces: ["cl-replay-v1"],
+        pools: [{ poolId: pool.id }],
+      },
+      tableName: "PoolState",
+      db,
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.pools[0]).toMatchObject({
+      status: "stale",
+      stateKind: "cl-replay-v1",
+      poolId: pool.id,
+      observedThroughBlock: 130,
+    });
+    expect(response.pools[0]).not.toHaveProperty("bitmapWords");
+    expect(response.pools[0]).not.toHaveProperty("initializedTicks");
+    expect(db.readCount).toBe(1);
   });
 
   test("does not expose CL replay arrays without replay opt-in", async () => {

--- a/src/fame-swap-pool-state/api.ts
+++ b/src/fame-swap-pool-state/api.ts
@@ -1,10 +1,13 @@
 import { isAddress, type Address, type Hex } from "viem";
 import {
+  batchGetLatestClReplayStates,
   batchGetLatestClHeadStates,
   batchGetLatestPoolStates,
   sourceRegistryIdFor,
   type FameClHeadLatestState,
   type FameClHeadSnapshotRegistryEntry,
+  type FameClReplayRegistryEntry,
+  type FameClReplayStateCapsule,
   type FamePoolLatestState,
   type PoolStateDocumentClient,
 } from "./dynamodb/pool-state.ts";
@@ -17,7 +20,9 @@ import type {
 } from "./types.ts";
 
 export type FamePoolStateStatus = "fresh" | "stale" | "unknown" | "unsupported";
-export type FamePoolStateRequestStateSurface = "cl-head-snapshot";
+export type FamePoolStateRequestStateSurface =
+  | "cl-head-snapshot"
+  | "cl-replay-v1";
 
 export type FamePoolStateRequestKey =
   | {
@@ -78,6 +83,47 @@ export type FamePoolStateResponseEntry =
       maxFreshnessBlocks: number;
     }
   | {
+      status: Extract<FamePoolStateStatus, "fresh" | "stale">;
+      stateKind: "cl-replay-v1";
+      poolId: string;
+      chainId: number;
+      poolAddress: Address;
+      token0: Address;
+      token1: Address;
+      venueFamily: FamePoolStateVenueFamily;
+      tickSpacing: number;
+      sqrtPriceX96: string;
+      tick: number;
+      liquidity: string;
+      fee: string;
+      feeSource: "pool-fee";
+      observedThroughBlock: number;
+      blockHash: Hex;
+      parentHash: Hex;
+      snapshotId: string;
+      stateHash: Hex;
+      source: "slipstream-pool-state";
+      sourceRegistryId: string;
+      maxFreshnessBlocks: number;
+      bitmapWordCount: number;
+      initializedTickCount: number;
+      bitmapChunkCount: number;
+      tickChunkCount: number;
+      minWordPosition: number | null;
+      maxWordPosition: number | null;
+      minTick: number | null;
+      maxTick: number | null;
+      bitmapWords: {
+        wordPosition: number;
+        bitmap: Hex;
+      }[];
+      initializedTicks: {
+        tick: number;
+        liquidityGross: string;
+        liquidityNet: string;
+      }[];
+    }
+  | {
       status: Extract<FamePoolStateStatus, "unsupported">;
       poolId: string;
       chainId: number;
@@ -100,6 +146,7 @@ export interface FamePoolStateBatchResponse {
 
 type QuoteModelPool = FamePoolStateRegistryEntry & { poolAddress: Address };
 type ClHeadPool = FameClHeadSnapshotRegistryEntry;
+type ClReplayPool = FameClReplayRegistryEntry;
 
 export class FamePoolStateRequestError extends Error {
   constructor(message: string) {
@@ -204,8 +251,11 @@ function parseStateSurfaces(
   }
   return value.map((item, index) => {
     const parsed = parseString(item, `${path}[${index.toString()}]`);
-    if (parsed !== "cl-head-snapshot") {
-      apiError(`${path}[${index.toString()}]`, "expected cl-head-snapshot");
+    if (parsed !== "cl-head-snapshot" && parsed !== "cl-replay-v1") {
+      apiError(
+        `${path}[${index.toString()}]`,
+        "expected cl-head-snapshot or cl-replay-v1",
+      );
     }
     return parsed;
   });
@@ -289,6 +339,16 @@ function isClHeadPool(pool: FamePoolStateRegistryEntry): pool is ClHeadPool {
   return pool.stateSurface === "cl-head-snapshot" && pool.tickSpacing !== null;
 }
 
+function isClReplayPool(pool: FamePoolStateRegistryEntry): pool is ClReplayPool {
+  return (
+    pool.replaySurface === "cl-replay-v1" &&
+    pool.stateSurface === "cl-head-snapshot" &&
+    pool.tickSpacing !== null &&
+    pool.poolAddress !== null &&
+    pool.venue === "aerodrome-slipstream"
+  );
+}
+
 function freshnessStatus(options: {
   state: { observedThroughBlock: number };
   currentBlock: number;
@@ -341,6 +401,30 @@ function clHeadStateMatchesRegistry({
   );
 }
 
+function clReplayStateMatchesRegistry({
+  state,
+  entry,
+  sourceRegistryId,
+}: {
+  state: FameClReplayStateCapsule;
+  entry: ClReplayPool;
+  sourceRegistryId: string;
+}): boolean {
+  const latest = state.latest;
+  return (
+    latest.sourceRegistryId === sourceRegistryId &&
+    latest.poolId === entry.id &&
+    latest.chainId === entry.chainId &&
+    latest.poolAddress.toLowerCase() === entry.poolAddress.toLowerCase() &&
+    latest.token0.toLowerCase() === entry.token0.toLowerCase() &&
+    latest.token1.toLowerCase() === entry.token1.toLowerCase() &&
+    latest.venueFamily === entry.venueFamily &&
+    latest.tickSpacing === entry.tickSpacing &&
+    latest.bitmapWordCount === state.bitmapWords.length &&
+    latest.initializedTickCount === state.initializedTicks.length
+  );
+}
+
 function unsupportedReasonForEntry(
   entry: FamePoolStateRegistryEntry,
 ): FamePoolStateUnsupportedReason {
@@ -376,6 +460,7 @@ export async function handleFamePoolStateBatchRequest({
   const maps = registryMaps(registry);
   const includeClHeadSnapshots =
     parsed.stateSurfaces?.includes("cl-head-snapshot") ?? false;
+  const includeClReplay = parsed.stateSurfaces?.includes("cl-replay-v1") ?? false;
   const entries = parsed.pools.map((pool) => ({
     request: pool,
     entry: registryEntryFor(pool, maps),
@@ -400,6 +485,17 @@ export async function handleFamePoolStateBatchRequest({
           .map((entry) => [entry.id, entry])
       : [],
   );
+  const clReplayPoolsById = new Map(
+    includeClReplay
+      ? entries
+          .map(({ entry }) => entry)
+          .filter(
+            (entry): entry is ClReplayPool =>
+              entry !== undefined && isClReplayPool(entry),
+          )
+          .map((entry) => [entry.id, entry])
+      : [],
+  );
   const states = await batchGetLatestPoolStates({
     db,
     tableName,
@@ -410,6 +506,11 @@ export async function handleFamePoolStateBatchRequest({
     tableName,
     pools: [...clHeadPoolsById.values()],
   });
+  const clReplayStates = await batchGetLatestClReplayStates({
+    db,
+    tableName,
+    pools: [...clReplayPoolsById.values()],
+  });
   const statesByAddress = new Map(
     states.map((state) => [
       addressStateKey(state.chainId, state.poolAddress),
@@ -418,6 +519,9 @@ export async function handleFamePoolStateBatchRequest({
   );
   const clHeadStatesByPoolId = new Map(
     clHeadStates.map((state) => [state.poolId, state]),
+  );
+  const clReplayStatesByPoolId = new Map(
+    clReplayStates.map((state) => [state.latest.poolId, state]),
   );
 
   const sourceRegistryId = sourceRegistryIdFor(registry.source);
@@ -433,6 +537,59 @@ export async function handleFamePoolStateBatchRequest({
           status: "unknown",
           requested,
           reason: "missing-registry-entry",
+        };
+      }
+      if (includeClReplay && isClReplayPool(entry)) {
+        const state = clReplayStatesByPoolId.get(entry.id);
+        if (
+          !state ||
+          !clReplayStateMatchesRegistry({ state, entry, sourceRegistryId })
+        ) {
+          return {
+            status: "unknown",
+            requested,
+            reason: "missing-indexed-state",
+          };
+        }
+        const latest = state.latest;
+
+        return {
+          status: freshnessStatus({
+            state: latest,
+            currentBlock: parsed.currentBlock,
+            maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+          }),
+          stateKind: "cl-replay-v1",
+          poolId: entry.id,
+          chainId: entry.chainId,
+          poolAddress: latest.poolAddress,
+          token0: latest.token0,
+          token1: latest.token1,
+          venueFamily: latest.venueFamily,
+          tickSpacing: latest.tickSpacing,
+          sqrtPriceX96: latest.sqrtPriceX96,
+          tick: latest.tick,
+          liquidity: latest.liquidity,
+          fee: latest.fee,
+          feeSource: latest.feeSource,
+          observedThroughBlock: latest.observedThroughBlock,
+          blockHash: latest.blockHash,
+          parentHash: latest.parentHash,
+          snapshotId: latest.snapshotId,
+          stateHash: latest.stateHash,
+          source: latest.source,
+          sourceRegistryId: latest.sourceRegistryId,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+          bitmapWordCount: latest.bitmapWordCount,
+          initializedTickCount: latest.initializedTickCount,
+          bitmapChunkCount: latest.bitmapChunkCount,
+          tickChunkCount: latest.tickChunkCount,
+          minWordPosition: latest.minWordPosition,
+          maxWordPosition: latest.maxWordPosition,
+          minTick: latest.minTick,
+          maxTick: latest.maxTick,
+          bitmapWords: state.bitmapWords,
+          initializedTicks: state.initializedTicks,
         };
       }
       if (includeClHeadSnapshots && isClHeadPool(entry)) {

--- a/src/fame-swap-pool-state/api.ts
+++ b/src/fame-swap-pool-state/api.ts
@@ -1,6 +1,7 @@
 import { isAddress, type Address, type Hex } from "viem";
 import {
-  batchGetLatestClReplayStates,
+  batchGetClReplayStateCapsules,
+  batchGetLatestClReplayPointers,
   batchGetLatestClHeadStates,
   batchGetLatestPoolStates,
   sourceRegistryIdFor,
@@ -8,6 +9,7 @@ import {
   type FameClHeadSnapshotRegistryEntry,
   type FameClReplayRegistryEntry,
   type FameClReplayStateCapsule,
+  type FameClReplayLatestState,
   type FamePoolLatestState,
   type PoolStateDocumentClient,
 } from "./dynamodb/pool-state.ts";
@@ -41,6 +43,55 @@ export interface FamePoolStateBatchRequest {
   maxFreshnessBlocks?: number;
   stateSurfaces?: FamePoolStateRequestStateSurface[];
   pools: FamePoolStateRequestKey[];
+}
+
+interface FameClReplayResponseBase {
+  stateKind: "cl-replay-v1";
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  token0: Address;
+  token1: Address;
+  venueFamily: FamePoolStateVenueFamily;
+  tickSpacing: number;
+  sqrtPriceX96: string;
+  tick: number;
+  liquidity: string;
+  fee: string;
+  feeSource: "pool-fee";
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  snapshotId: string;
+  stateHash: Hex;
+  source: "slipstream-pool-state";
+  sourceRegistryId: string;
+  maxFreshnessBlocks: number;
+  bitmapWordCount: number;
+  initializedTickCount: number;
+  bitmapChunkCount: number;
+  tickChunkCount: number;
+  minWordPosition: number | null;
+  maxWordPosition: number | null;
+  minTick: number | null;
+  maxTick: number | null;
+}
+
+interface FameClReplayFreshResponseEntry extends FameClReplayResponseBase {
+  status: "fresh";
+  bitmapWords: {
+    wordPosition: number;
+    bitmap: Hex;
+  }[];
+  initializedTicks: {
+    tick: number;
+    liquidityGross: string;
+    liquidityNet: string;
+  }[];
+}
+
+interface FameClReplayStaleResponseEntry extends FameClReplayResponseBase {
+  status: "stale";
 }
 
 export type FamePoolStateResponseEntry =
@@ -82,47 +133,8 @@ export type FamePoolStateResponseEntry =
       sourceRegistryId: string;
       maxFreshnessBlocks: number;
     }
-  | {
-      status: Extract<FamePoolStateStatus, "fresh" | "stale">;
-      stateKind: "cl-replay-v1";
-      poolId: string;
-      chainId: number;
-      poolAddress: Address;
-      token0: Address;
-      token1: Address;
-      venueFamily: FamePoolStateVenueFamily;
-      tickSpacing: number;
-      sqrtPriceX96: string;
-      tick: number;
-      liquidity: string;
-      fee: string;
-      feeSource: "pool-fee";
-      observedThroughBlock: number;
-      blockHash: Hex;
-      parentHash: Hex;
-      snapshotId: string;
-      stateHash: Hex;
-      source: "slipstream-pool-state";
-      sourceRegistryId: string;
-      maxFreshnessBlocks: number;
-      bitmapWordCount: number;
-      initializedTickCount: number;
-      bitmapChunkCount: number;
-      tickChunkCount: number;
-      minWordPosition: number | null;
-      maxWordPosition: number | null;
-      minTick: number | null;
-      maxTick: number | null;
-      bitmapWords: {
-        wordPosition: number;
-        bitmap: Hex;
-      }[];
-      initializedTicks: {
-        tick: number;
-        liquidityGross: string;
-        liquidityNet: string;
-      }[];
-    }
+  | FameClReplayFreshResponseEntry
+  | FameClReplayStaleResponseEntry
   | {
       status: Extract<FamePoolStateStatus, "unsupported">;
       poolId: string;
@@ -288,10 +300,7 @@ export function parseFamePoolStateBatchRequest(
     ...(stateSurfaces === undefined
       ? {}
       : {
-          stateSurfaces: parseStateSurfaces(
-            stateSurfaces,
-            "$.stateSurfaces",
-          ),
+          stateSurfaces: parseStateSurfaces(stateSurfaces, "$.stateSurfaces"),
         }),
     pools: poolsValue.map((pool, index) =>
       parsePoolKey(pool, `$.pools[${index}]`),
@@ -339,7 +348,9 @@ function isClHeadPool(pool: FamePoolStateRegistryEntry): pool is ClHeadPool {
   return pool.stateSurface === "cl-head-snapshot" && pool.tickSpacing !== null;
 }
 
-function isClReplayPool(pool: FamePoolStateRegistryEntry): pool is ClReplayPool {
+function isClReplayPool(
+  pool: FamePoolStateRegistryEntry,
+): pool is ClReplayPool {
   return (
     pool.replaySurface === "cl-replay-v1" &&
     pool.stateSurface === "cl-head-snapshot" &&
@@ -401,6 +412,27 @@ function clHeadStateMatchesRegistry({
   );
 }
 
+function clReplayLatestStateMatchesRegistry({
+  latest,
+  entry,
+  sourceRegistryId,
+}: {
+  latest: FameClReplayLatestState;
+  entry: ClReplayPool;
+  sourceRegistryId: string;
+}): boolean {
+  return (
+    latest.sourceRegistryId === sourceRegistryId &&
+    latest.poolId === entry.id &&
+    latest.chainId === entry.chainId &&
+    latest.poolAddress.toLowerCase() === entry.poolAddress.toLowerCase() &&
+    latest.token0.toLowerCase() === entry.token0.toLowerCase() &&
+    latest.token1.toLowerCase() === entry.token1.toLowerCase() &&
+    latest.venueFamily === entry.venueFamily &&
+    latest.tickSpacing === entry.tickSpacing
+  );
+}
+
 function clReplayStateMatchesRegistry({
   state,
   entry,
@@ -412,24 +444,58 @@ function clReplayStateMatchesRegistry({
 }): boolean {
   const latest = state.latest;
   return (
-    latest.sourceRegistryId === sourceRegistryId &&
-    latest.poolId === entry.id &&
-    latest.chainId === entry.chainId &&
-    latest.poolAddress.toLowerCase() === entry.poolAddress.toLowerCase() &&
-    latest.token0.toLowerCase() === entry.token0.toLowerCase() &&
-    latest.token1.toLowerCase() === entry.token1.toLowerCase() &&
-    latest.venueFamily === entry.venueFamily &&
-    latest.tickSpacing === entry.tickSpacing &&
+    clReplayLatestStateMatchesRegistry({ latest, entry, sourceRegistryId }) &&
     latest.bitmapWordCount === state.bitmapWords.length &&
     latest.initializedTickCount === state.initializedTicks.length
   );
+}
+
+function clReplayResponseBase({
+  latest,
+  maxFreshnessBlocks,
+}: {
+  latest: FameClReplayLatestState;
+  maxFreshnessBlocks: number;
+}): FameClReplayResponseBase {
+  return {
+    stateKind: "cl-replay-v1",
+    poolId: latest.poolId,
+    chainId: latest.chainId,
+    poolAddress: latest.poolAddress,
+    token0: latest.token0,
+    token1: latest.token1,
+    venueFamily: latest.venueFamily,
+    tickSpacing: latest.tickSpacing,
+    sqrtPriceX96: latest.sqrtPriceX96,
+    tick: latest.tick,
+    liquidity: latest.liquidity,
+    fee: latest.fee,
+    feeSource: latest.feeSource,
+    observedThroughBlock: latest.observedThroughBlock,
+    blockHash: latest.blockHash,
+    parentHash: latest.parentHash,
+    snapshotId: latest.snapshotId,
+    stateHash: latest.stateHash,
+    source: latest.source,
+    sourceRegistryId: latest.sourceRegistryId,
+    maxFreshnessBlocks,
+    bitmapWordCount: latest.bitmapWordCount,
+    initializedTickCount: latest.initializedTickCount,
+    bitmapChunkCount: latest.bitmapChunkCount,
+    tickChunkCount: latest.tickChunkCount,
+    minWordPosition: latest.minWordPosition,
+    maxWordPosition: latest.maxWordPosition,
+    minTick: latest.minTick,
+    maxTick: latest.maxTick,
+  };
 }
 
 function unsupportedReasonForEntry(
   entry: FamePoolStateRegistryEntry,
 ): FamePoolStateUnsupportedReason {
   if (entry.unsupportedReason) return entry.unsupportedReason;
-  if (entry.stateSurface === "cl-head-snapshot") return "concentrated-liquidity";
+  if (entry.stateSurface === "cl-head-snapshot")
+    return "concentrated-liquidity";
   return "unsupported-venue";
 }
 
@@ -457,10 +523,12 @@ export async function handleFamePoolStateBatchRequest({
     parsed.maxFreshnessBlocks ?? producerMaxFreshnessBlocks,
     producerMaxFreshnessBlocks,
   );
+  const sourceRegistryId = sourceRegistryIdFor(registry.source);
   const maps = registryMaps(registry);
   const includeClHeadSnapshots =
     parsed.stateSurfaces?.includes("cl-head-snapshot") ?? false;
-  const includeClReplay = parsed.stateSurfaces?.includes("cl-replay-v1") ?? false;
+  const includeClReplay =
+    parsed.stateSurfaces?.includes("cl-replay-v1") ?? false;
   const entries = parsed.pools.map((pool) => ({
     request: pool,
     entry: registryEntryFor(pool, maps),
@@ -506,10 +574,27 @@ export async function handleFamePoolStateBatchRequest({
     tableName,
     pools: [...clHeadPoolsById.values()],
   });
-  const clReplayStates = await batchGetLatestClReplayStates({
+  const clReplayLatestStates = await batchGetLatestClReplayPointers({
     db,
     tableName,
     pools: [...clReplayPoolsById.values()],
+  });
+  const freshClReplayLatestStates = clReplayLatestStates.filter((latest) => {
+    const entry = clReplayPoolsById.get(latest.poolId);
+    return (
+      entry !== undefined &&
+      clReplayLatestStateMatchesRegistry({ latest, entry, sourceRegistryId }) &&
+      freshnessStatus({
+        state: latest,
+        currentBlock: parsed.currentBlock,
+        maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+      }) === "fresh"
+    );
+  });
+  const clReplayStates = await batchGetClReplayStateCapsules({
+    db,
+    tableName,
+    latestStates: freshClReplayLatestStates,
   });
   const statesByAddress = new Map(
     states.map((state) => [
@@ -523,8 +608,9 @@ export async function handleFamePoolStateBatchRequest({
   const clReplayStatesByPoolId = new Map(
     clReplayStates.map((state) => [state.latest.poolId, state]),
   );
-
-  const sourceRegistryId = sourceRegistryIdFor(registry.source);
+  const clReplayLatestStatesByPoolId = new Map(
+    clReplayLatestStates.map((state) => [state.poolId, state]),
+  );
 
   return {
     sourceRegistryId,
@@ -540,6 +626,39 @@ export async function handleFamePoolStateBatchRequest({
         };
       }
       if (includeClReplay && isClReplayPool(entry)) {
+        const latest = clReplayLatestStatesByPoolId.get(entry.id);
+        if (
+          !latest ||
+          !clReplayLatestStateMatchesRegistry({
+            latest,
+            entry,
+            sourceRegistryId,
+          })
+        ) {
+          return {
+            status: "unknown",
+            requested,
+            reason: "missing-indexed-state",
+          };
+        }
+        const status = freshnessStatus({
+          state: latest,
+          currentBlock: parsed.currentBlock,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+        });
+
+        const baseReplayResponse = clReplayResponseBase({
+          latest,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+        });
+
+        if (status === "stale") {
+          return {
+            status,
+            ...baseReplayResponse,
+          };
+        }
+
         const state = clReplayStatesByPoolId.get(entry.id);
         if (
           !state ||
@@ -551,43 +670,10 @@ export async function handleFamePoolStateBatchRequest({
             reason: "missing-indexed-state",
           };
         }
-        const latest = state.latest;
 
         return {
-          status: freshnessStatus({
-            state: latest,
-            currentBlock: parsed.currentBlock,
-            maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
-          }),
-          stateKind: "cl-replay-v1",
-          poolId: entry.id,
-          chainId: entry.chainId,
-          poolAddress: latest.poolAddress,
-          token0: latest.token0,
-          token1: latest.token1,
-          venueFamily: latest.venueFamily,
-          tickSpacing: latest.tickSpacing,
-          sqrtPriceX96: latest.sqrtPriceX96,
-          tick: latest.tick,
-          liquidity: latest.liquidity,
-          fee: latest.fee,
-          feeSource: latest.feeSource,
-          observedThroughBlock: latest.observedThroughBlock,
-          blockHash: latest.blockHash,
-          parentHash: latest.parentHash,
-          snapshotId: latest.snapshotId,
-          stateHash: latest.stateHash,
-          source: latest.source,
-          sourceRegistryId: latest.sourceRegistryId,
-          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
-          bitmapWordCount: latest.bitmapWordCount,
-          initializedTickCount: latest.initializedTickCount,
-          bitmapChunkCount: latest.bitmapChunkCount,
-          tickChunkCount: latest.tickChunkCount,
-          minWordPosition: latest.minWordPosition,
-          maxWordPosition: latest.maxWordPosition,
-          minTick: latest.minTick,
-          maxTick: latest.maxTick,
+          status,
+          ...baseReplayResponse,
           bitmapWords: state.bitmapWords,
           initializedTicks: state.initializedTicks,
         };

--- a/src/fame-swap-pool-state/dynamodb/pool-state.test.ts
+++ b/src/fame-swap-pool-state/dynamodb/pool-state.test.ts
@@ -3,6 +3,7 @@ import { BatchGetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 import type { Address, Hex } from "viem";
 import {
   batchGetLatestClReplayStates,
+  CL_REPLAY_CHUNK_TTL_SECONDS,
   batchGetLatestClHeadStates,
   batchGetLatestPoolStates,
   clReplayStateRowsFromSnapshot,
@@ -17,6 +18,7 @@ import {
   latestStateFromReserves,
   putLatestClHeadState,
   putLatestPoolState,
+  sourceRegistryIdFor,
   type FameClReplayRegistryEntry,
   type FameClHeadSnapshotRegistryEntry,
   type PoolStateDocumentClient,
@@ -120,6 +122,18 @@ function keyFromKey(key: Record<string, unknown>): string {
   return `${pk}\u0000${sk}`;
 }
 
+function stringField(item: Record<string, unknown>, key: string): string {
+  const value = item[key];
+  if (typeof value !== "string") throw new Error(`${key} must be a string.`);
+  return value;
+}
+
+function numberField(item: Record<string, unknown>, key: string): number {
+  const value = item[key];
+  if (typeof value !== "number") throw new Error(`${key} must be a number.`);
+  return value;
+}
+
 class ReplayStateDb implements PoolStateDocumentClient {
   public readonly commands: SentCommand[] = [];
   public readonly items = new Map<string, Record<string, unknown>>();
@@ -133,6 +147,39 @@ class ReplayStateDb implements PoolStateDocumentClient {
     if (command instanceof PutCommand) {
       const item = command.input.Item;
       if (!item) throw new Error("PutCommand fixture is missing Item.");
+      const condition = String(command.input.ConditionExpression ?? "");
+      const existing = this.items.get(keyFromItem(item));
+      if (
+        condition ===
+          "attribute_not_exists(pk) OR observedThroughBlock < :observedThroughBlock OR (observedThroughBlock = :observedThroughBlock AND sourceRegistryId = :sourceRegistryId)" &&
+        existing
+      ) {
+        const values = command.input.ExpressionAttributeValues;
+        if (!values) {
+          throw new Error(
+            "PutCommand fixture is missing ExpressionAttributeValues.",
+          );
+        }
+        const incomingBlock = numberField(values, ":observedThroughBlock");
+        const incomingSourceRegistryId = stringField(
+          values,
+          ":sourceRegistryId",
+        );
+        const currentBlock = numberField(existing, "observedThroughBlock");
+        const currentSourceRegistryId = stringField(
+          existing,
+          "sourceRegistryId",
+        );
+        if (
+          currentBlock > incomingBlock ||
+          (currentBlock === incomingBlock &&
+            currentSourceRegistryId !== incomingSourceRegistryId)
+        ) {
+          const error = new Error("conditional");
+          error.name = "ConditionalCheckFailedException";
+          throw error;
+        }
+      }
       this.items.set(keyFromItem(item), item);
       return {};
     }
@@ -153,7 +200,9 @@ class ReplayStateDb implements PoolStateDocumentClient {
   }
 }
 
-function quoteModelPool(id: string): FamePoolStateRegistryEntry & { poolAddress: Address } {
+function quoteModelPool(
+  id: string,
+): FamePoolStateRegistryEntry & { poolAddress: Address } {
   const pool = famePoolStateRegistry.pools.find((entry) => entry.id === id);
   if (!pool || pool.poolAddress === null) {
     throw new Error(`Missing quote-model pool ${id}.`);
@@ -223,6 +272,12 @@ function clReplayPool(): FameClReplayRegistryEntry {
 }
 
 describe("FAME pool-state DynamoDB mapping", () => {
+  test("includes the helper registry contract version in source registry ids", () => {
+    expect(sourceRegistryIdFor(famePoolStateRegistry.source)).toMatch(
+      /^pool-state-registry-v3:0x[0-9a-f]{64}:0x[0-9a-f]{64}$/,
+    );
+  });
+
   test("builds latest-state rows with token-ordered reserves and k", () => {
     const pool = quoteModelPool("uniswap-v2-fame-direct");
     const state = latestStateFromReserves({
@@ -235,7 +290,8 @@ describe("FAME pool-state DynamoDB mapping", () => {
         transactionIndex: 2,
         logIndex: 7,
       },
-      transactionHash: "0x0000000000000000000000000000000000000000000000000000000000000001",
+      transactionHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
       source: "sync-event",
       sourceRegistryId: "unit",
       updatedAt: "2026-05-17T00:00:00.000Z",
@@ -324,10 +380,13 @@ describe("FAME pool-state DynamoDB mapping", () => {
       liquidity: 123_456_789n,
       fee: 100n,
       observedThroughBlock: 321,
-      blockHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
-      parentHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
       snapshotId: "unit-snapshot-321",
-      stateHash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
       sourceRegistryId: "unit-registry",
       updatedAt: "2026-05-20T00:00:00.000Z",
       bitmapWords: [
@@ -388,6 +447,92 @@ describe("FAME pool-state DynamoDB mapping", () => {
       minTick: 199_800,
       maxTick: 200_000,
     });
+    expect(rows.latest).not.toHaveProperty("expiresAt");
+    expect(rows.bitmapChunks[0]?.expiresAt).toBe(
+      Math.floor(Date.parse("2026-05-20T00:00:00.000Z") / 1_000) +
+        CL_REPLAY_CHUNK_TTL_SECONDS,
+    );
+    expect(rows.tickChunks[0]?.expiresAt).toBe(rows.bitmapChunks[0]?.expiresAt);
+  });
+
+  test("keeps the published replay capsule when a same-block registry write is ignored", async () => {
+    const pool = clReplayPool();
+    const publishedRows = clReplayStateRowsFromSnapshot({
+      pool,
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 100n,
+      observedThroughBlock: 321,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      snapshotId: "unit-snapshot-321:registry-a",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
+      sourceRegistryId: "registry-a",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
+    });
+    const rejectedRows = clReplayStateRowsFromSnapshot({
+      pool,
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 100n,
+      observedThroughBlock: 321,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      snapshotId: "unit-snapshot-321:registry-b",
+      stateHash:
+        "0x4444444444444444444444444444444444444444444444444444444444444444",
+      sourceRegistryId: "registry-b",
+      updatedAt: "2026-05-20T00:01:00.000Z",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 50n, liquidityNet: 30n },
+      ],
+    });
+    const db = new ReplayStateDb();
+
+    await expect(
+      putLatestClReplayState({
+        db,
+        tableName: "PoolState",
+        rows: publishedRows,
+      }),
+    ).resolves.toBe("written");
+    await expect(
+      putLatestClReplayState({
+        db,
+        tableName: "PoolState",
+        rows: rejectedRows,
+      }),
+    ).resolves.toBe("ignored");
+
+    await expect(
+      batchGetLatestClReplayStates({
+        db,
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).resolves.toEqual([
+      {
+        latest: publishedRows.latest,
+        bitmapWords: publishedRows.bitmapChunks.flatMap(
+          (chunk) => chunk.bitmapWords,
+        ),
+        initializedTicks: publishedRows.tickChunks.flatMap(
+          (chunk) => chunk.initializedTicks,
+        ),
+      },
+    ]);
   });
 
   test("returns no CL replay capsule when an expected chunk is missing", async () => {
@@ -399,14 +544,19 @@ describe("FAME pool-state DynamoDB mapping", () => {
       liquidity: 1_000n,
       fee: 100n,
       observedThroughBlock: 321,
-      blockHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
-      parentHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
       snapshotId: "unit-snapshot-321",
-      stateHash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
       sourceRegistryId: "unit-registry",
       updatedAt: "2026-05-20T00:00:00.000Z",
       bitmapWords: [{ wordPosition: 7, bitmap: 1n }],
-      initializedTicks: [{ tick: 199_900, liquidityGross: 25n, liquidityNet: 15n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
       bitmapChunkSize: 1,
       tickChunkSize: 1,
     });
@@ -430,14 +580,19 @@ describe("FAME pool-state DynamoDB mapping", () => {
       liquidity: 1_000n,
       fee: 100n,
       observedThroughBlock: 321,
-      blockHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
-      parentHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
       snapshotId: "unit-snapshot-321",
-      stateHash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
       sourceRegistryId: "unit-registry",
       updatedAt: "2026-05-20T00:00:00.000Z",
       bitmapWords: [{ wordPosition: 7, bitmap: 1n }],
-      initializedTicks: [{ tick: 199_900, liquidityGross: 25n, liquidityNet: 15n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
       bitmapChunkSize: 1,
       tickChunkSize: 1,
     });
@@ -470,14 +625,19 @@ describe("FAME pool-state DynamoDB mapping", () => {
       liquidity: 1_000n,
       fee: 100n,
       observedThroughBlock: 321,
-      blockHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
-      parentHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
       snapshotId: "unit-snapshot-321",
-      stateHash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
       sourceRegistryId: "unit-registry",
       updatedAt: "2026-05-20T00:00:00.000Z",
       bitmapWords: [{ wordPosition: 7, bitmap: 1n }],
-      initializedTicks: [{ tick: 199_900, liquidityGross: 25n, liquidityNet: 15n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
       bitmapChunkSize: 1,
       tickChunkSize: 1,
     });
@@ -497,7 +657,10 @@ describe("FAME pool-state DynamoDB mapping", () => {
       batchGetLatestClReplayStates({
         db: new ReplayStateDb([
           rows.latest,
-          { ...rows.bitmapChunks[0], bitmapWords: [{ wordPosition: 7, bitmap: "0x1" }] },
+          {
+            ...rows.bitmapChunks[0],
+            bitmapWords: [{ wordPosition: 7, bitmap: "0x1" }],
+          },
           ...rows.tickChunks,
         ]),
         tableName: "PoolState",

--- a/src/fame-swap-pool-state/dynamodb/pool-state.test.ts
+++ b/src/fame-swap-pool-state/dynamodb/pool-state.test.ts
@@ -1,17 +1,23 @@
 import { describe, expect, test } from "@jest/globals";
+import { BatchGetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 import type { Address, Hex } from "viem";
 import {
+  batchGetLatestClReplayStates,
   batchGetLatestClHeadStates,
   batchGetLatestPoolStates,
+  clReplayStateRowsFromSnapshot,
   comparePoolStateEventVersions,
   getLatestClHeadState,
   getLatestPoolState,
   latestClHeadStateFromSnapshot,
   latestClHeadStateKey,
+  latestClReplayStateKey,
   latestPoolStateKey,
+  putLatestClReplayState,
   latestStateFromReserves,
   putLatestClHeadState,
   putLatestPoolState,
+  type FameClReplayRegistryEntry,
   type FameClHeadSnapshotRegistryEntry,
   type PoolStateDocumentClient,
   type PoolStateDynamoResponse,
@@ -96,6 +102,57 @@ class ItemDb implements PoolStateDocumentClient {
   }
 }
 
+function keyFromItem(item: Record<string, unknown>): string {
+  const pk = item.pk;
+  const sk = item.sk;
+  if (typeof pk !== "string" || typeof sk !== "string") {
+    throw new Error("DynamoDB fixture item is missing pk/sk.");
+  }
+  return `${pk}\u0000${sk}`;
+}
+
+function keyFromKey(key: Record<string, unknown>): string {
+  const pk = key.pk;
+  const sk = key.sk;
+  if (typeof pk !== "string" || typeof sk !== "string") {
+    throw new Error("DynamoDB fixture key is missing pk/sk.");
+  }
+  return `${pk}\u0000${sk}`;
+}
+
+class ReplayStateDb implements PoolStateDocumentClient {
+  public readonly commands: SentCommand[] = [];
+  public readonly items = new Map<string, Record<string, unknown>>();
+
+  constructor(items: readonly Record<string, unknown>[] = []) {
+    for (const item of items) this.items.set(keyFromItem(item), item);
+  }
+
+  async send(command: SentCommand): Promise<PoolStateDynamoResponse> {
+    this.commands.push(command);
+    if (command instanceof PutCommand) {
+      const item = command.input.Item;
+      if (!item) throw new Error("PutCommand fixture is missing Item.");
+      this.items.set(keyFromItem(item), item);
+      return {};
+    }
+    if (!(command instanceof BatchGetCommand)) {
+      throw new Error(`Unexpected command ${command.constructor.name}.`);
+    }
+
+    const request = command.input.RequestItems?.PoolState;
+    const keys: Record<string, unknown>[] = request?.Keys ?? [];
+    return {
+      Responses: {
+        PoolState: keys.flatMap((key) => {
+          const item = this.items.get(keyFromKey(key));
+          return item ? [item] : [];
+        }),
+      },
+    };
+  }
+}
+
 function quoteModelPool(id: string): FamePoolStateRegistryEntry & { poolAddress: Address } {
   const pool = famePoolStateRegistry.pools.find((entry) => entry.id === id);
   if (!pool || pool.poolAddress === null) {
@@ -138,6 +195,30 @@ function firstV4ClHeadPool(): FameClHeadSnapshotRegistryEntry {
     ...pool,
     stateSurface: pool.stateSurface,
     tickSpacing: pool.tickSpacing,
+  };
+}
+
+function clReplayPool(): FameClReplayRegistryEntry {
+  const pool = famePoolStateRegistry.pools.find(
+    (entry) => entry.id === "slipstream-usdc-weth-100",
+  );
+  if (
+    !pool ||
+    pool.replaySurface !== "cl-replay-v1" ||
+    pool.stateSurface !== "cl-head-snapshot" ||
+    pool.poolAddress === null ||
+    pool.tickSpacing === null ||
+    pool.venue !== "aerodrome-slipstream"
+  ) {
+    throw new Error("Missing replay-capable Slipstream pool.");
+  }
+  return {
+    ...pool,
+    replaySurface: pool.replaySurface,
+    stateSurface: pool.stateSurface,
+    poolAddress: pool.poolAddress,
+    tickSpacing: pool.tickSpacing,
+    venue: pool.venue,
   };
 }
 
@@ -232,6 +313,213 @@ describe("FAME pool-state DynamoDB mapping", () => {
         pool,
       }),
     ).resolves.toEqual(state);
+  });
+
+  test("round-trips complete CL replay capsules with chunked bitmap and ticks", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayStateRowsFromSnapshot({
+      pool,
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 123_456_789n,
+      fee: 100n,
+      observedThroughBlock: 321,
+      blockHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      snapshotId: "unit-snapshot-321",
+      stateHash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      bitmapWords: [
+        { wordPosition: 7, bitmap: 1n },
+        { wordPosition: 8, bitmap: 2n ** 255n },
+      ],
+      initializedTicks: [
+        { tick: 199_800, liquidityGross: 10n, liquidityNet: -10n },
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+        { tick: 200_000, liquidityGross: 35n, liquidityNet: -5n },
+      ],
+      bitmapChunkSize: 1,
+      tickChunkSize: 2,
+    });
+    const db = new ReplayStateDb();
+
+    await expect(
+      putLatestClReplayState({
+        db,
+        tableName: "PoolState",
+        rows,
+      }),
+    ).resolves.toBe("written");
+    await expect(
+      batchGetLatestClReplayStates({
+        db,
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).resolves.toEqual([
+      {
+        latest: rows.latest,
+        bitmapWords: rows.bitmapChunks.flatMap((chunk) => chunk.bitmapWords),
+        initializedTicks: rows.tickChunks.flatMap(
+          (chunk) => chunk.initializedTicks,
+        ),
+      },
+    ]);
+    expect(db.commands.map((command) => command.constructor.name)).toEqual([
+      "PutCommand",
+      "PutCommand",
+      "PutCommand",
+      "PutCommand",
+      "PutCommand",
+      "BatchGetCommand",
+      "BatchGetCommand",
+    ]);
+    expect(rows.latest).toMatchObject({
+      ...latestClReplayStateKey(pool),
+      stateKind: "cl-replay-v1",
+      fee: "100",
+      bitmapWordCount: 2,
+      initializedTickCount: 3,
+      bitmapChunkCount: 2,
+      tickChunkCount: 2,
+      minWordPosition: 7,
+      maxWordPosition: 8,
+      minTick: 199_800,
+      maxTick: 200_000,
+    });
+  });
+
+  test("returns no CL replay capsule when an expected chunk is missing", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayStateRowsFromSnapshot({
+      pool,
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 100n,
+      observedThroughBlock: 321,
+      blockHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      snapshotId: "unit-snapshot-321",
+      stateHash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n }],
+      initializedTicks: [{ tick: 199_900, liquidityGross: 25n, liquidityNet: 15n }],
+      bitmapChunkSize: 1,
+      tickChunkSize: 1,
+    });
+    const db = new ReplayStateDb([rows.latest, ...rows.bitmapChunks]);
+
+    await expect(
+      batchGetLatestClReplayStates({
+        db,
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  test("returns no CL replay capsule when a chunk identity differs from the pointer", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayStateRowsFromSnapshot({
+      pool,
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 100n,
+      observedThroughBlock: 321,
+      blockHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      snapshotId: "unit-snapshot-321",
+      stateHash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n }],
+      initializedTicks: [{ tick: 199_900, liquidityGross: 25n, liquidityNet: 15n }],
+      bitmapChunkSize: 1,
+      tickChunkSize: 1,
+    });
+    const mismatchedTickChunk = {
+      ...rows.tickChunks[0],
+      stateHash:
+        "0x4444444444444444444444444444444444444444444444444444444444444444",
+    };
+    const db = new ReplayStateDb([
+      rows.latest,
+      ...rows.bitmapChunks,
+      mismatchedTickChunk,
+    ]);
+
+    await expect(
+      batchGetLatestClReplayStates({
+        db,
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  test("rejects malformed CL replay fee, bitmap, and tick liquidity values", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayStateRowsFromSnapshot({
+      pool,
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 100n,
+      observedThroughBlock: 321,
+      blockHash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash: "0x2222222222222222222222222222222222222222222222222222222222222222",
+      snapshotId: "unit-snapshot-321",
+      stateHash: "0x3333333333333333333333333333333333333333333333333333333333333333",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n }],
+      initializedTicks: [{ tick: 199_900, liquidityGross: 25n, liquidityNet: 15n }],
+      bitmapChunkSize: 1,
+      tickChunkSize: 1,
+    });
+
+    await expect(
+      batchGetLatestClReplayStates({
+        db: new ReplayStateDb([
+          { ...rows.latest, fee: "0100" },
+          ...rows.bitmapChunks,
+          ...rows.tickChunks,
+        ]),
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).rejects.toThrow(/Invalid latest CL replay-state DynamoDB item/);
+    await expect(
+      batchGetLatestClReplayStates({
+        db: new ReplayStateDb([
+          rows.latest,
+          { ...rows.bitmapChunks[0], bitmapWords: [{ wordPosition: 7, bitmap: "0x1" }] },
+          ...rows.tickChunks,
+        ]),
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).rejects.toThrow(/Invalid CL replay bitmap chunk DynamoDB item/);
+    await expect(
+      batchGetLatestClReplayStates({
+        db: new ReplayStateDb([
+          rows.latest,
+          ...rows.bitmapChunks,
+          {
+            ...rows.tickChunks[0],
+            initializedTicks: [
+              { tick: 199_900, liquidityGross: "25", liquidityNet: 15 },
+            ],
+          },
+        ]),
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).rejects.toThrow(/Invalid CL replay tick chunk DynamoDB item/);
   });
 
   test("orders event versions by block, transaction index, then log index", () => {

--- a/src/fame-swap-pool-state/dynamodb/pool-state.ts
+++ b/src/fame-swap-pool-state/dynamodb/pool-state.ts
@@ -7,9 +7,11 @@ import {
   UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { isAddress, isHex, type Address, type Hex } from "viem";
-import type {
-  FamePoolStateRegistryEntry,
-  FamePoolStateVenueFamily,
+import {
+  FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION,
+  type FamePoolStateRegistryEntry,
+  type FamePoolStateRegistrySource,
+  type FamePoolStateVenueFamily,
 } from "../types.ts";
 
 type PoolStateCommand =
@@ -165,6 +167,7 @@ export interface FameClReplayBitmapChunkState extends Record<string, unknown> {
   source: FameClReplaySource;
   sourceRegistryId: string;
   updatedAt: string;
+  expiresAt?: number;
   chunkIndex: number;
   bitmapWords: FameClReplayBitmapWord[];
 }
@@ -184,6 +187,7 @@ export interface FameClReplayTickChunkState extends Record<string, unknown> {
   source: FameClReplaySource;
   sourceRegistryId: string;
   updatedAt: string;
+  expiresAt?: number;
   chunkIndex: number;
   initializedTicks: FameClReplayInitializedTick[];
 }
@@ -256,9 +260,10 @@ function clHeadPoolIdentity(pool: FameClHeadSnapshotRegistryEntry): string {
   throw new Error(`CL head pool ${pool.id} must have poolAddress or poolKey.`);
 }
 
-export function latestClHeadStateKey(
-  pool: FameClHeadSnapshotRegistryEntry,
-): { pk: string; sk: "cl-head-snapshot-v1" } {
+export function latestClHeadStateKey(pool: FameClHeadSnapshotRegistryEntry): {
+  pk: string;
+  sk: "cl-head-snapshot-v1";
+} {
   return {
     pk: `pool:${pool.chainId.toString()}:${clHeadPoolIdentity(pool)}`,
     sk: "cl-head-snapshot-v1",
@@ -269,9 +274,10 @@ function clReplayPoolIdentity(pool: FameClReplayRegistryEntry): string {
   return `address:${pool.poolAddress.toLowerCase()}`;
 }
 
-export function latestClReplayStateKey(
-  pool: FameClReplayRegistryEntry,
-): { pk: string; sk: "cl-replay-v1" } {
+export function latestClReplayStateKey(pool: FameClReplayRegistryEntry): {
+  pk: string;
+  sk: "cl-replay-v1";
+} {
   return {
     pk: `pool:${pool.chainId.toString()}:${clReplayPoolIdentity(pool)}`,
     sk: "cl-replay-v1",
@@ -312,9 +318,12 @@ export function cursorKey(chainId: number): { pk: string; sk: "cursor" } {
 }
 
 export function sourceRegistryIdFor(
-  registrySource: { poolsJsonHash: Hex; solverRoutesJsonHash: Hex },
+  registrySource: Pick<
+    FamePoolStateRegistrySource,
+    "poolsJsonHash" | "solverRoutesJsonHash"
+  >,
 ): string {
-  return `${registrySource.poolsJsonHash}:${registrySource.solverRoutesJsonHash}`;
+  return `pool-state-registry-v${FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION.toString()}:${registrySource.poolsJsonHash}:${registrySource.solverRoutesJsonHash}`;
 }
 
 export function comparePoolStateEventVersions(
@@ -360,7 +369,11 @@ function itemToLatestClReplayState(
   return item ? parseLatestClReplayStateItem(item) : null;
 }
 
-function invalidItem(recordType: string, field: string, message: string): never {
+function invalidItem(
+  recordType: string,
+  field: string,
+  message: string,
+): never {
   throw new PoolStateInvalidItemError(recordType, field, message);
 }
 
@@ -441,7 +454,11 @@ function signedDecimalStringField(
 ): string {
   const value = stringField(item, recordType, field);
   if (!/^-?(0|[1-9][0-9]*)$/.test(value) || value === "-0") {
-    invalidItem(recordType, field, "expected a canonical signed decimal string");
+    invalidItem(
+      recordType,
+      field,
+      "expected a canonical signed decimal string",
+    );
   }
   return value;
 }
@@ -505,7 +522,11 @@ function arrayField(
   }
   return value.map((entry, index) => {
     if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
-      invalidItem(recordType, `${field}[${index.toString()}]`, "expected an object");
+      invalidItem(
+        recordType,
+        `${field}[${index.toString()}]`,
+        "expected an object",
+      );
     }
     return entry as Record<string, unknown>;
   });
@@ -676,7 +697,11 @@ function parseLatestClHeadStateItem(
     feeBps: finiteNumberField(item, recordType, "feeBps"),
     feeLabel: stringField(item, recordType, "feeLabel"),
     tickSpacing: numberField(item, recordType, "tickSpacing"),
-    stateViewAddress: nullableAddressField(item, recordType, "stateViewAddress"),
+    stateViewAddress: nullableAddressField(
+      item,
+      recordType,
+      "stateViewAddress",
+    ),
     sqrtPriceX96: stringField(item, recordType, "sqrtPriceX96"),
     tick: integerField(item, recordType, "tick"),
     liquidity: stringField(item, recordType, "liquidity"),
@@ -695,11 +720,7 @@ function parseReplayBitmapWord(
   const wordPosition = value.wordPosition;
   const bitmap = value.bitmap;
   if (typeof wordPosition !== "number" || !Number.isSafeInteger(wordPosition)) {
-    invalidItem(
-      recordType,
-      `${field}.wordPosition`,
-      "expected a safe integer",
-    );
+    invalidItem(recordType, `${field}.wordPosition`, "expected a safe integer");
   }
   if (typeof bitmap !== "string" || !/^0x[0-9a-f]{64}$/.test(bitmap)) {
     invalidItem(
@@ -817,12 +838,13 @@ function parseClReplayBitmapChunkItem(
     sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
     updatedAt: stringField(item, recordType, "updatedAt"),
     chunkIndex: numberField(item, recordType, "chunkIndex"),
-    bitmapWords: arrayField(item, recordType, "bitmapWords").map((entry, index) =>
-      parseReplayBitmapWord(
-        entry,
-        recordType,
-        `bitmapWords[${index.toString()}]`,
-      ),
+    bitmapWords: arrayField(item, recordType, "bitmapWords").map(
+      (entry, index) =>
+        parseReplayBitmapWord(
+          entry,
+          recordType,
+          `bitmapWords[${index.toString()}]`,
+        ),
     ),
   };
 }
@@ -919,7 +941,10 @@ async function batchGetPoolStateItems({
     );
     const incompleteKeyCount = unprocessedKeyCount(response, tableName);
     if (incompleteKeyCount > 0) {
-      throw new PoolStateIncompleteBatchReadError(tableName, incompleteKeyCount);
+      throw new PoolStateIncompleteBatchReadError(
+        tableName,
+        incompleteKeyCount,
+      );
     }
     items.push(...(response.Responses?.[tableName] ?? []));
   }
@@ -979,7 +1004,11 @@ function completeReplayCapsuleFromItems({
   itemsByKey: ReadonlyMap<string, Record<string, unknown>>;
 }): FameClReplayStateCapsule | null {
   const bitmapChunks: FameClReplayBitmapChunkState[] = [];
-  for (let chunkIndex = 0; chunkIndex < latest.bitmapChunkCount; chunkIndex += 1) {
+  for (
+    let chunkIndex = 0;
+    chunkIndex < latest.bitmapChunkCount;
+    chunkIndex += 1
+  ) {
     const key = clReplayBitmapChunkKey(latest, latest.snapshotId, chunkIndex);
     const item = itemsByKey.get(dynamoKeyString(key));
     if (!item) return null;
@@ -995,7 +1024,11 @@ function completeReplayCapsuleFromItems({
   }
 
   const tickChunks: FameClReplayTickChunkState[] = [];
-  for (let chunkIndex = 0; chunkIndex < latest.tickChunkCount; chunkIndex += 1) {
+  for (
+    let chunkIndex = 0;
+    chunkIndex < latest.tickChunkCount;
+    chunkIndex += 1
+  ) {
     const key = clReplayTickChunkKey(latest, latest.snapshotId, chunkIndex);
     const item = itemsByKey.get(dynamoKeyString(key));
     if (!item) return null;
@@ -1011,7 +1044,9 @@ function completeReplayCapsuleFromItems({
   }
 
   const bitmapWords = bitmapChunks.flatMap((chunk) => chunk.bitmapWords);
-  const initializedTicks = tickChunks.flatMap((chunk) => chunk.initializedTicks);
+  const initializedTicks = tickChunks.flatMap(
+    (chunk) => chunk.initializedTicks,
+  );
   if (!replayCapsuleMatchesPointer(latest, bitmapWords, initializedTicks)) {
     return null;
   }
@@ -1034,7 +1069,10 @@ export function latestStateFromReserves(options: {
   sourceRegistryId: string;
   updatedAt: string;
 }): FamePoolLatestState {
-  const key = latestPoolStateKey(options.pool.chainId, options.pool.poolAddress);
+  const key = latestPoolStateKey(
+    options.pool.chainId,
+    options.pool.poolAddress,
+  );
   return {
     ...key,
     poolId: options.pool.id,
@@ -1096,6 +1134,7 @@ export function latestClHeadStateFromSnapshot(options: {
 
 export const CL_REPLAY_DEFAULT_BITMAP_WORDS_PER_CHUNK = 128;
 export const CL_REPLAY_DEFAULT_TICKS_PER_CHUNK = 128;
+export const CL_REPLAY_CHUNK_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 function assertNonNegativeBigInt(value: bigint, field: string): void {
   if (value < 0n) {
@@ -1105,8 +1144,18 @@ function assertNonNegativeBigInt(value: bigint, field: string): void {
 
 function assertPositiveChunkSize(value: number, field: string): void {
   if (!Number.isSafeInteger(value) || value <= 0) {
-    throw new Error(`CL replay snapshot ${field} must be a positive safe integer.`);
+    throw new Error(
+      `CL replay snapshot ${field} must be a positive safe integer.`,
+    );
   }
+}
+
+function epochSecondsFromIsoTimestamp(value: string, field: string): number {
+  const milliseconds = Date.parse(value);
+  if (!Number.isFinite(milliseconds)) {
+    throw new Error(`CL replay snapshot ${field} must be an ISO timestamp.`);
+  }
+  return Math.floor(milliseconds / 1_000);
 }
 
 function canonicalUint256Hex(value: bigint): Hex {
@@ -1130,7 +1179,9 @@ function assertStrictlyIncreasing(
 ): void {
   for (let index = 1; index < values.length; index += 1) {
     if (values[index - 1] >= values[index]) {
-      throw new Error(`CL replay snapshot ${field} values must be unique and sorted.`);
+      throw new Error(
+        `CL replay snapshot ${field} values must be unique and sorted.`,
+      );
     }
   }
 }
@@ -1193,6 +1244,10 @@ export function clReplayStateRowsFromSnapshot(options: {
       };
     });
 
+  const chunkExpiresAt =
+    epochSecondsFromIsoTimestamp(options.updatedAt, "updatedAt") +
+    CL_REPLAY_CHUNK_TTL_SECONDS;
+
   assertStrictlyIncreasing(
     bitmapWords.map((word) => word.wordPosition),
     "bitmap word",
@@ -1251,6 +1306,7 @@ export function clReplayStateRowsFromSnapshot(options: {
         source: "slipstream-pool-state",
         sourceRegistryId: options.sourceRegistryId,
         updatedAt: options.updatedAt,
+        expiresAt: chunkExpiresAt,
         chunkIndex,
         bitmapWords: chunk,
       }) satisfies FameClReplayBitmapChunkState,
@@ -1272,6 +1328,7 @@ export function clReplayStateRowsFromSnapshot(options: {
         source: "slipstream-pool-state",
         sourceRegistryId: options.sourceRegistryId,
         updatedAt: options.updatedAt,
+        expiresAt: chunkExpiresAt,
         chunkIndex,
         initializedTicks: chunk,
       }) satisfies FameClReplayTickChunkState,
@@ -1380,7 +1437,49 @@ export async function batchGetLatestClHeadStates({
     .filter((item): item is FameClHeadLatestState => item !== null);
 }
 
-export async function batchGetLatestClReplayStates({
+function assertClReplayLatestChunkBounds(
+  latest: FameClReplayLatestState,
+): void {
+  if (latest.bitmapWordCount === 0) {
+    if (latest.bitmapChunkCount !== 0) {
+      throw new PoolStateInvalidItemError(
+        "latest CL replay-state",
+        "bitmapChunkCount",
+        "must be 0 when bitmapWordCount is 0",
+      );
+    }
+  } else if (
+    latest.bitmapChunkCount < 1 ||
+    latest.bitmapChunkCount > latest.bitmapWordCount
+  ) {
+    throw new PoolStateInvalidItemError(
+      "latest CL replay-state",
+      "bitmapChunkCount",
+      "must be between 1 and bitmapWordCount",
+    );
+  }
+
+  if (latest.initializedTickCount === 0) {
+    if (latest.tickChunkCount !== 0) {
+      throw new PoolStateInvalidItemError(
+        "latest CL replay-state",
+        "tickChunkCount",
+        "must be 0 when initializedTickCount is 0",
+      );
+    }
+  } else if (
+    latest.tickChunkCount < 1 ||
+    latest.tickChunkCount > latest.initializedTickCount
+  ) {
+    throw new PoolStateInvalidItemError(
+      "latest CL replay-state",
+      "tickChunkCount",
+      "must be between 1 and initializedTickCount",
+    );
+  }
+}
+
+export async function batchGetLatestClReplayPointers({
   db = defaultDb,
   tableName,
   pools,
@@ -1388,7 +1487,7 @@ export async function batchGetLatestClReplayStates({
   db?: PoolStateDocumentClient;
   tableName: string;
   pools: readonly FameClReplayRegistryEntry[];
-}): Promise<FameClReplayStateCapsule[]> {
+}): Promise<FameClReplayLatestState[]> {
   if (pools.length === 0) return [];
 
   const latestItems = await batchGetPoolStateItems({
@@ -1396,9 +1495,26 @@ export async function batchGetLatestClReplayStates({
     tableName,
     keys: pools.map((pool) => latestClReplayStateKey(pool)),
   });
-  const latestStates = latestItems
+  return latestItems
     .map(itemToLatestClReplayState)
-    .filter((item): item is FameClReplayLatestState => item !== null);
+    .filter((item): item is FameClReplayLatestState => item !== null)
+    .map((latest) => {
+      assertClReplayLatestChunkBounds(latest);
+      return latest;
+    });
+}
+
+export async function batchGetClReplayStateCapsules({
+  db = defaultDb,
+  tableName,
+  latestStates,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  latestStates: readonly FameClReplayLatestState[];
+}): Promise<FameClReplayStateCapsule[]> {
+  if (latestStates.length === 0) return [];
+
   const chunkKeys = latestStates.flatMap((latest) => [
     ...Array.from({ length: latest.bitmapChunkCount }, (_, chunkIndex) =>
       clReplayBitmapChunkKey(latest, latest.snapshotId, chunkIndex),
@@ -1425,6 +1541,27 @@ export async function batchGetLatestClReplayStates({
   return latestStates
     .map((latest) => completeReplayCapsuleFromItems({ latest, itemsByKey }))
     .filter((state): state is FameClReplayStateCapsule => state !== null);
+}
+
+export async function batchGetLatestClReplayStates({
+  db = defaultDb,
+  tableName,
+  pools,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  pools: readonly FameClReplayRegistryEntry[];
+}): Promise<FameClReplayStateCapsule[]> {
+  const latestStates = await batchGetLatestClReplayPointers({
+    db,
+    tableName,
+    pools,
+  });
+  return batchGetClReplayStateCapsules({
+    db,
+    tableName,
+    latestStates,
+  });
 }
 
 export async function putLatestPoolState({

--- a/src/fame-swap-pool-state/dynamodb/pool-state.ts
+++ b/src/fame-swap-pool-state/dynamodb/pool-state.ts
@@ -97,6 +97,109 @@ export interface FameClHeadLatestState {
   updatedAt: string;
 }
 
+export type FameClReplaySource = "slipstream-pool-state";
+
+export interface FameClReplayBitmapWord {
+  wordPosition: number;
+  bitmap: Hex;
+}
+
+export interface FameClReplayInitializedTick {
+  tick: number;
+  liquidityGross: string;
+  liquidityNet: string;
+}
+
+export interface FameClReplayLatestState extends Record<string, unknown> {
+  pk: string;
+  sk: "cl-replay-v1";
+  stateKind: "cl-replay-v1";
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  token0: Address;
+  token1: Address;
+  venueFamily: FamePoolStateVenueFamily;
+  tickSpacing: number;
+  sqrtPriceX96: string;
+  tick: number;
+  liquidity: string;
+  fee: string;
+  feeSource: "pool-fee";
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  snapshotId: string;
+  stateHash: Hex;
+  source: FameClReplaySource;
+  sourceRegistryId: string;
+  updatedAt: string;
+  bitmapWordCount: number;
+  initializedTickCount: number;
+  bitmapChunkCount: number;
+  tickChunkCount: number;
+  minWordPosition: number | null;
+  maxWordPosition: number | null;
+  minTick: number | null;
+  maxTick: number | null;
+}
+
+export type FameClReplayBitmapChunkSortKey =
+  `cl-replay-v1:${string}:bitmap:${number}`;
+
+export type FameClReplayTickChunkSortKey =
+  `cl-replay-v1:${string}:tick:${number}`;
+
+export interface FameClReplayBitmapChunkState extends Record<string, unknown> {
+  pk: string;
+  sk: FameClReplayBitmapChunkSortKey;
+  stateKind: "cl-replay-bitmap-chunk-v1";
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  snapshotId: string;
+  stateHash: Hex;
+  source: FameClReplaySource;
+  sourceRegistryId: string;
+  updatedAt: string;
+  chunkIndex: number;
+  bitmapWords: FameClReplayBitmapWord[];
+}
+
+export interface FameClReplayTickChunkState extends Record<string, unknown> {
+  pk: string;
+  sk: FameClReplayTickChunkSortKey;
+  stateKind: "cl-replay-tick-chunk-v1";
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  snapshotId: string;
+  stateHash: Hex;
+  source: FameClReplaySource;
+  sourceRegistryId: string;
+  updatedAt: string;
+  chunkIndex: number;
+  initializedTicks: FameClReplayInitializedTick[];
+}
+
+export interface FameClReplayStateRows {
+  latest: FameClReplayLatestState;
+  bitmapChunks: FameClReplayBitmapChunkState[];
+  tickChunks: FameClReplayTickChunkState[];
+}
+
+export interface FameClReplayStateCapsule {
+  latest: FameClReplayLatestState;
+  bitmapWords: FameClReplayBitmapWord[];
+  initializedTicks: FameClReplayInitializedTick[];
+}
+
 export interface FamePoolStateCursor {
   pk: string;
   sk: "cursor";
@@ -111,6 +214,12 @@ export type PutLatestPoolStateResult = "written" | "ignored";
 export type FameClHeadSnapshotRegistryEntry = FamePoolStateRegistryEntry & {
   stateSurface: "cl-head-snapshot";
   tickSpacing: number;
+};
+
+export type FameClReplayRegistryEntry = FameClHeadSnapshotRegistryEntry & {
+  replaySurface: "cl-replay-v1";
+  venue: "aerodrome-slipstream";
+  poolAddress: Address;
 };
 
 export class PoolStateIncompleteBatchReadError extends Error {
@@ -153,6 +262,45 @@ export function latestClHeadStateKey(
   return {
     pk: `pool:${pool.chainId.toString()}:${clHeadPoolIdentity(pool)}`,
     sk: "cl-head-snapshot-v1",
+  };
+}
+
+function clReplayPoolIdentity(pool: FameClReplayRegistryEntry): string {
+  return `address:${pool.poolAddress.toLowerCase()}`;
+}
+
+export function latestClReplayStateKey(
+  pool: FameClReplayRegistryEntry,
+): { pk: string; sk: "cl-replay-v1" } {
+  return {
+    pk: `pool:${pool.chainId.toString()}:${clReplayPoolIdentity(pool)}`,
+    sk: "cl-replay-v1",
+  };
+}
+
+function clReplayAddressKey(chainId: number, poolAddress: Address): string {
+  return `pool:${chainId.toString()}:address:${poolAddress.toLowerCase()}`;
+}
+
+function clReplayBitmapChunkKey(
+  pool: { chainId: number; poolAddress: Address },
+  snapshotId: string,
+  chunkIndex: number,
+): { pk: string; sk: FameClReplayBitmapChunkSortKey } {
+  return {
+    pk: clReplayAddressKey(pool.chainId, pool.poolAddress),
+    sk: `cl-replay-v1:${snapshotId}:bitmap:${chunkIndex}`,
+  };
+}
+
+function clReplayTickChunkKey(
+  pool: { chainId: number; poolAddress: Address },
+  snapshotId: string,
+  chunkIndex: number,
+): { pk: string; sk: FameClReplayTickChunkSortKey } {
+  return {
+    pk: clReplayAddressKey(pool.chainId, pool.poolAddress),
+    sk: `cl-replay-v1:${snapshotId}:tick:${chunkIndex}`,
   };
 }
 
@@ -204,6 +352,12 @@ function itemToLatestClHeadState(
   item?: Record<string, unknown> | null,
 ): FameClHeadLatestState | null {
   return item ? parseLatestClHeadStateItem(item) : null;
+}
+
+function itemToLatestClReplayState(
+  item?: Record<string, unknown> | null,
+): FameClReplayLatestState | null {
+  return item ? parseLatestClReplayStateItem(item) : null;
 }
 
 function invalidItem(recordType: string, field: string, message: string): never {
@@ -258,6 +412,105 @@ function finiteNumberField(
   return value;
 }
 
+function nullableIntegerField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): number | null {
+  const value = item[field];
+  if (value === null) return null;
+  return integerField(item, recordType, field);
+}
+
+function decimalStringField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): string {
+  const value = stringField(item, recordType, field);
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) {
+    invalidItem(recordType, field, "expected a canonical decimal string");
+  }
+  return value;
+}
+
+function signedDecimalStringField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): string {
+  const value = stringField(item, recordType, field);
+  if (!/^-?(0|[1-9][0-9]*)$/.test(value) || value === "-0") {
+    invalidItem(recordType, field, "expected a canonical signed decimal string");
+  }
+  return value;
+}
+
+function bytes32HexField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): Hex {
+  const value = stringField(item, recordType, field);
+  if (!/^0x[0-9a-f]{64}$/.test(value)) {
+    invalidItem(recordType, field, "expected a canonical bytes32 hex string");
+  }
+  return value as Hex;
+}
+
+function uint256HexField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): Hex {
+  const value = stringField(item, recordType, field);
+  if (!/^0x[0-9a-f]{64}$/.test(value)) {
+    invalidItem(recordType, field, "expected a canonical uint256 hex string");
+  }
+  return value as Hex;
+}
+
+function clReplayBitmapChunkSortKeyField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): FameClReplayBitmapChunkSortKey {
+  const value = stringField(item, recordType, field);
+  if (!/^cl-replay-v1:.+:bitmap:[0-9]+$/.test(value)) {
+    invalidItem(recordType, field, "expected a CL replay bitmap chunk key");
+  }
+  return value as FameClReplayBitmapChunkSortKey;
+}
+
+function clReplayTickChunkSortKeyField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): FameClReplayTickChunkSortKey {
+  const value = stringField(item, recordType, field);
+  if (!/^cl-replay-v1:.+:tick:[0-9]+$/.test(value)) {
+    invalidItem(recordType, field, "expected a CL replay tick chunk key");
+  }
+  return value as FameClReplayTickChunkSortKey;
+}
+
+function arrayField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): Record<string, unknown>[] {
+  const value = item[field];
+  if (!Array.isArray(value)) {
+    invalidItem(recordType, field, "expected an array");
+  }
+  return value.map((entry, index) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      invalidItem(recordType, `${field}[${index.toString()}]`, "expected an object");
+    }
+    return entry as Record<string, unknown>;
+  });
+}
+
 function literalField<const Value extends string>(
   item: Record<string, unknown>,
   recordType: string,
@@ -295,6 +548,18 @@ function clHeadSourceField(
       field,
       "expected pool-slot0-liquidity or v4-state-view",
     );
+  }
+  return value;
+}
+
+function clReplaySourceField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): FameClReplaySource {
+  const value = item[field];
+  if (value !== "slipstream-pool-state") {
+    invalidItem(recordType, field, "expected slipstream-pool-state");
   }
   return value;
 }
@@ -422,6 +687,182 @@ function parseLatestClHeadStateItem(
   };
 }
 
+function parseReplayBitmapWord(
+  value: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): FameClReplayBitmapWord {
+  const wordPosition = value.wordPosition;
+  const bitmap = value.bitmap;
+  if (typeof wordPosition !== "number" || !Number.isSafeInteger(wordPosition)) {
+    invalidItem(
+      recordType,
+      `${field}.wordPosition`,
+      "expected a safe integer",
+    );
+  }
+  if (typeof bitmap !== "string" || !/^0x[0-9a-f]{64}$/.test(bitmap)) {
+    invalidItem(
+      recordType,
+      `${field}.bitmap`,
+      "expected a canonical uint256 hex string",
+    );
+  }
+  return {
+    wordPosition,
+    bitmap: bitmap as Hex,
+  };
+}
+
+function parseReplayInitializedTick(
+  value: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): FameClReplayInitializedTick {
+  const tick = value.tick;
+  const liquidityGross = value.liquidityGross;
+  const liquidityNet = value.liquidityNet;
+  if (typeof tick !== "number" || !Number.isSafeInteger(tick)) {
+    invalidItem(recordType, `${field}.tick`, "expected a safe integer");
+  }
+  if (
+    typeof liquidityGross !== "string" ||
+    !/^(0|[1-9][0-9]*)$/.test(liquidityGross)
+  ) {
+    invalidItem(
+      recordType,
+      `${field}.liquidityGross`,
+      "expected a canonical decimal string",
+    );
+  }
+  if (
+    typeof liquidityNet !== "string" ||
+    !/^-?(0|[1-9][0-9]*)$/.test(liquidityNet) ||
+    liquidityNet === "-0"
+  ) {
+    invalidItem(
+      recordType,
+      `${field}.liquidityNet`,
+      "expected a canonical signed decimal string",
+    );
+  }
+  return {
+    tick,
+    liquidityGross,
+    liquidityNet,
+  };
+}
+
+function parseLatestClReplayStateItem(
+  item: Record<string, unknown>,
+): FameClReplayLatestState {
+  const recordType = "latest CL replay-state";
+  return {
+    pk: stringField(item, recordType, "pk"),
+    sk: literalField(item, recordType, "sk", "cl-replay-v1"),
+    stateKind: literalField(item, recordType, "stateKind", "cl-replay-v1"),
+    poolId: stringField(item, recordType, "poolId"),
+    chainId: numberField(item, recordType, "chainId"),
+    poolAddress: addressField(item, recordType, "poolAddress"),
+    token0: addressField(item, recordType, "token0"),
+    token1: addressField(item, recordType, "token1"),
+    venueFamily: venueFamilyField(item, recordType, "venueFamily"),
+    tickSpacing: numberField(item, recordType, "tickSpacing"),
+    sqrtPriceX96: decimalStringField(item, recordType, "sqrtPriceX96"),
+    tick: integerField(item, recordType, "tick"),
+    liquidity: decimalStringField(item, recordType, "liquidity"),
+    fee: decimalStringField(item, recordType, "fee"),
+    feeSource: literalField(item, recordType, "feeSource", "pool-fee"),
+    observedThroughBlock: numberField(item, recordType, "observedThroughBlock"),
+    blockHash: bytes32HexField(item, recordType, "blockHash"),
+    parentHash: bytes32HexField(item, recordType, "parentHash"),
+    snapshotId: stringField(item, recordType, "snapshotId"),
+    stateHash: bytes32HexField(item, recordType, "stateHash"),
+    source: clReplaySourceField(item, recordType, "source"),
+    sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
+    updatedAt: stringField(item, recordType, "updatedAt"),
+    bitmapWordCount: numberField(item, recordType, "bitmapWordCount"),
+    initializedTickCount: numberField(item, recordType, "initializedTickCount"),
+    bitmapChunkCount: numberField(item, recordType, "bitmapChunkCount"),
+    tickChunkCount: numberField(item, recordType, "tickChunkCount"),
+    minWordPosition: nullableIntegerField(item, recordType, "minWordPosition"),
+    maxWordPosition: nullableIntegerField(item, recordType, "maxWordPosition"),
+    minTick: nullableIntegerField(item, recordType, "minTick"),
+    maxTick: nullableIntegerField(item, recordType, "maxTick"),
+  };
+}
+
+function parseClReplayBitmapChunkItem(
+  item: Record<string, unknown>,
+): FameClReplayBitmapChunkState {
+  const recordType = "CL replay bitmap chunk";
+  return {
+    pk: stringField(item, recordType, "pk"),
+    sk: clReplayBitmapChunkSortKeyField(item, recordType, "sk"),
+    stateKind: literalField(
+      item,
+      recordType,
+      "stateKind",
+      "cl-replay-bitmap-chunk-v1",
+    ),
+    poolId: stringField(item, recordType, "poolId"),
+    chainId: numberField(item, recordType, "chainId"),
+    poolAddress: addressField(item, recordType, "poolAddress"),
+    observedThroughBlock: numberField(item, recordType, "observedThroughBlock"),
+    blockHash: bytes32HexField(item, recordType, "blockHash"),
+    parentHash: bytes32HexField(item, recordType, "parentHash"),
+    snapshotId: stringField(item, recordType, "snapshotId"),
+    stateHash: bytes32HexField(item, recordType, "stateHash"),
+    source: clReplaySourceField(item, recordType, "source"),
+    sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
+    updatedAt: stringField(item, recordType, "updatedAt"),
+    chunkIndex: numberField(item, recordType, "chunkIndex"),
+    bitmapWords: arrayField(item, recordType, "bitmapWords").map((entry, index) =>
+      parseReplayBitmapWord(
+        entry,
+        recordType,
+        `bitmapWords[${index.toString()}]`,
+      ),
+    ),
+  };
+}
+
+function parseClReplayTickChunkItem(
+  item: Record<string, unknown>,
+): FameClReplayTickChunkState {
+  const recordType = "CL replay tick chunk";
+  return {
+    pk: stringField(item, recordType, "pk"),
+    sk: clReplayTickChunkSortKeyField(item, recordType, "sk"),
+    stateKind: literalField(
+      item,
+      recordType,
+      "stateKind",
+      "cl-replay-tick-chunk-v1",
+    ),
+    poolId: stringField(item, recordType, "poolId"),
+    chainId: numberField(item, recordType, "chainId"),
+    poolAddress: addressField(item, recordType, "poolAddress"),
+    observedThroughBlock: numberField(item, recordType, "observedThroughBlock"),
+    blockHash: bytes32HexField(item, recordType, "blockHash"),
+    parentHash: bytes32HexField(item, recordType, "parentHash"),
+    snapshotId: stringField(item, recordType, "snapshotId"),
+    stateHash: bytes32HexField(item, recordType, "stateHash"),
+    source: clReplaySourceField(item, recordType, "source"),
+    sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
+    updatedAt: stringField(item, recordType, "updatedAt"),
+    chunkIndex: numberField(item, recordType, "chunkIndex"),
+    initializedTicks: arrayField(item, recordType, "initializedTicks").map(
+      (entry, index) =>
+        parseReplayInitializedTick(
+          entry,
+          recordType,
+          `initializedTicks[${index.toString()}]`,
+        ),
+    ),
+  };
+}
+
 function parseCursorItem(item: Record<string, unknown>): FamePoolStateCursor {
   const recordType = "pool-state cursor";
   return {
@@ -439,6 +880,147 @@ function unprocessedKeyCount(
   tableName: string,
 ): number {
   return response.UnprocessedKeys?.[tableName]?.Keys?.length ?? 0;
+}
+
+function dynamoKeyString(key: { pk: string; sk: string }): string {
+  return `${key.pk}\u0000${key.sk}`;
+}
+
+function itemDynamoKeyString(
+  item: Record<string, unknown>,
+  recordType: string,
+): string {
+  return dynamoKeyString({
+    pk: stringField(item, recordType, "pk"),
+    sk: stringField(item, recordType, "sk"),
+  });
+}
+
+async function batchGetPoolStateItems({
+  db,
+  tableName,
+  keys,
+}: {
+  db: PoolStateDocumentClient;
+  tableName: string;
+  keys: readonly { pk: string; sk: string }[];
+}): Promise<Record<string, unknown>[]> {
+  const batchSize = 100;
+  const items: Record<string, unknown>[] = [];
+  for (let index = 0; index < keys.length; index += batchSize) {
+    const response = await db.send(
+      new BatchGetCommand({
+        RequestItems: {
+          [tableName]: {
+            Keys: keys.slice(index, index + batchSize),
+          },
+        },
+      }),
+    );
+    const incompleteKeyCount = unprocessedKeyCount(response, tableName);
+    if (incompleteKeyCount > 0) {
+      throw new PoolStateIncompleteBatchReadError(tableName, incompleteKeyCount);
+    }
+    items.push(...(response.Responses?.[tableName] ?? []));
+  }
+  return items;
+}
+
+function replayChunkMatchesLatest(
+  latest: FameClReplayLatestState,
+  chunk: FameClReplayBitmapChunkState | FameClReplayTickChunkState,
+): boolean {
+  return (
+    chunk.pk === latest.pk &&
+    chunk.poolId === latest.poolId &&
+    chunk.chainId === latest.chainId &&
+    chunk.poolAddress.toLowerCase() === latest.poolAddress.toLowerCase() &&
+    chunk.observedThroughBlock === latest.observedThroughBlock &&
+    chunk.blockHash === latest.blockHash &&
+    chunk.parentHash === latest.parentHash &&
+    chunk.snapshotId === latest.snapshotId &&
+    chunk.stateHash === latest.stateHash &&
+    chunk.source === latest.source &&
+    chunk.sourceRegistryId === latest.sourceRegistryId
+  );
+}
+
+function strictlyIncreasingNumbers(values: readonly number[]): boolean {
+  for (let index = 1; index < values.length; index += 1) {
+    if (values[index - 1] >= values[index]) return false;
+  }
+  return true;
+}
+
+function replayCapsuleMatchesPointer(
+  latest: FameClReplayLatestState,
+  bitmapWords: readonly FameClReplayBitmapWord[],
+  initializedTicks: readonly FameClReplayInitializedTick[],
+): boolean {
+  const wordPositions = bitmapWords.map((word) => word.wordPosition);
+  const tickIndexes = initializedTicks.map((tick) => tick.tick);
+  return (
+    bitmapWords.length === latest.bitmapWordCount &&
+    initializedTicks.length === latest.initializedTickCount &&
+    minOrNull(wordPositions) === latest.minWordPosition &&
+    maxOrNull(wordPositions) === latest.maxWordPosition &&
+    minOrNull(tickIndexes) === latest.minTick &&
+    maxOrNull(tickIndexes) === latest.maxTick &&
+    strictlyIncreasingNumbers(wordPositions) &&
+    strictlyIncreasingNumbers(tickIndexes)
+  );
+}
+
+function completeReplayCapsuleFromItems({
+  latest,
+  itemsByKey,
+}: {
+  latest: FameClReplayLatestState;
+  itemsByKey: ReadonlyMap<string, Record<string, unknown>>;
+}): FameClReplayStateCapsule | null {
+  const bitmapChunks: FameClReplayBitmapChunkState[] = [];
+  for (let chunkIndex = 0; chunkIndex < latest.bitmapChunkCount; chunkIndex += 1) {
+    const key = clReplayBitmapChunkKey(latest, latest.snapshotId, chunkIndex);
+    const item = itemsByKey.get(dynamoKeyString(key));
+    if (!item) return null;
+    const chunk = parseClReplayBitmapChunkItem(item);
+    if (
+      chunk.chunkIndex !== chunkIndex ||
+      chunk.sk !== key.sk ||
+      !replayChunkMatchesLatest(latest, chunk)
+    ) {
+      return null;
+    }
+    bitmapChunks.push(chunk);
+  }
+
+  const tickChunks: FameClReplayTickChunkState[] = [];
+  for (let chunkIndex = 0; chunkIndex < latest.tickChunkCount; chunkIndex += 1) {
+    const key = clReplayTickChunkKey(latest, latest.snapshotId, chunkIndex);
+    const item = itemsByKey.get(dynamoKeyString(key));
+    if (!item) return null;
+    const chunk = parseClReplayTickChunkItem(item);
+    if (
+      chunk.chunkIndex !== chunkIndex ||
+      chunk.sk !== key.sk ||
+      !replayChunkMatchesLatest(latest, chunk)
+    ) {
+      return null;
+    }
+    tickChunks.push(chunk);
+  }
+
+  const bitmapWords = bitmapChunks.flatMap((chunk) => chunk.bitmapWords);
+  const initializedTicks = tickChunks.flatMap((chunk) => chunk.initializedTicks);
+  if (!replayCapsuleMatchesPointer(latest, bitmapWords, initializedTicks)) {
+    return null;
+  }
+
+  return {
+    latest,
+    bitmapWords,
+    initializedTicks,
+  };
 }
 
 export function latestStateFromReserves(options: {
@@ -509,6 +1091,196 @@ export function latestClHeadStateFromSnapshot(options: {
     source: options.source,
     sourceRegistryId: options.sourceRegistryId,
     updatedAt: options.updatedAt,
+  };
+}
+
+export const CL_REPLAY_DEFAULT_BITMAP_WORDS_PER_CHUNK = 128;
+export const CL_REPLAY_DEFAULT_TICKS_PER_CHUNK = 128;
+
+function assertNonNegativeBigInt(value: bigint, field: string): void {
+  if (value < 0n) {
+    throw new Error(`CL replay snapshot ${field} must be non-negative.`);
+  }
+}
+
+function assertPositiveChunkSize(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`CL replay snapshot ${field} must be a positive safe integer.`);
+  }
+}
+
+function canonicalUint256Hex(value: bigint): Hex {
+  if (value < 0n || value >= 2n ** 256n) {
+    throw new Error("CL replay bitmap word must fit uint256.");
+  }
+  return `0x${value.toString(16).padStart(64, "0")}` as Hex;
+}
+
+function chunkArray<T>(values: readonly T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize));
+  }
+  return chunks;
+}
+
+function assertStrictlyIncreasing(
+  values: readonly number[],
+  field: string,
+): void {
+  for (let index = 1; index < values.length; index += 1) {
+    if (values[index - 1] >= values[index]) {
+      throw new Error(`CL replay snapshot ${field} values must be unique and sorted.`);
+    }
+  }
+}
+
+function minOrNull(values: readonly number[]): number | null {
+  return values.length === 0 ? null : values[0];
+}
+
+function maxOrNull(values: readonly number[]): number | null {
+  return values.length === 0 ? null : values[values.length - 1];
+}
+
+export function clReplayStateRowsFromSnapshot(options: {
+  pool: FameClReplayRegistryEntry;
+  sqrtPriceX96: bigint;
+  tick: number;
+  liquidity: bigint;
+  fee: bigint;
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  snapshotId: string;
+  stateHash: Hex;
+  sourceRegistryId: string;
+  updatedAt: string;
+  bitmapWords: readonly { wordPosition: number; bitmap: bigint }[];
+  initializedTicks: readonly {
+    tick: number;
+    liquidityGross: bigint;
+    liquidityNet: bigint;
+  }[];
+  bitmapChunkSize?: number;
+  tickChunkSize?: number;
+}): FameClReplayStateRows {
+  assertNonNegativeBigInt(options.sqrtPriceX96, "sqrtPriceX96");
+  assertNonNegativeBigInt(options.liquidity, "liquidity");
+  assertNonNegativeBigInt(options.fee, "fee");
+
+  const bitmapChunkSize =
+    options.bitmapChunkSize ?? CL_REPLAY_DEFAULT_BITMAP_WORDS_PER_CHUNK;
+  const tickChunkSize =
+    options.tickChunkSize ?? CL_REPLAY_DEFAULT_TICKS_PER_CHUNK;
+  assertPositiveChunkSize(bitmapChunkSize, "bitmapChunkSize");
+  assertPositiveChunkSize(tickChunkSize, "tickChunkSize");
+
+  const bitmapWords = [...options.bitmapWords]
+    .sort((left, right) => left.wordPosition - right.wordPosition)
+    .map((word) => ({
+      wordPosition: word.wordPosition,
+      bitmap: canonicalUint256Hex(word.bitmap),
+    }));
+  const initializedTicks = [...options.initializedTicks]
+    .sort((left, right) => left.tick - right.tick)
+    .map((tick) => {
+      assertNonNegativeBigInt(tick.liquidityGross, "liquidityGross");
+      return {
+        tick: tick.tick,
+        liquidityGross: tick.liquidityGross.toString(),
+        liquidityNet: tick.liquidityNet.toString(),
+      };
+    });
+
+  assertStrictlyIncreasing(
+    bitmapWords.map((word) => word.wordPosition),
+    "bitmap word",
+  );
+  assertStrictlyIncreasing(
+    initializedTicks.map((tick) => tick.tick),
+    "initialized tick",
+  );
+
+  const latest = {
+    ...latestClReplayStateKey(options.pool),
+    stateKind: "cl-replay-v1",
+    poolId: options.pool.id,
+    chainId: options.pool.chainId,
+    poolAddress: options.pool.poolAddress,
+    token0: options.pool.token0,
+    token1: options.pool.token1,
+    venueFamily: options.pool.venueFamily,
+    tickSpacing: options.pool.tickSpacing,
+    sqrtPriceX96: options.sqrtPriceX96.toString(),
+    tick: options.tick,
+    liquidity: options.liquidity.toString(),
+    fee: options.fee.toString(),
+    feeSource: "pool-fee",
+    observedThroughBlock: options.observedThroughBlock,
+    blockHash: options.blockHash,
+    parentHash: options.parentHash,
+    snapshotId: options.snapshotId,
+    stateHash: options.stateHash,
+    source: "slipstream-pool-state",
+    sourceRegistryId: options.sourceRegistryId,
+    updatedAt: options.updatedAt,
+    bitmapWordCount: bitmapWords.length,
+    initializedTickCount: initializedTicks.length,
+    bitmapChunkCount: Math.ceil(bitmapWords.length / bitmapChunkSize),
+    tickChunkCount: Math.ceil(initializedTicks.length / tickChunkSize),
+    minWordPosition: minOrNull(bitmapWords.map((word) => word.wordPosition)),
+    maxWordPosition: maxOrNull(bitmapWords.map((word) => word.wordPosition)),
+    minTick: minOrNull(initializedTicks.map((tick) => tick.tick)),
+    maxTick: maxOrNull(initializedTicks.map((tick) => tick.tick)),
+  } satisfies FameClReplayLatestState;
+
+  const bitmapChunks = chunkArray(bitmapWords, bitmapChunkSize).map(
+    (chunk, chunkIndex) =>
+      ({
+        ...clReplayBitmapChunkKey(options.pool, options.snapshotId, chunkIndex),
+        stateKind: "cl-replay-bitmap-chunk-v1",
+        poolId: options.pool.id,
+        chainId: options.pool.chainId,
+        poolAddress: options.pool.poolAddress,
+        observedThroughBlock: options.observedThroughBlock,
+        blockHash: options.blockHash,
+        parentHash: options.parentHash,
+        snapshotId: options.snapshotId,
+        stateHash: options.stateHash,
+        source: "slipstream-pool-state",
+        sourceRegistryId: options.sourceRegistryId,
+        updatedAt: options.updatedAt,
+        chunkIndex,
+        bitmapWords: chunk,
+      }) satisfies FameClReplayBitmapChunkState,
+  );
+
+  const tickChunks = chunkArray(initializedTicks, tickChunkSize).map(
+    (chunk, chunkIndex) =>
+      ({
+        ...clReplayTickChunkKey(options.pool, options.snapshotId, chunkIndex),
+        stateKind: "cl-replay-tick-chunk-v1",
+        poolId: options.pool.id,
+        chainId: options.pool.chainId,
+        poolAddress: options.pool.poolAddress,
+        observedThroughBlock: options.observedThroughBlock,
+        blockHash: options.blockHash,
+        parentHash: options.parentHash,
+        snapshotId: options.snapshotId,
+        stateHash: options.stateHash,
+        source: "slipstream-pool-state",
+        sourceRegistryId: options.sourceRegistryId,
+        updatedAt: options.updatedAt,
+        chunkIndex,
+        initializedTicks: chunk,
+      }) satisfies FameClReplayTickChunkState,
+  );
+
+  return {
+    latest,
+    bitmapChunks,
+    tickChunks,
   };
 }
 
@@ -608,6 +1380,53 @@ export async function batchGetLatestClHeadStates({
     .filter((item): item is FameClHeadLatestState => item !== null);
 }
 
+export async function batchGetLatestClReplayStates({
+  db = defaultDb,
+  tableName,
+  pools,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  pools: readonly FameClReplayRegistryEntry[];
+}): Promise<FameClReplayStateCapsule[]> {
+  if (pools.length === 0) return [];
+
+  const latestItems = await batchGetPoolStateItems({
+    db,
+    tableName,
+    keys: pools.map((pool) => latestClReplayStateKey(pool)),
+  });
+  const latestStates = latestItems
+    .map(itemToLatestClReplayState)
+    .filter((item): item is FameClReplayLatestState => item !== null);
+  const chunkKeys = latestStates.flatMap((latest) => [
+    ...Array.from({ length: latest.bitmapChunkCount }, (_, chunkIndex) =>
+      clReplayBitmapChunkKey(latest, latest.snapshotId, chunkIndex),
+    ),
+    ...Array.from({ length: latest.tickChunkCount }, (_, chunkIndex) =>
+      clReplayTickChunkKey(latest, latest.snapshotId, chunkIndex),
+    ),
+  ]);
+  const chunkItems =
+    chunkKeys.length === 0
+      ? []
+      : await batchGetPoolStateItems({
+          db,
+          tableName,
+          keys: chunkKeys,
+        });
+  const itemsByKey = new Map(
+    chunkItems.map((item) => [
+      itemDynamoKeyString(item, "CL replay chunk"),
+      item,
+    ]),
+  );
+
+  return latestStates
+    .map((latest) => completeReplayCapsuleFromItems({ latest, itemsByKey }))
+    .filter((state): state is FameClReplayStateCapsule => state !== null);
+}
+
 export async function putLatestPoolState({
   db = defaultDb,
   tableName,
@@ -658,6 +1477,44 @@ export async function putLatestClHeadState({
         ExpressionAttributeValues: {
           ":observedThroughBlock": state.observedThroughBlock,
           ":sourceRegistryId": state.sourceRegistryId,
+        },
+      }),
+    );
+    return "written";
+  } catch (error) {
+    if (isConditionalCheckFailed(error)) return "ignored";
+    throw error;
+  }
+}
+
+export async function putLatestClReplayState({
+  db = defaultDb,
+  tableName,
+  rows,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  rows: FameClReplayStateRows;
+}): Promise<PutLatestPoolStateResult> {
+  for (const chunk of [...rows.bitmapChunks, ...rows.tickChunks]) {
+    await db.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: chunk,
+      }),
+    );
+  }
+
+  try {
+    await db.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: rows.latest,
+        ConditionExpression:
+          "attribute_not_exists(pk) OR observedThroughBlock < :observedThroughBlock OR (observedThroughBlock = :observedThroughBlock AND sourceRegistryId = :sourceRegistryId)",
+        ExpressionAttributeValues: {
+          ":observedThroughBlock": rows.latest.observedThroughBlock,
+          ":sourceRegistryId": rows.latest.sourceRegistryId,
         },
       }),
     );

--- a/src/fame-swap-pool-state/indexer.test.ts
+++ b/src/fame-swap-pool-state/indexer.test.ts
@@ -3,14 +3,17 @@ import type { Address, Hex } from "viem";
 import {
   indexFamePoolStates,
   type FameClHeadSnapshotRead,
+  type FameClReplaySnapshotRead,
   type FamePoolStateIndexerClient,
   type FamePoolStateSyncLog,
 } from "./indexer.ts";
 import {
   cursorKey,
   latestClHeadStateKey,
+  latestClReplayStateKey,
   latestPoolStateKey,
   type FameClHeadSnapshotRegistryEntry,
+  type FameClReplayRegistryEntry,
   type PoolStateDocumentClient,
   type PoolStateDynamoResponse,
 } from "./dynamodb/pool-state.ts";
@@ -135,6 +138,10 @@ class InMemoryPoolStateDb implements PoolStateDocumentClient {
     return this.items.get(keyFromValue(latestClHeadStateKey(pool)));
   }
 
+  getLatestClReplay(pool: FameClReplayRegistryEntry) {
+    return this.items.get(keyFromValue(latestClReplayStateKey(pool)));
+  }
+
   getCursor(chainId: number) {
     return this.items.get(keyFromValue(cursorKey(chainId)));
   }
@@ -147,8 +154,10 @@ class FakePoolStateClient implements FamePoolStateIndexerClient {
     readonly [bigint, bigint, number]
   >();
   public clHeadSnapshotsByPoolId = new Map<string, FameClHeadSnapshotRead>();
+  public clReplaySnapshotsByPoolId = new Map<string, FameClReplaySnapshotRead>();
   public failingReserveAddress: Address | null = null;
   public failingClHeadPoolId: string | null = null;
+  public failingClReplayPoolId: string | null = null;
 
   constructor(
     private readonly logs: readonly FamePoolStateSyncLog[],
@@ -204,6 +213,32 @@ class FakePoolStateClient implements FamePoolStateIndexerClient {
           options.pool.venue === "uniswap-v4"
             ? "v4-state-view"
             : "pool-slot0-liquidity",
+      }
+    );
+  }
+
+  async getClReplaySnapshot(options: {
+    pool: FameClReplayRegistryEntry;
+  }): Promise<FameClReplaySnapshotRead> {
+    if (options.pool.id === this.failingClReplayPoolId) {
+      throw new Error("CL replay read failed");
+    }
+    return (
+      this.clReplaySnapshotsByPoolId.get(options.pool.id) ?? {
+        sqrtPriceX96: 2n ** 96n,
+        tick: 199_900,
+        liquidity: 1_000n,
+        fee: 100n,
+        blockHash:
+          "0x1111111111111111111111111111111111111111111111111111111111111111",
+        parentHash:
+          "0x2222222222222222222222222222222222222222222222222222222222222222",
+        bitmapWords: [{ wordPosition: 7, bitmap: 1n }],
+        initializedTicks: [
+          { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+        ],
+        providerReadCount: 5,
+        durationMs: 12,
       }
     );
   }
@@ -292,6 +327,27 @@ function clHeadPool(id: string): FameClHeadSnapshotRegistryEntry {
     ...entry,
     stateSurface: entry.stateSurface,
     tickSpacing: entry.tickSpacing,
+  };
+}
+
+function clReplayPool(): FameClReplayRegistryEntry {
+  const entry = registryEntry("slipstream-usdc-weth-100");
+  if (
+    entry.replaySurface !== "cl-replay-v1" ||
+    entry.stateSurface !== "cl-head-snapshot" ||
+    entry.poolAddress === null ||
+    entry.tickSpacing === null ||
+    entry.venue !== "aerodrome-slipstream"
+  ) {
+    throw new Error("slipstream-usdc-weth-100 is not CL replay eligible.");
+  }
+  return {
+    ...entry,
+    replaySurface: entry.replaySurface,
+    stateSurface: entry.stateSurface,
+    poolAddress: entry.poolAddress,
+    tickSpacing: entry.tickSpacing,
+    venue: entry.venue,
   };
 }
 
@@ -442,6 +498,112 @@ describe("FAME pool-state indexer", () => {
       observedThroughBlock: 118,
       source: "pool-slot0-liquidity",
     });
+  });
+
+  test("writes complete CL replay snapshots for the one replay-capable pool", async () => {
+    const replayPool = clReplayPool();
+    const db = new InMemoryPoolStateDb();
+    const client = new FakePoolStateClient([], 120n);
+    client.clReplaySnapshotsByPoolId.set(replayPool.id, {
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 9_999n,
+      fee: 100n,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      bitmapWords: [
+        { wordPosition: 7, bitmap: 1n },
+        { wordPosition: 8, bitmap: 2n },
+      ],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+        { tick: 200_000, liquidityGross: 50n, liquidityNet: -15n },
+      ],
+      providerReadCount: 75,
+      durationMs: 42,
+    });
+
+    const result = await indexFamePoolStates({
+      client,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      now: new Date("2026-05-20T00:00:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      clReplaySnapshots: 1,
+      clReplayWrittenPools: 1,
+      clReplayFailedPools: 0,
+      clReplayMetrics: [
+        {
+          poolId: replayPool.id,
+          bitmapWordCount: 2,
+          initializedTickCount: 2,
+          bitmapChunkCount: 1,
+          tickChunkCount: 1,
+          providerReadCount: 75,
+          durationMs: 42,
+          stateHash: expect.stringMatching(/^0x[0-9a-f]{64}$/),
+        },
+      ],
+    });
+    expect(db.getLatestClReplay(replayPool)).toMatchObject({
+      stateKind: "cl-replay-v1",
+      poolId: replayPool.id,
+      tick: 199_900,
+      liquidity: "9999",
+      fee: "100",
+      observedThroughBlock: 118,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      bitmapWordCount: 2,
+      initializedTickCount: 2,
+      minTick: 199_900,
+      maxTick: 200_000,
+    });
+  });
+
+  test("records CL replay failures without blocking CL head snapshots", async () => {
+    const replayPool = clReplayPool();
+    const db = new InMemoryPoolStateDb();
+    const client = new FakePoolStateClient([], 120n);
+    client.failingClReplayPoolId = replayPool.id;
+    client.clHeadSnapshotsByPoolId.set(replayPool.id, {
+      sqrtPriceX96: 123n,
+      tick: 5,
+      liquidity: 456n,
+      source: "pool-slot0-liquidity",
+    });
+
+    const result = await indexFamePoolStates({
+      client,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      now: new Date("2026-05-20T00:00:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      clHeadSnapshots: 1,
+      clHeadWrittenPools: 1,
+      clReplaySnapshots: 0,
+      clReplayWrittenPools: 0,
+      clReplayFailedPools: 1,
+      clReplayFailures: [
+        {
+          poolId: replayPool.id,
+          message: "CL replay read failed",
+        },
+      ],
+    });
+    expect(db.getLatestClHead(replayPool)).toMatchObject({
+      tick: 5,
+      liquidity: "456",
+    });
+    expect(db.getLatestClReplay(replayPool)).toBeUndefined();
   });
 
   test("repairs reserve drift from getReserves before advancing freshness", async () => {

--- a/src/fame-swap-pool-state/indexer.test.ts
+++ b/src/fame-swap-pool-state/indexer.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "@jest/globals";
+import { decodeFunctionResult, encodeAbiParameters } from "viem";
 import type { Address, Hex } from "viem";
 import {
   indexFamePoolStates,
+  SlipstreamTicksAbi,
   type FameClHeadSnapshotRead,
   type FameClReplaySnapshotRead,
   type FamePoolStateIndexerClient,
@@ -378,6 +380,29 @@ function registryWithPools(
 }
 
 describe("FAME pool-state indexer", () => {
+  test("decodes Aerodrome Slipstream tick state with staked and reward fields", () => {
+    const result = decodeFunctionResult({
+      abi: SlipstreamTicksAbi,
+      functionName: "ticks",
+      data: encodeAbiParameters(SlipstreamTicksAbi[0].outputs, [
+        25n,
+        15n,
+        0n,
+        101n,
+        202n,
+        303n,
+        -404n,
+        1_234_567n,
+        88,
+        true,
+      ]),
+    });
+
+    expect(result[0]).toBe(25n);
+    expect(result[1]).toBe(15n);
+    expect(result[9]).toBe(true);
+  });
+
   test("writes Sync reserves, k, observed-through block, and cursor", async () => {
     const pool = quotePool("uniswap-v2-fame-direct");
     const db = new InMemoryPoolStateDb();

--- a/src/fame-swap-pool-state/indexer.test.ts
+++ b/src/fame-swap-pool-state/indexer.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, test } from "@jest/globals";
 import { decodeFunctionResult, encodeAbiParameters } from "viem";
 import type { Address, Hex } from "viem";
 import {
+  assertNoClReplaySnapshotFailures,
+  FameClReplaySnapshotIndexingError,
+  getSlipstreamClReplaySnapshot,
   indexFamePoolStates,
   SlipstreamTicksAbi,
   type FameClHeadSnapshotRead,
   type FameClReplaySnapshotRead,
   type FamePoolStateIndexerClient,
   type FamePoolStateSyncLog,
+  type SlipstreamReplayReadClient,
 } from "./indexer.ts";
 import {
   cursorKey,
@@ -46,7 +50,9 @@ class InMemoryPoolStateDb implements PoolStateDocumentClient {
         }
         responses[tableName] = keys
           .map((key) => this.items.get(keyFromValue(key)))
-          .filter((item): item is Record<string, unknown> => item !== undefined);
+          .filter(
+            (item): item is Record<string, unknown> => item !== undefined,
+          );
       }
       return { Responses: responses };
     }
@@ -79,7 +85,10 @@ class InMemoryPoolStateDb implements PoolStateDocumentClient {
         const values = parseItem(input.ExpressionAttributeValues);
         const currentBlock = numberField(existing, "observedThroughBlock");
         const incomingBlock = numberField(values, ":observedThroughBlock");
-        const currentSourceRegistryId = stringField(existing, "sourceRegistryId");
+        const currentSourceRegistryId = stringField(
+          existing,
+          "sourceRegistryId",
+        );
         const incomingSourceRegistryId = stringField(
           values,
           ":sourceRegistryId",
@@ -156,7 +165,10 @@ class FakePoolStateClient implements FamePoolStateIndexerClient {
     readonly [bigint, bigint, number]
   >();
   public clHeadSnapshotsByPoolId = new Map<string, FameClHeadSnapshotRead>();
-  public clReplaySnapshotsByPoolId = new Map<string, FameClReplaySnapshotRead>();
+  public clReplaySnapshotsByPoolId = new Map<
+    string,
+    FameClReplaySnapshotRead
+  >();
   public failingReserveAddress: Address | null = null;
   public failingClHeadPoolId: string | null = null;
   public failingClReplayPoolId: string | null = null;
@@ -243,6 +255,99 @@ class FakePoolStateClient implements FamePoolStateIndexerClient {
         durationMs: 12,
       }
     );
+  }
+}
+
+class FakeSlipstreamReplayReadClient implements SlipstreamReplayReadClient {
+  public readonly blockNumbers: bigint[] = [];
+  public readonly tickBitmapWordPositions: number[] = [];
+  public readonly tickIndexes: number[] = [];
+  public blockHash: Hex =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+  public parentHash: Hex =
+    "0x2222222222222222222222222222222222222222222222222222222222222222";
+  public readonly bitmaps = new Map<number, bigint>([
+    [-1, 1n << 255n],
+    [0, 1n << 2n],
+  ]);
+  public readonly tickStates = new Map<
+    number,
+    { liquidityGross: bigint; liquidityNet: bigint; initialized: boolean }
+  >([
+    [-100, { liquidityGross: 25n, liquidityNet: -10n, initialized: true }],
+    [200, { liquidityGross: 50n, liquidityNet: 15n, initialized: true }],
+  ]);
+
+  async getBlock(options: {
+    blockNumber: bigint;
+  }): Promise<{ hash: Hex | null; parentHash: Hex }> {
+    this.blockNumbers.push(options.blockNumber);
+    return {
+      hash: this.blockHash,
+      parentHash: this.parentHash,
+    };
+  }
+
+  async getSlot0(options: {
+    blockNumber: bigint;
+  }): Promise<readonly [bigint, number, number, number, number, boolean]> {
+    this.blockNumbers.push(options.blockNumber);
+    return [2n ** 96n, 100, 0, 0, 0, true] as const;
+  }
+
+  async getLiquidity(options: { blockNumber: bigint }): Promise<bigint> {
+    this.blockNumbers.push(options.blockNumber);
+    return 1_000n;
+  }
+
+  async getFee(options: { blockNumber: bigint }): Promise<bigint> {
+    this.blockNumbers.push(options.blockNumber);
+    return 100n;
+  }
+
+  async getTickBitmap(options: {
+    wordPosition: number;
+    blockNumber: bigint;
+  }): Promise<bigint> {
+    this.blockNumbers.push(options.blockNumber);
+    this.tickBitmapWordPositions.push(options.wordPosition);
+    return this.bitmaps.get(options.wordPosition) ?? 0n;
+  }
+
+  async getTick(options: {
+    tick: number;
+    blockNumber: bigint;
+  }): Promise<
+    readonly [
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      number,
+      boolean,
+    ]
+  > {
+    this.blockNumbers.push(options.blockNumber);
+    this.tickIndexes.push(options.tick);
+    const state = this.tickStates.get(options.tick);
+    if (!state)
+      throw new Error(`Missing fake tick ${options.tick.toString()}.`);
+    return [
+      state.liquidityGross,
+      state.liquidityNet,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0n,
+      0,
+      state.initialized,
+    ] as const;
   }
 }
 
@@ -401,6 +506,42 @@ describe("FAME pool-state indexer", () => {
     expect(result[0]).toBe(25n);
     expect(result[1]).toBe(15n);
     expect(result[9]).toBe(true);
+  });
+
+  test("builds Slipstream replay snapshots from bitmap and tick reads at one block", async () => {
+    const pool = clReplayPool();
+    const client = new FakeSlipstreamReplayReadClient();
+
+    const snapshot = await getSlipstreamClReplaySnapshot({
+      client,
+      pool,
+      blockNumber: 118n,
+    });
+
+    expect(snapshot).toMatchObject({
+      sqrtPriceX96: 2n ** 96n,
+      tick: 100,
+      liquidity: 1_000n,
+      fee: 100n,
+      blockHash: client.blockHash,
+      parentHash: client.parentHash,
+      bitmapWords: [
+        { wordPosition: -1, bitmap: 1n << 255n },
+        { wordPosition: 0, bitmap: 1n << 2n },
+      ],
+      initializedTicks: [
+        { tick: -100, liquidityGross: 25n, liquidityNet: -10n },
+        { tick: 200, liquidityGross: 50n, liquidityNet: 15n },
+      ],
+      providerReadCount: 77,
+    });
+    expect(client.tickBitmapWordPositions).toHaveLength(70);
+    expect(client.tickBitmapWordPositions[0]).toBe(-35);
+    expect(client.tickBitmapWordPositions.at(-1)).toBe(34);
+    expect(client.tickIndexes).toEqual([-100, 200]);
+    expect(
+      client.blockNumbers.every((blockNumber) => blockNumber === 118n),
+    ).toBe(true);
   });
 
   test("writes Sync reserves, k, observed-through block, and cursor", async () => {
@@ -589,6 +730,9 @@ describe("FAME pool-state indexer", () => {
       minTick: 199_900,
       maxTick: 200_000,
     });
+    expect(
+      stringField(parseItem(db.getLatestClReplay(replayPool)), "snapshotId"),
+    ).toContain(result.sourceRegistryId);
   });
 
   test("records CL replay failures without blocking CL head snapshots", async () => {
@@ -629,6 +773,20 @@ describe("FAME pool-state indexer", () => {
       liquidity: "456",
     });
     expect(db.getLatestClReplay(replayPool)).toBeUndefined();
+  });
+
+  test("throws an operational error when required CL replay snapshots fail", () => {
+    expect(() =>
+      assertNoClReplaySnapshotFailures({
+        clReplayFailedPools: 1,
+        clReplayFailures: [
+          {
+            poolId: "slipstream-usdc-weth-100",
+            message: "CL replay read failed",
+          },
+        ],
+      }),
+    ).toThrow(FameClReplaySnapshotIndexingError);
   });
 
   test("repairs reserve drift from getReserves before advancing freshness", async () => {

--- a/src/fame-swap-pool-state/indexer.ts
+++ b/src/fame-swap-pool-state/indexer.ts
@@ -110,7 +110,7 @@ const SlipstreamTickBitmapAbi = [
   },
 ] as const;
 
-const SlipstreamTicksAbi = [
+export const SlipstreamTicksAbi = [
   {
     type: "function",
     name: "ticks",
@@ -119,8 +119,10 @@ const SlipstreamTicksAbi = [
     outputs: [
       { name: "liquidityGross", type: "uint128" },
       { name: "liquidityNet", type: "int128" },
+      { name: "stakedLiquidityNet", type: "int128" },
       { name: "feeGrowthOutside0X128", type: "uint256" },
       { name: "feeGrowthOutside1X128", type: "uint256" },
+      { name: "rewardGrowthOutsideX128", type: "uint256" },
       { name: "tickCumulativeOutside", type: "int56" },
       { name: "secondsPerLiquidityOutsideX128", type: "uint160" },
       { name: "secondsOutside", type: "uint32" },
@@ -750,6 +752,8 @@ export function createViemPoolStateIndexerClient(
           const [
             liquidityGross,
             liquidityNet,
+            ,
+            ,
             ,
             ,
             ,

--- a/src/fame-swap-pool-state/indexer.ts
+++ b/src/fame-swap-pool-state/indexer.ts
@@ -1,4 +1,9 @@
-import type { Address, Hex } from "viem";
+import {
+  encodeAbiParameters,
+  keccak256,
+  type Address,
+  type Hex,
+} from "viem";
 import {
   Uint256ReserveSyncEvent,
   UniswapV2PairReserveAbi,
@@ -8,16 +13,20 @@ import type { baseClient } from "@/viem.ts";
 import {
   batchGetLatestClHeadStates,
   batchGetLatestPoolStates,
+  clReplayStateRowsFromSnapshot,
   getPoolStateCursor,
   latestClHeadStateFromSnapshot,
   latestStateFromReserves,
   markPoolObservedThroughBlock,
+  putLatestClReplayState,
   putLatestClHeadState,
   putLatestPoolState,
   setPoolStateCursor,
   sourceRegistryIdFor,
   type FameClHeadSnapshotRegistryEntry,
   type FameClHeadSource,
+  type FameClReplayRegistryEntry,
+  type FameClReplayStateRows,
   type PoolStateDocumentClient,
 } from "./dynamodb/pool-state.ts";
 import { famePoolStateRegistry } from "./registry/index.ts";
@@ -28,7 +37,13 @@ import type {
 
 type QuoteModelPool = FamePoolStateRegistryEntry & { poolAddress: Address };
 type ClHeadPool = FameClHeadSnapshotRegistryEntry;
+type ClReplayPool = FameClReplayRegistryEntry;
 type FamePoolStateSyncEventKind = "uint112-reserves" | "uint256-reserves";
+
+const CL_MIN_TICK = -887_272;
+const CL_MAX_TICK = 887_272;
+const CL_TICK_BITMAP_WORD_SIZE = 256;
+const CL_REPLAY_PROVIDER_READ_BATCH_SIZE = 32;
 
 const SlipstreamSlot0Abi = [
   {
@@ -72,6 +87,45 @@ const ConcentratedPoolLiquidityAbi = [
     stateMutability: "view",
     inputs: [],
     outputs: [{ name: "liquidity", type: "uint128" }],
+  },
+] as const;
+
+const SlipstreamFeeAbi = [
+  {
+    type: "function",
+    name: "fee",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "fee", type: "uint24" }],
+  },
+] as const;
+
+const SlipstreamTickBitmapAbi = [
+  {
+    type: "function",
+    name: "tickBitmap",
+    stateMutability: "view",
+    inputs: [{ name: "wordPosition", type: "int16" }],
+    outputs: [{ name: "bitmap", type: "uint256" }],
+  },
+] as const;
+
+const SlipstreamTicksAbi = [
+  {
+    type: "function",
+    name: "ticks",
+    stateMutability: "view",
+    inputs: [{ name: "tick", type: "int24" }],
+    outputs: [
+      { name: "liquidityGross", type: "uint128" },
+      { name: "liquidityNet", type: "int128" },
+      { name: "feeGrowthOutside0X128", type: "uint256" },
+      { name: "feeGrowthOutside1X128", type: "uint256" },
+      { name: "tickCumulativeOutside", type: "int56" },
+      { name: "secondsPerLiquidityOutsideX128", type: "uint160" },
+      { name: "secondsOutside", type: "uint32" },
+      { name: "initialized", type: "bool" },
+    ],
   },
 ] as const;
 
@@ -130,6 +184,10 @@ export interface FamePoolStateIndexerClient {
     pool: ClHeadPool;
     blockNumber: bigint;
   }): Promise<FameClHeadSnapshotRead>;
+  getClReplaySnapshot(options: {
+    pool: ClReplayPool;
+    blockNumber: bigint;
+  }): Promise<FameClReplaySnapshotRead>;
 }
 
 export interface FameClHeadSnapshotRead {
@@ -139,9 +197,49 @@ export interface FameClHeadSnapshotRead {
   source: FameClHeadSource;
 }
 
+export interface FameClReplayBitmapWordRead {
+  wordPosition: number;
+  bitmap: bigint;
+}
+
+export interface FameClReplayInitializedTickRead {
+  tick: number;
+  liquidityGross: bigint;
+  liquidityNet: bigint;
+}
+
+export interface FameClReplaySnapshotRead {
+  sqrtPriceX96: bigint;
+  tick: number;
+  liquidity: bigint;
+  fee: bigint;
+  blockHash: Hex;
+  parentHash: Hex;
+  bitmapWords: readonly FameClReplayBitmapWordRead[];
+  initializedTicks: readonly FameClReplayInitializedTickRead[];
+  providerReadCount: number;
+  durationMs: number;
+}
+
 export interface FameClHeadSnapshotFailure {
   poolId: string;
   message: string;
+}
+
+export interface FameClReplaySnapshotFailure {
+  poolId: string;
+  message: string;
+}
+
+export interface FameClReplaySnapshotMetric {
+  poolId: string;
+  bitmapWordCount: number;
+  initializedTickCount: number;
+  bitmapChunkCount: number;
+  tickChunkCount: number;
+  providerReadCount: number;
+  durationMs: number;
+  stateHash: Hex;
 }
 
 export interface FamePoolStateIndexerResult {
@@ -159,6 +257,11 @@ export interface FamePoolStateIndexerResult {
   clHeadWrittenPools: number;
   clHeadFailedPools: number;
   clHeadFailures: FameClHeadSnapshotFailure[];
+  clReplaySnapshots: number;
+  clReplayWrittenPools: number;
+  clReplayFailedPools: number;
+  clReplayFailures: FameClReplaySnapshotFailure[];
+  clReplayMetrics: FameClReplaySnapshotMetric[];
   sourceRegistryId: string;
 }
 
@@ -175,6 +278,17 @@ function clHeadPools(registry: FamePoolStateRegistryFile): ClHeadPool[] {
   return registry.pools.filter(
     (pool): pool is ClHeadPool =>
       pool.stateSurface === "cl-head-snapshot" && pool.tickSpacing !== null,
+  );
+}
+
+function clReplayPools(registry: FamePoolStateRegistryFile): ClReplayPool[] {
+  return registry.pools.filter(
+    (pool): pool is ClReplayPool =>
+      pool.replaySurface === "cl-replay-v1" &&
+      pool.stateSurface === "cl-head-snapshot" &&
+      pool.tickSpacing !== null &&
+      pool.poolAddress !== null &&
+      pool.venue === "aerodrome-slipstream",
   );
 }
 
@@ -228,6 +342,161 @@ function requireStateViewAddress(pool: ClHeadPool): Address {
     );
   }
   return pool.stateViewAddress;
+}
+
+function floorDiv(left: number, right: number): number {
+  return Math.floor(left / right);
+}
+
+function tickBitmapWordPositions(tickSpacing: number): number[] {
+  if (!Number.isSafeInteger(tickSpacing) || tickSpacing <= 0) {
+    throw new Error("CL replay tickSpacing must be a positive safe integer.");
+  }
+  const minCompressedTick = Math.ceil(CL_MIN_TICK / tickSpacing);
+  const maxCompressedTick = Math.floor(CL_MAX_TICK / tickSpacing);
+  const minWord = floorDiv(minCompressedTick, CL_TICK_BITMAP_WORD_SIZE);
+  const maxWord = floorDiv(maxCompressedTick, CL_TICK_BITMAP_WORD_SIZE);
+  return Array.from(
+    { length: maxWord - minWord + 1 },
+    (_, index) => minWord + index,
+  );
+}
+
+function initializedTicksForBitmapWord({
+  wordPosition,
+  bitmap,
+  tickSpacing,
+}: {
+  wordPosition: number;
+  bitmap: bigint;
+  tickSpacing: number;
+}): number[] {
+  const ticks: number[] = [];
+  for (let bit = 0; bit < CL_TICK_BITMAP_WORD_SIZE; bit += 1) {
+    if (((bitmap >> BigInt(bit)) & 1n) === 0n) continue;
+    const compressedTick = wordPosition * CL_TICK_BITMAP_WORD_SIZE + bit;
+    const tick = compressedTick * tickSpacing;
+    if (tick >= CL_MIN_TICK && tick <= CL_MAX_TICK) ticks.push(tick);
+  }
+  return ticks;
+}
+
+async function mapInBatches<Input, Output>(
+  values: readonly Input[],
+  batchSize: number,
+  mapper: (value: Input) => Promise<Output>,
+): Promise<Output[]> {
+  const outputs: Output[] = [];
+  for (let index = 0; index < values.length; index += batchSize) {
+    outputs.push(
+      ...(await Promise.all(values.slice(index, index + batchSize).map(mapper))),
+    );
+  }
+  return outputs;
+}
+
+function clReplaySnapshotId({
+  poolId,
+  observedThroughBlock,
+  blockHash,
+}: {
+  poolId: string;
+  observedThroughBlock: number;
+  blockHash: Hex;
+}): string {
+  return `cl-replay-v1:${poolId}:${observedThroughBlock.toString()}:${blockHash}`;
+}
+
+function clReplayStateHash({
+  snapshot,
+  observedThroughBlock,
+}: {
+  snapshot: FameClReplaySnapshotRead;
+  observedThroughBlock: number;
+}): Hex {
+  return keccak256(
+    encodeAbiParameters(
+      [
+        { name: "sqrtPriceX96", type: "uint160" },
+        { name: "tick", type: "int24" },
+        { name: "liquidity", type: "uint128" },
+        { name: "fee", type: "uint24" },
+        { name: "observedThroughBlock", type: "uint256" },
+        { name: "blockHash", type: "bytes32" },
+        { name: "parentHash", type: "bytes32" },
+        {
+          name: "bitmapWords",
+          type: "tuple[]",
+          components: [
+            { name: "wordPosition", type: "int16" },
+            { name: "bitmap", type: "uint256" },
+          ],
+        },
+        {
+          name: "initializedTicks",
+          type: "tuple[]",
+          components: [
+            { name: "tick", type: "int24" },
+            { name: "liquidityGross", type: "uint128" },
+            { name: "liquidityNet", type: "int128" },
+          ],
+        },
+      ],
+      [
+        snapshot.sqrtPriceX96,
+        snapshot.tick,
+        snapshot.liquidity,
+        safeNumber(snapshot.fee, "CL replay fee"),
+        BigInt(observedThroughBlock),
+        snapshot.blockHash,
+        snapshot.parentHash,
+        snapshot.bitmapWords.map((word) => ({
+          wordPosition: word.wordPosition,
+          bitmap: word.bitmap,
+        })),
+        snapshot.initializedTicks.map((tick) => ({
+          tick: tick.tick,
+          liquidityGross: tick.liquidityGross,
+          liquidityNet: tick.liquidityNet,
+        })),
+      ],
+    ),
+  );
+}
+
+function clReplayRowsFromSnapshot({
+  pool,
+  snapshot,
+  observedThroughBlock,
+  sourceRegistryId,
+  updatedAt,
+}: {
+  pool: ClReplayPool;
+  snapshot: FameClReplaySnapshotRead;
+  observedThroughBlock: number;
+  sourceRegistryId: string;
+  updatedAt: string;
+}): FameClReplayStateRows {
+  return clReplayStateRowsFromSnapshot({
+    pool,
+    sqrtPriceX96: snapshot.sqrtPriceX96,
+    tick: snapshot.tick,
+    liquidity: snapshot.liquidity,
+    fee: snapshot.fee,
+    observedThroughBlock,
+    blockHash: snapshot.blockHash,
+    parentHash: snapshot.parentHash,
+    snapshotId: clReplaySnapshotId({
+      poolId: pool.id,
+      observedThroughBlock,
+      blockHash: snapshot.blockHash,
+    }),
+    stateHash: clReplayStateHash({ snapshot, observedThroughBlock }),
+    sourceRegistryId,
+    updatedAt,
+    bitmapWords: snapshot.bitmapWords,
+    initializedTicks: snapshot.initializedTicks,
+  });
 }
 
 function sortedLogs(
@@ -422,6 +691,115 @@ export function createViemPoolStateIndexerClient(
 
       throw new Error(`${pool.id} has no CL head reader.`);
     },
+    async getClReplaySnapshot({ pool, blockNumber }) {
+      const startedAtMs = Date.now();
+      const poolAddress = pool.poolAddress;
+      const blockBefore = await client.getBlock({ blockNumber });
+      if (blockBefore.hash === null) {
+        throw new Error(`Block ${blockNumber.toString()} has no hash.`);
+      }
+
+      const [[sqrtPriceX96, tick], liquidity, fee] = await Promise.all([
+        client.readContract({
+          address: poolAddress,
+          abi: SlipstreamSlot0Abi,
+          functionName: "slot0",
+          blockNumber,
+        }),
+        client.readContract({
+          address: poolAddress,
+          abi: ConcentratedPoolLiquidityAbi,
+          functionName: "liquidity",
+          blockNumber,
+        }),
+        client.readContract({
+          address: poolAddress,
+          abi: SlipstreamFeeAbi,
+          functionName: "fee",
+          blockNumber,
+        }),
+      ]);
+
+      const wordPositions = tickBitmapWordPositions(pool.tickSpacing);
+      const wordReads = await mapInBatches(
+        wordPositions,
+        CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
+        async (wordPosition) => ({
+          wordPosition,
+          bitmap: await client.readContract({
+            address: poolAddress,
+            abi: SlipstreamTickBitmapAbi,
+            functionName: "tickBitmap",
+            args: [wordPosition],
+            blockNumber,
+          }),
+        }),
+      );
+      const bitmapWords = wordReads.filter((word) => word.bitmap !== 0n);
+      const initializedTickIndexes = bitmapWords.flatMap((word) =>
+        initializedTicksForBitmapWord({
+          wordPosition: word.wordPosition,
+          bitmap: word.bitmap,
+          tickSpacing: pool.tickSpacing,
+        }),
+      );
+      const initializedTicks = await mapInBatches(
+        initializedTickIndexes,
+        CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
+        async (initializedTick) => {
+          const [
+            liquidityGross,
+            liquidityNet,
+            ,
+            ,
+            ,
+            ,
+            ,
+            initialized,
+          ] = await client.readContract({
+            address: poolAddress,
+            abi: SlipstreamTicksAbi,
+            functionName: "ticks",
+            args: [initializedTick],
+            blockNumber,
+          });
+          if (!initialized) {
+            throw new Error(
+              `Tick bitmap marked ${initializedTick.toString()} initialized but ticks() did not.`,
+            );
+          }
+          return {
+            tick: initializedTick,
+            liquidityGross,
+            liquidityNet,
+          };
+        },
+      );
+
+      const blockAfter = await client.getBlock({ blockNumber });
+      if (
+        blockAfter.hash !== blockBefore.hash ||
+        blockAfter.parentHash !== blockBefore.parentHash
+      ) {
+        throw new Error(
+          `Block identity changed while reading ${pool.id} replay snapshot.`,
+        );
+      }
+
+      return {
+        sqrtPriceX96,
+        tick,
+        liquidity,
+        fee: BigInt(fee),
+        blockHash: blockBefore.hash,
+        parentHash: blockBefore.parentHash,
+        bitmapWords,
+        initializedTicks,
+        providerReadCount:
+          2 + 3 + wordPositions.length + initializedTickIndexes.length,
+        durationMs: Date.now() - startedAtMs,
+      };
+    },
   };
 }
 
@@ -443,6 +821,7 @@ export async function indexFamePoolStates({
   const startedAtMs = Date.now();
   const pools = quoteModelPools(registry);
   const clPools = clHeadPools(registry);
+  const replayPools = clReplayPools(registry);
   const sourceRegistryId = sourceRegistryIdFor(registry.source);
   const latestBlock = await client.getBlockNumber();
   const safeBlock = safeHeadBlock(latestBlock, confirmationBlocks);
@@ -660,6 +1039,64 @@ export async function indexFamePoolStates({
     if (result === "written") clHeadWrittenPools += 1;
   }
 
+  const clReplayReads = await Promise.allSettled(
+    replayPools.map(async (pool) => {
+      const snapshot = await client.getClReplaySnapshot({
+        pool,
+        blockNumber: safeBlock,
+      });
+      return {
+        pool,
+        snapshot,
+      };
+    }),
+  );
+  const clReplaySnapshots: {
+    pool: ClReplayPool;
+    snapshot: FameClReplaySnapshotRead;
+  }[] = [];
+  const clReplayFailures: FameClReplaySnapshotFailure[] = [];
+  clReplayReads.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      clReplaySnapshots.push(result.value);
+      return;
+    }
+    const pool = replayPools[index];
+    if (!pool) throw new Error("CL replay read result missing pool.");
+    clReplayFailures.push({
+      poolId: pool.id,
+      message: errorMessage(result.reason),
+    });
+  });
+
+  let clReplayWrittenPools = 0;
+  const clReplayMetrics: FameClReplaySnapshotMetric[] = [];
+  for (const { pool, snapshot } of clReplaySnapshots) {
+    const rows = clReplayRowsFromSnapshot({
+      pool,
+      snapshot,
+      observedThroughBlock,
+      sourceRegistryId,
+      updatedAt,
+    });
+    const result = await putLatestClReplayState({
+      db,
+      tableName,
+      rows,
+    });
+    if (result === "written") clReplayWrittenPools += 1;
+    clReplayMetrics.push({
+      poolId: pool.id,
+      bitmapWordCount: rows.latest.bitmapWordCount,
+      initializedTickCount: rows.latest.initializedTickCount,
+      bitmapChunkCount: rows.latest.bitmapChunkCount,
+      tickChunkCount: rows.latest.tickChunkCount,
+      providerReadCount: snapshot.providerReadCount,
+      durationMs: snapshot.durationMs,
+      stateHash: rows.latest.stateHash,
+    });
+  }
+
   return {
     chainId: client.chain.id,
     durationMs: Date.now() - startedAtMs,
@@ -675,6 +1112,11 @@ export async function indexFamePoolStates({
     clHeadWrittenPools,
     clHeadFailedPools: clHeadFailures.length,
     clHeadFailures,
+    clReplaySnapshots: clReplaySnapshots.length,
+    clReplayWrittenPools,
+    clReplayFailedPools: clReplayFailures.length,
+    clReplayFailures,
+    clReplayMetrics,
     sourceRegistryId,
   };
 }

--- a/src/fame-swap-pool-state/indexer.ts
+++ b/src/fame-swap-pool-state/indexer.ts
@@ -1,9 +1,4 @@
-import {
-  encodeAbiParameters,
-  keccak256,
-  type Address,
-  type Hex,
-} from "viem";
+import { encodeAbiParameters, keccak256, type Address, type Hex } from "viem";
 import {
   Uint256ReserveSyncEvent,
   UniswapV2PairReserveAbi,
@@ -192,6 +187,47 @@ export interface FamePoolStateIndexerClient {
   }): Promise<FameClReplaySnapshotRead>;
 }
 
+export interface SlipstreamReplayReadClient {
+  getBlock(options: {
+    blockNumber: bigint;
+  }): Promise<{ hash: Hex | null; parentHash: Hex }>;
+  getSlot0(options: {
+    poolAddress: Address;
+    blockNumber: bigint;
+  }): Promise<readonly [bigint, number, number, number, number, boolean]>;
+  getLiquidity(options: {
+    poolAddress: Address;
+    blockNumber: bigint;
+  }): Promise<bigint>;
+  getFee(options: {
+    poolAddress: Address;
+    blockNumber: bigint;
+  }): Promise<bigint | number>;
+  getTickBitmap(options: {
+    poolAddress: Address;
+    wordPosition: number;
+    blockNumber: bigint;
+  }): Promise<bigint>;
+  getTick(options: {
+    poolAddress: Address;
+    tick: number;
+    blockNumber: bigint;
+  }): Promise<
+    readonly [
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      bigint,
+      number,
+      boolean,
+    ]
+  >;
+}
+
 export interface FameClHeadSnapshotRead {
   sqrtPriceX96: bigint;
   tick: number;
@@ -265,6 +301,28 @@ export interface FamePoolStateIndexerResult {
   clReplayFailures: FameClReplaySnapshotFailure[];
   clReplayMetrics: FameClReplaySnapshotMetric[];
   sourceRegistryId: string;
+}
+
+export class FameClReplaySnapshotIndexingError extends Error {
+  constructor(failures: readonly FameClReplaySnapshotFailure[]) {
+    super(
+      `CL replay snapshot failed for ${failures
+        .map((failure) => `${failure.poolId}: ${failure.message}`)
+        .join("; ")}`,
+    );
+    this.name = "FameClReplaySnapshotIndexingError";
+  }
+}
+
+export function assertNoClReplaySnapshotFailures(
+  result: Pick<
+    FamePoolStateIndexerResult,
+    "clReplayFailedPools" | "clReplayFailures"
+  >,
+): void {
+  if (result.clReplayFailedPools > 0) {
+    throw new FameClReplaySnapshotIndexingError(result.clReplayFailures);
+  }
 }
 
 function quoteModelPools(
@@ -391,7 +449,9 @@ async function mapInBatches<Input, Output>(
   const outputs: Output[] = [];
   for (let index = 0; index < values.length; index += batchSize) {
     outputs.push(
-      ...(await Promise.all(values.slice(index, index + batchSize).map(mapper))),
+      ...(await Promise.all(
+        values.slice(index, index + batchSize).map(mapper),
+      )),
     );
   }
   return outputs;
@@ -401,12 +461,14 @@ function clReplaySnapshotId({
   poolId,
   observedThroughBlock,
   blockHash,
+  sourceRegistryId,
 }: {
   poolId: string;
   observedThroughBlock: number;
   blockHash: Hex;
+  sourceRegistryId: string;
 }): string {
-  return `cl-replay-v1:${poolId}:${observedThroughBlock.toString()}:${blockHash}`;
+  return `cl-replay-v1:${poolId}:${observedThroughBlock.toString()}:${blockHash}:${sourceRegistryId}`;
 }
 
 function clReplayStateHash({
@@ -492,6 +554,7 @@ function clReplayRowsFromSnapshot({
       poolId: pool.id,
       observedThroughBlock,
       blockHash: snapshot.blockHash,
+      sourceRegistryId,
     }),
     stateHash: clReplayStateHash({ snapshot, observedThroughBlock }),
     sourceRegistryId,
@@ -559,6 +622,106 @@ function errorMessage(error: unknown): string {
   }
   if (typeof error === "string" && error.length > 0) return error;
   return "Unknown error";
+}
+
+export async function getSlipstreamClReplaySnapshot({
+  client,
+  pool,
+  blockNumber,
+}: {
+  client: SlipstreamReplayReadClient;
+  pool: ClReplayPool;
+  blockNumber: bigint;
+}): Promise<FameClReplaySnapshotRead> {
+  const startedAtMs = Date.now();
+  const poolAddress = pool.poolAddress;
+  const blockBefore = await client.getBlock({ blockNumber });
+  if (blockBefore.hash === null) {
+    throw new Error(`Block ${blockNumber.toString()} has no hash.`);
+  }
+
+  const [[sqrtPriceX96, tick], liquidity, fee] = await Promise.all([
+    client.getSlot0({
+      poolAddress,
+      blockNumber,
+    }),
+    client.getLiquidity({
+      poolAddress,
+      blockNumber,
+    }),
+    client.getFee({
+      poolAddress,
+      blockNumber,
+    }),
+  ]);
+
+  const wordPositions = tickBitmapWordPositions(pool.tickSpacing);
+  const wordReads = await mapInBatches(
+    wordPositions,
+    CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
+    async (wordPosition) => ({
+      wordPosition,
+      bitmap: await client.getTickBitmap({
+        poolAddress,
+        wordPosition,
+        blockNumber,
+      }),
+    }),
+  );
+  const bitmapWords = wordReads.filter((word) => word.bitmap !== 0n);
+  const initializedTickIndexes = bitmapWords.flatMap((word) =>
+    initializedTicksForBitmapWord({
+      wordPosition: word.wordPosition,
+      bitmap: word.bitmap,
+      tickSpacing: pool.tickSpacing,
+    }),
+  );
+  const initializedTicks = await mapInBatches(
+    initializedTickIndexes,
+    CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
+    async (initializedTick) => {
+      const [liquidityGross, liquidityNet, , , , , , , , initialized] =
+        await client.getTick({
+          poolAddress,
+          tick: initializedTick,
+          blockNumber,
+        });
+      if (!initialized) {
+        throw new Error(
+          `Tick bitmap marked ${initializedTick.toString()} initialized but ticks() did not.`,
+        );
+      }
+      return {
+        tick: initializedTick,
+        liquidityGross,
+        liquidityNet,
+      };
+    },
+  );
+
+  const blockAfter = await client.getBlock({ blockNumber });
+  if (
+    blockAfter.hash !== blockBefore.hash ||
+    blockAfter.parentHash !== blockBefore.parentHash
+  ) {
+    throw new Error(
+      `Block identity changed while reading ${pool.id} replay snapshot.`,
+    );
+  }
+
+  return {
+    sqrtPriceX96,
+    tick,
+    liquidity,
+    fee: BigInt(fee),
+    blockHash: blockBefore.hash,
+    parentHash: blockBefore.parentHash,
+    bitmapWords,
+    initializedTicks,
+    providerReadCount:
+      2 + 3 + wordPositions.length + initializedTickIndexes.length,
+    durationMs: Date.now() - startedAtMs,
+  };
 }
 
 export function createViemPoolStateIndexerClient(
@@ -694,115 +857,61 @@ export function createViemPoolStateIndexerClient(
       throw new Error(`${pool.id} has no CL head reader.`);
     },
     async getClReplaySnapshot({ pool, blockNumber }) {
-      const startedAtMs = Date.now();
-      const poolAddress = pool.poolAddress;
-      const blockBefore = await client.getBlock({ blockNumber });
-      if (blockBefore.hash === null) {
-        throw new Error(`Block ${blockNumber.toString()} has no hash.`);
-      }
-
-      const [[sqrtPriceX96, tick], liquidity, fee] = await Promise.all([
-        client.readContract({
-          address: poolAddress,
-          abi: SlipstreamSlot0Abi,
-          functionName: "slot0",
-          blockNumber,
-        }),
-        client.readContract({
-          address: poolAddress,
-          abi: ConcentratedPoolLiquidityAbi,
-          functionName: "liquidity",
-          blockNumber,
-        }),
-        client.readContract({
-          address: poolAddress,
-          abi: SlipstreamFeeAbi,
-          functionName: "fee",
-          blockNumber,
-        }),
-      ]);
-
-      const wordPositions = tickBitmapWordPositions(pool.tickSpacing);
-      const wordReads = await mapInBatches(
-        wordPositions,
-        CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
-        async (wordPosition) => ({
-          wordPosition,
-          bitmap: await client.readContract({
-            address: poolAddress,
-            abi: SlipstreamTickBitmapAbi,
-            functionName: "tickBitmap",
-            args: [wordPosition],
-            blockNumber,
-          }),
-        }),
-      );
-      const bitmapWords = wordReads.filter((word) => word.bitmap !== 0n);
-      const initializedTickIndexes = bitmapWords.flatMap((word) =>
-        initializedTicksForBitmapWord({
-          wordPosition: word.wordPosition,
-          bitmap: word.bitmap,
-          tickSpacing: pool.tickSpacing,
-        }),
-      );
-      const initializedTicks = await mapInBatches(
-        initializedTickIndexes,
-        CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
-        async (initializedTick) => {
-          const [
-            liquidityGross,
-            liquidityNet,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            ,
-            initialized,
-          ] = await client.readContract({
-            address: poolAddress,
-            abi: SlipstreamTicksAbi,
-            functionName: "ticks",
-            args: [initializedTick],
-            blockNumber,
-          });
-          if (!initialized) {
-            throw new Error(
-              `Tick bitmap marked ${initializedTick.toString()} initialized but ticks() did not.`,
-            );
-          }
-          return {
-            tick: initializedTick,
-            liquidityGross,
-            liquidityNet,
-          };
+      return getSlipstreamClReplaySnapshot({
+        client: {
+          getBlock(options) {
+            return client.getBlock(options);
+          },
+          getSlot0({ poolAddress, blockNumber: readBlockNumber }) {
+            return client.readContract({
+              address: poolAddress,
+              abi: SlipstreamSlot0Abi,
+              functionName: "slot0",
+              blockNumber: readBlockNumber,
+            });
+          },
+          getLiquidity({ poolAddress, blockNumber: readBlockNumber }) {
+            return client.readContract({
+              address: poolAddress,
+              abi: ConcentratedPoolLiquidityAbi,
+              functionName: "liquidity",
+              blockNumber: readBlockNumber,
+            });
+          },
+          getFee({ poolAddress, blockNumber: readBlockNumber }) {
+            return client.readContract({
+              address: poolAddress,
+              abi: SlipstreamFeeAbi,
+              functionName: "fee",
+              blockNumber: readBlockNumber,
+            });
+          },
+          getTickBitmap({
+            poolAddress,
+            wordPosition,
+            blockNumber: readBlockNumber,
+          }) {
+            return client.readContract({
+              address: poolAddress,
+              abi: SlipstreamTickBitmapAbi,
+              functionName: "tickBitmap",
+              args: [wordPosition],
+              blockNumber: readBlockNumber,
+            });
+          },
+          getTick({ poolAddress, tick, blockNumber: readBlockNumber }) {
+            return client.readContract({
+              address: poolAddress,
+              abi: SlipstreamTicksAbi,
+              functionName: "ticks",
+              args: [tick],
+              blockNumber: readBlockNumber,
+            });
+          },
         },
-      );
-
-      const blockAfter = await client.getBlock({ blockNumber });
-      if (
-        blockAfter.hash !== blockBefore.hash ||
-        blockAfter.parentHash !== blockBefore.parentHash
-      ) {
-        throw new Error(
-          `Block identity changed while reading ${pool.id} replay snapshot.`,
-        );
-      }
-
-      return {
-        sqrtPriceX96,
-        tick,
-        liquidity,
-        fee: BigInt(fee),
-        blockHash: blockBefore.hash,
-        parentHash: blockBefore.parentHash,
-        bitmapWords,
-        initializedTicks,
-        providerReadCount:
-          2 + 3 + wordPositions.length + initializedTickIndexes.length,
-        durationMs: Date.now() - startedAtMs,
-      };
+        pool,
+        blockNumber,
+      });
     },
   };
 }

--- a/src/fame-swap-pool-state/lambdas/indexer.ts
+++ b/src/fame-swap-pool-state/lambdas/indexer.ts
@@ -1,6 +1,10 @@
 import { baseClient } from "@/viem.ts";
-import { FAME_POOL_STATE_CONFIRMATION_BLOCKS, FAME_POOL_STATE_TABLE_NAME } from "../config.ts";
 import {
+  FAME_POOL_STATE_CONFIRMATION_BLOCKS,
+  FAME_POOL_STATE_TABLE_NAME,
+} from "../config.ts";
+import {
+  assertNoClReplaySnapshotFailures,
   createViemPoolStateIndexerClient,
   indexFamePoolStates,
 } from "../indexer.ts";
@@ -12,10 +16,15 @@ export async function handler(): Promise<void> {
     confirmationBlocks: FAME_POOL_STATE_CONFIRMATION_BLOCKS,
   });
 
-  console.log(
-    JSON.stringify({
-      event: "fame-pool-state-indexed",
-      ...result,
-    }),
-  );
+  const payload = {
+    event: "fame-pool-state-indexed",
+    ...result,
+  };
+
+  if (result.clReplayFailedPools > 0) {
+    console.error(JSON.stringify(payload));
+    assertNoClReplaySnapshotFailures(result);
+  }
+
+  console.log(JSON.stringify(payload));
 }

--- a/src/fame-swap-pool-state/registry/base-v1-pools.json
+++ b/src/fame-swap-pool-state/registry/base-v1-pools.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "status": "generated-reviewed-route-candidates",
   "source": {
     "repo": "www",

--- a/src/fame-swap-pool-state/registry/base-v1-pools.json
+++ b/src/fame-swap-pool-state/registry/base-v1-pools.json
@@ -58,6 +58,7 @@
       "stateViewAddress": null,
       "capability": "quote-model",
       "stateSurface": "constant-product-reserves",
+      "replaySurface": null,
       "quoteModel": "constant-product-reserves",
       "unsupportedReason": null
     },
@@ -82,6 +83,7 @@
       "stateViewAddress": null,
       "capability": "tracked-only",
       "stateSurface": null,
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": "native-wrap"
     },
@@ -106,6 +108,7 @@
       "stateViewAddress": null,
       "capability": "quote-model",
       "stateSurface": "constant-product-reserves",
+      "replaySurface": null,
       "quoteModel": "constant-product-reserves",
       "unsupportedReason": null
     },
@@ -130,6 +133,7 @@
       "stateViewAddress": null,
       "capability": "quote-model",
       "stateSurface": "constant-product-reserves",
+      "replaySurface": null,
       "quoteModel": "constant-product-reserves",
       "unsupportedReason": null
     },
@@ -154,6 +158,7 @@
       "stateViewAddress": null,
       "capability": "tracked-only",
       "stateSurface": null,
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": "stable-pool"
     },
@@ -178,6 +183,7 @@
       "stateViewAddress": null,
       "capability": "quote-model",
       "stateSurface": "constant-product-reserves",
+      "replaySurface": null,
       "quoteModel": "constant-product-reserves",
       "unsupportedReason": null
     },
@@ -202,6 +208,7 @@
       "stateViewAddress": null,
       "capability": "quote-model",
       "stateSurface": "constant-product-reserves",
+      "replaySurface": null,
       "quoteModel": "constant-product-reserves",
       "unsupportedReason": null
     },
@@ -226,6 +233,7 @@
       "stateViewAddress": null,
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -250,6 +258,7 @@
       "stateViewAddress": null,
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -274,6 +283,7 @@
       "stateViewAddress": null,
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": "cl-replay-v1",
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -298,6 +308,7 @@
       "stateViewAddress": null,
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -322,6 +333,7 @@
       "stateViewAddress": null,
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -346,6 +358,7 @@
       "stateViewAddress": null,
       "capability": "quote-model",
       "stateSurface": "constant-product-reserves",
+      "replaySurface": null,
       "quoteModel": "constant-product-reserves",
       "unsupportedReason": null
     },
@@ -370,6 +383,7 @@
       "stateViewAddress": null,
       "capability": "quote-model",
       "stateSurface": "constant-product-reserves",
+      "replaySurface": null,
       "quoteModel": "constant-product-reserves",
       "unsupportedReason": null
     },
@@ -394,6 +408,7 @@
       "stateViewAddress": null,
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -418,6 +433,7 @@
       "stateViewAddress": null,
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -442,6 +458,7 @@
       "stateViewAddress": null,
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -466,6 +483,7 @@
       "stateViewAddress": null,
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -490,6 +508,7 @@
       "stateViewAddress": "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -514,6 +533,7 @@
       "stateViewAddress": "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     },
@@ -538,6 +558,7 @@
       "stateViewAddress": "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
       "capability": "market-state",
       "stateSurface": "cl-head-snapshot",
+      "replaySurface": null,
       "quoteModel": null,
       "unsupportedReason": null
     }

--- a/src/fame-swap-pool-state/registry/index.test.ts
+++ b/src/fame-swap-pool-state/registry/index.test.ts
@@ -18,10 +18,10 @@ function registryWithFirstPool(overrides: Record<string, unknown>): unknown {
 describe("FAME swap pool-state registry", () => {
   test("loads the generated www registry with quote-model and tracked-only pools", () => {
     const quoteModelPools = famePoolStateRegistry.pools.filter(
-      (pool) => pool.capability === "quote-model"
+      (pool) => pool.capability === "quote-model",
     );
     const trackedOnlyPools = famePoolStateRegistry.pools.filter(
-      (pool) => pool.capability === "tracked-only"
+      (pool) => pool.capability === "tracked-only",
     );
 
     expect(famePoolStateRegistry.source.repo).toBe("www");
@@ -123,7 +123,23 @@ describe("FAME swap pool-state registry", () => {
     });
 
     expect(() => parseFamePoolStateRegistry(broken)).toThrow(
-      /poolAddress: must be an EVM address/
+      /poolAddress: must be an EVM address/,
+    );
+  });
+
+  test("requires explicit replaySurface fields in schema v3 rows", () => {
+    const [firstPool, ...remainingPools] = famePoolStateRegistry.pools;
+    if (!firstPool) throw new Error("Generated registry has no pools.");
+    const poolWithoutReplaySurface: Record<string, unknown> = { ...firstPool };
+    delete poolWithoutReplaySurface.replaySurface;
+
+    const broken = {
+      ...famePoolStateRegistry,
+      pools: [poolWithoutReplaySurface, ...remainingPools],
+    };
+
+    expect(() => parseFamePoolStateRegistry(broken)).toThrow(
+      /replaySurface: missing required field/,
     );
   });
 
@@ -136,15 +152,17 @@ describe("FAME swap pool-state registry", () => {
     });
 
     expect(() => parseFamePoolStateRegistry(broken)).toThrow(
-      /quote-model pool must have fee metadata/
+      /quote-model pool must have fee metadata/,
     );
   });
 
   test("rejects market-state rows without complete reader metadata", () => {
     const clPool = famePoolStateRegistry.pools.find(
-      (pool) => pool.capability === "market-state" && pool.venue !== "uniswap-v4",
+      (pool) =>
+        pool.capability === "market-state" && pool.venue !== "uniswap-v4",
     );
-    if (!clPool) throw new Error("Generated registry has no address-backed CL pool.");
+    if (!clPool)
+      throw new Error("Generated registry has no address-backed CL pool.");
     const broken = {
       ...famePoolStateRegistry,
       pools: [

--- a/src/fame-swap-pool-state/registry/index.test.ts
+++ b/src/fame-swap-pool-state/registry/index.test.ts
@@ -39,6 +39,7 @@ describe("FAME swap pool-state registry", () => {
       quoteModelPools.every(
         (pool) =>
           pool.stateSurface === "constant-product-reserves" &&
+          pool.replaySurface === null &&
           pool.quoteModel === "constant-product-reserves" &&
           pool.unsupportedReason === null,
       ),
@@ -100,6 +101,22 @@ describe("FAME swap pool-state registry", () => {
     expect(uniswapV4?.stateViewAddress).not.toBeNull();
   });
 
+  test("marks only slipstream-usdc-weth-100 as replay-capable", () => {
+    const replayPools = famePoolStateRegistry.pools.filter(
+      (pool) => pool.replaySurface === "cl-replay-v1",
+    );
+
+    expect(replayPools.map((pool) => pool.id)).toEqual([
+      "slipstream-usdc-weth-100",
+    ]);
+    expect(replayPools[0]?.stateSurface).toBe("cl-head-snapshot");
+    expect(replayPools[0]?.venue).toBe("aerodrome-slipstream");
+    expect(replayPools[0]?.tickSpacing).toBe(100);
+    expect(replayPools[0]?.poolAddress).toBe(
+      "0xb2cc224c1c9fee385f8ad6a55b4d94e92359dc59",
+    );
+  });
+
   test("rejects malformed generated registry rows", () => {
     const broken = registryWithFirstPool({
       poolAddress: "not-an-address",
@@ -140,6 +157,32 @@ describe("FAME swap pool-state registry", () => {
 
     expect(() => parseFamePoolStateRegistry(broken)).toThrow(
       /address-backed market-state pool must have poolAddress/,
+    );
+  });
+
+  test("rejects replay-surface rows outside the one-pool milestone", () => {
+    const replayPool = famePoolStateRegistry.pools.find(
+      (pool) => pool.id === "slipstream-usdc-weth-100",
+    );
+    const otherClPool = famePoolStateRegistry.pools.find(
+      (pool) =>
+        pool.id !== "slipstream-usdc-weth-100" &&
+        pool.capability === "market-state" &&
+        pool.venue === "aerodrome-slipstream",
+    );
+    if (!replayPool || !otherClPool) {
+      throw new Error("Generated registry missing CL replay fixtures.");
+    }
+    const broken = {
+      ...famePoolStateRegistry,
+      pools: [
+        { ...replayPool, replaySurface: null },
+        { ...otherClPool, replaySurface: "cl-replay-v1" },
+      ],
+    };
+
+    expect(() => parseFamePoolStateRegistry(broken)).toThrow(
+      /only slipstream-usdc-weth-100 can have replaySurface/,
     );
   });
 });

--- a/src/fame-swap-pool-state/registry/index.ts
+++ b/src/fame-swap-pool-state/registry/index.ts
@@ -5,6 +5,7 @@ import {
   type FamePoolStateCapability,
   type FamePoolStateFeeDescriptor,
   type FamePoolStateQuoteModel,
+  type FamePoolStateReplaySurface,
   type FamePoolStateRegistryDirection,
   type FamePoolStateRegistryEntry,
   type FamePoolStateRegistryFile,
@@ -52,6 +53,10 @@ const stateSurfaceValues = [
   "constant-product-reserves",
 ] as const satisfies readonly FamePoolStateSurface[];
 
+const replaySurfaceValues = [
+  "cl-replay-v1",
+] as const satisfies readonly FamePoolStateReplaySurface[];
+
 const unsupportedReasonValues = [
   "concentrated-liquidity",
   "missing-fee-metadata",
@@ -80,6 +85,13 @@ function field(
     registryError(`${path}.${key}`, "missing required field");
   }
   return record[key];
+}
+
+function optionalField(
+  record: Record<string, unknown>,
+  key: string,
+): unknown | undefined {
+  return Object.hasOwn(record, key) ? record[key] : undefined;
 }
 
 function parseString(value: unknown, path: string): string {
@@ -268,6 +280,14 @@ function parseEntry(value: unknown, path: string): FamePoolStateRegistryEntry {
       `${path}.stateSurface`,
       stateSurfaceValues,
     ),
+    replaySurface:
+      optionalField(record, "replaySurface") === undefined
+        ? null
+        : parseNullableEnum(
+            optionalField(record, "replaySurface"),
+            `${path}.replaySurface`,
+            replaySurfaceValues,
+          ),
     quoteModel: parseNullableEnum(
       field(record, "quoteModel", path),
       `${path}.quoteModel`,
@@ -292,6 +312,9 @@ function parseEntry(value: unknown, path: string): FamePoolStateRegistryEntry {
     }
     if (entry.unsupportedReason !== null) {
       registryError(path, "quote-model pool cannot have unsupportedReason");
+    }
+    if (entry.replaySurface !== null) {
+      registryError(path, "quote-model pool cannot have replaySurface");
     }
     if (entry.poolAddress === null) {
       registryError(path, "quote-model pool must have a poolAddress");
@@ -328,12 +351,29 @@ function parseEntry(value: unknown, path: string): FamePoolStateRegistryEntry {
     } else if (entry.poolAddress === null) {
       registryError(path, "address-backed market-state pool must have poolAddress");
     }
+    if (entry.replaySurface !== null) {
+      if (entry.id !== "slipstream-usdc-weth-100") {
+        registryError(path, "only slipstream-usdc-weth-100 can have replaySurface");
+      }
+      if (entry.venue !== "aerodrome-slipstream") {
+        registryError(path, "replaySurface pool must be Slipstream");
+      }
+      if (entry.poolAddress === null) {
+        registryError(path, "replaySurface pool must have poolAddress");
+      }
+      if (entry.stateSurface !== "cl-head-snapshot") {
+        registryError(path, "replaySurface pool must keep CL head state surface");
+      }
+    }
   } else {
     if (entry.quoteModel !== null) {
       registryError(path, "tracked-only pool cannot have quoteModel");
     }
     if (entry.stateSurface !== null) {
       registryError(path, "tracked-only pool cannot have stateSurface");
+    }
+    if (entry.replaySurface !== null) {
+      registryError(path, "tracked-only pool cannot have replaySurface");
     }
     if (entry.unsupportedReason === null) {
       registryError(path, "tracked-only pool must have unsupportedReason");
@@ -373,6 +413,22 @@ function assertUniquePools(pools: readonly FamePoolStateRegistryEntry[]): void {
   }
 }
 
+function assertReplaySurfaceScope(
+  pools: readonly FamePoolStateRegistryEntry[],
+): void {
+  const replayPools = pools.filter((pool) => pool.replaySurface !== null);
+  if (
+    replayPools.length !== 1 ||
+    replayPools[0]?.id !== "slipstream-usdc-weth-100" ||
+    replayPools[0].replaySurface !== "cl-replay-v1"
+  ) {
+    registryError(
+      "pools",
+      "expected exactly slipstream-usdc-weth-100 to have cl-replay-v1",
+    );
+  }
+}
+
 export function parseFamePoolStateRegistry(
   value: unknown,
 ): FamePoolStateRegistryFile {
@@ -402,6 +458,7 @@ export function parseFamePoolStateRegistry(
     pools: parseArray(field(record, "pools", "$"), "$.pools", parseEntry),
   };
   assertUniquePools(registry.pools);
+  assertReplaySurfaceScope(registry.pools);
   return registry;
 }
 

--- a/src/fame-swap-pool-state/registry/index.ts
+++ b/src/fame-swap-pool-state/registry/index.ts
@@ -87,13 +87,6 @@ function field(
   return record[key];
 }
 
-function optionalField(
-  record: Record<string, unknown>,
-  key: string,
-): unknown | undefined {
-  return Object.hasOwn(record, key) ? record[key] : undefined;
-}
-
 function parseString(value: unknown, path: string): string {
   if (typeof value !== "string" || value.length === 0) {
     registryError(path, "expected a non-empty string");
@@ -194,10 +187,15 @@ function parseFee(value: unknown, path: string): FamePoolStateFeeDescriptor {
   };
 }
 
-function parseSource(value: unknown, path: string): FamePoolStateRegistrySource {
+function parseSource(
+  value: unknown,
+  path: string,
+): FamePoolStateRegistrySource {
   const record = parseObject(value, path);
   return {
-    repo: parseEnum(field(record, "repo", path), `${path}.repo`, ["www"] as const),
+    repo: parseEnum(field(record, "repo", path), `${path}.repo`, [
+      "www",
+    ] as const),
     schemaVersion: parseInteger(
       field(record, "schemaVersion", path),
       `${path}.schemaVersion`,
@@ -243,14 +241,21 @@ function parseEntry(value: unknown, path: string): FamePoolStateRegistryEntry {
     `${path}.capability`,
     capabilityValues,
   );
-  const chainId = parseInteger(field(record, "chainId", path), `${path}.chainId`);
+  const chainId = parseInteger(
+    field(record, "chainId", path),
+    `${path}.chainId`,
+  );
   if (chainId !== 8453) {
     registryError(`${path}.chainId`, "expected Base mainnet chain id 8453");
   }
   const entry: FamePoolStateRegistryEntry = {
     id: parseString(field(record, "id", path), `${path}.id`),
     chainId,
-    venue: parseEnum(field(record, "venue", path), `${path}.venue`, venueValues),
+    venue: parseEnum(
+      field(record, "venue", path),
+      `${path}.venue`,
+      venueValues,
+    ),
     venueFamily: parseEnum(
       field(record, "venueFamily", path),
       `${path}.venueFamily`,
@@ -280,14 +285,11 @@ function parseEntry(value: unknown, path: string): FamePoolStateRegistryEntry {
       `${path}.stateSurface`,
       stateSurfaceValues,
     ),
-    replaySurface:
-      optionalField(record, "replaySurface") === undefined
-        ? null
-        : parseNullableEnum(
-            optionalField(record, "replaySurface"),
-            `${path}.replaySurface`,
-            replaySurfaceValues,
-          ),
+    replaySurface: parseNullableEnum(
+      field(record, "replaySurface", path),
+      `${path}.replaySurface`,
+      replaySurfaceValues,
+    ),
     quoteModel: parseNullableEnum(
       field(record, "quoteModel", path),
       `${path}.quoteModel`,
@@ -305,7 +307,10 @@ function parseEntry(value: unknown, path: string): FamePoolStateRegistryEntry {
       registryError(path, "quote-model pool must have fee metadata");
     }
     if (entry.quoteModel !== "constant-product-reserves") {
-      registryError(path, "quote-model pool must use constant-product reserves");
+      registryError(
+        path,
+        "quote-model pool must use constant-product reserves",
+      );
     }
     if (entry.stateSurface !== "constant-product-reserves") {
       registryError(path, "quote-model pool must use reserve state surface");
@@ -349,11 +354,17 @@ function parseEntry(value: unknown, path: string): FamePoolStateRegistryEntry {
         );
       }
     } else if (entry.poolAddress === null) {
-      registryError(path, "address-backed market-state pool must have poolAddress");
+      registryError(
+        path,
+        "address-backed market-state pool must have poolAddress",
+      );
     }
     if (entry.replaySurface !== null) {
       if (entry.id !== "slipstream-usdc-weth-100") {
-        registryError(path, "only slipstream-usdc-weth-100 can have replaySurface");
+        registryError(
+          path,
+          "only slipstream-usdc-weth-100 can have replaySurface",
+        );
       }
       if (entry.venue !== "aerodrome-slipstream") {
         registryError(path, "replaySurface pool must be Slipstream");
@@ -362,7 +373,10 @@ function parseEntry(value: unknown, path: string): FamePoolStateRegistryEntry {
         registryError(path, "replaySurface pool must have poolAddress");
       }
       if (entry.stateSurface !== "cl-head-snapshot") {
-        registryError(path, "replaySurface pool must keep CL head state surface");
+        registryError(
+          path,
+          "replaySurface pool must keep CL head state surface",
+        );
       }
     }
   } else {
@@ -424,7 +438,7 @@ function assertReplaySurfaceScope(
   ) {
     registryError(
       "pools",
-      "expected exactly slipstream-usdc-weth-100 to have cl-replay-v1",
+      "expected exactly slipstream-usdc-weth-100 to have cl-replay-v1; only slipstream-usdc-weth-100 can have replaySurface",
     );
   }
 }
@@ -471,8 +485,9 @@ function registryAddressKey(chainId: number, poolAddress: Address): string {
   return `${chainId.toString()}:${poolAddress.toLowerCase()}`;
 }
 
-export const famePoolStateRegistry =
-  parseFamePoolStateRegistry(loadGeneratedRegistry());
+export const famePoolStateRegistry = parseFamePoolStateRegistry(
+  loadGeneratedRegistry(),
+);
 
 const registryEntriesById = new Map(
   famePoolStateRegistry.pools.map((pool) => [pool.id, pool]),
@@ -488,9 +503,7 @@ const registryEntriesByAddress = new Map(
 );
 
 export function getFamePoolStateRegistryEntry(
-  input:
-    | { poolId: string }
-    | { chainId: number; poolAddress: Address },
+  input: { poolId: string } | { chainId: number; poolAddress: Address },
 ): FamePoolStateRegistryEntry | undefined {
   if ("poolId" in input) {
     return registryEntriesById.get(input.poolId);

--- a/src/fame-swap-pool-state/types.ts
+++ b/src/fame-swap-pool-state/types.ts
@@ -27,6 +27,7 @@ export type FamePoolStateCapability =
   | "quote-model"
   | "tracked-only";
 export type FamePoolStateQuoteModel = "constant-product-reserves";
+export type FamePoolStateReplaySurface = "cl-replay-v1";
 export type FamePoolStateSurface =
   | "cl-head-snapshot"
   | "constant-product-reserves";
@@ -80,6 +81,7 @@ export interface FamePoolStateRegistryEntry {
   stateViewAddress: Address | null;
   capability: FamePoolStateCapability;
   stateSurface: FamePoolStateSurface | null;
+  replaySurface: FamePoolStateReplaySurface | null;
   quoteModel: FamePoolStateQuoteModel | null;
   unsupportedReason: FamePoolStateUnsupportedReason | null;
 }

--- a/src/fame-swap-pool-state/types.ts
+++ b/src/fame-swap-pool-state/types.ts
@@ -1,6 +1,6 @@
 import type { Address, Hex } from "viem";
 
-export const FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION = 2;
+export const FAME_POOL_STATE_REGISTRY_SCHEMA_VERSION = 3;
 
 export type FamePoolStateVenue =
   | "aerodrome-slipstream"


### PR DESCRIPTION
## Summary

This makes `slipstream-usdc-weth-100` the first FAME concentrated-liquidity pool that can be fully indexed as replayable state. The helper now publishes a complete, same-safe-block `cl-replay-v1` capsule for that one pool while keeping quote authority in `www` and preserving live fallback as the production behavior.

## What Changed

| Area | Outcome |
| --- | --- |
| Registry contract | Marks only `slipstream-usdc-weth-100` as `cl-replay-v1` capable and rejects replay metadata anywhere else. |
| DynamoDB state | Adds latest-pointer plus chunked bitmap/tick rows, with block identity and state hash checks before a capsule can be returned. |
| Indexer | Reads slot0, active liquidity, dynamic fee, full tick bitmap words, initialized tick liquidity, and block identity at one safe block. |
| API | Serves replay state only through explicit `stateSurfaces: ["cl-replay-v1"]` opt-in; incomplete or mismatched capsules stay unavailable. |
| Docs | Updates the pool-state handoff and rollout notes with the dev smoke path, parity harness expectations, and future event-driven/hybrid follow-ups. |

The branch also includes the planning/ideation docs that led to this one-pool snapshot-first approach and a small `.gitignore` hygiene commit for local worktree folders.

## Deploy Smoke

Please add or keep the `DEPLOY_POOL_STATE_DEV` label on this PR to deploy the pool-state-only dev stack. That path deploys `BotPoolStateDev` with the Base RPC and dev service token only, then emits the `/fame/pool-state` endpoint we can wire into `www` for route-lab and parity checks.

## Verification

- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn test src/fame-swap-pool-state/registry/index.test.ts src/fame-swap-pool-state/dynamodb/pool-state.test.ts src/fame-swap-pool-state/indexer.test.ts src/fame-swap-pool-state/api.test.ts`
- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn types`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
