### PR TITLE
fix(fame): harden CloudWatch retention and pool-state logs

### DIFF
--- a/deploy/lib/alchemy-webhook.ts
+++ b/deploy/lib/alchemy-webhook.ts
@@ -7,6 +7,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
+import { createLambdaLogGroup } from "./lambda-log-groups.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export interface Props {
@@ -58,6 +59,11 @@ export class AlchemyWebhooks extends Construct {
         compile(path.join(__dirname, "../../src/webhook/swap/index.ts")),
       ),
       handler: "index.handler",
+      logGroup: createLambdaLogGroup(
+        this,
+        "SwapSchwingLogGroup",
+        "mixedEthereumBase",
+      ),
       timeout: cdk.Duration.seconds(5),
       memorySize: 256,
       environment: {

--- a/deploy/lib/events-lambdas.ts
+++ b/deploy/lib/events-lambdas.ts
@@ -13,6 +13,7 @@ import * as eventTargets from "aws-cdk-lib/aws-events-targets";
 import * as events from "aws-cdk-lib/aws-events";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
+import { createLambdaLogGroup } from "./lambda-log-groups.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export interface Props {
@@ -122,6 +123,11 @@ export class EventLambdas extends Construct {
       architecture: lambda.Architecture.ARM_64,
       code: lambda.Code.fromAsset(interactionHandlerCodeDir),
       handler: "index.handler",
+      logGroup: createLambdaLogGroup(
+        this,
+        "InteractionHandlerLogGroup",
+        "appAudit",
+      ),
       timeout: cdk.Duration.seconds(5),
       memorySize: 256,
       environment: {
@@ -146,6 +152,11 @@ export class EventLambdas extends Construct {
       runtime: lambda.Runtime.NODEJS_24_X,
       code: lambda.Code.fromAsset(deferredMessageCodeDir),
       handler: "index.handler",
+      logGroup: createLambdaLogGroup(
+        this,
+        "DeferredMessageLogGroup",
+        "appAudit",
+      ),
       timeout: cdk.Duration.seconds(30),
       memorySize: 256,
       environment: {
@@ -168,6 +179,11 @@ export class EventLambdas extends Construct {
       runtime: lambda.Runtime.NODEJS_24_X,
       code: lambda.Code.fromAsset(fameEventCodeDir),
       handler: "index.handler",
+      logGroup: createLambdaLogGroup(
+        this,
+        "FameEventLogGroup",
+        "mixedEthereumBase",
+      ),
       timeout: cdk.Duration.seconds(60),
       memorySize: 512,
       environment: {
@@ -199,6 +215,7 @@ export class EventLambdas extends Construct {
       runtime: lambda.Runtime.NODEJS_24_X,
       code: lambda.Code.fromAsset(wrapEventCodeDir),
       handler: "index.handler",
+      logGroup: createLambdaLogGroup(this, "WrapEventLogGroup", "ethereum"),
       timeout: cdk.Duration.seconds(60),
       memorySize: 512,
       environment: {

--- a/deploy/lib/fame-pool-state.ts
+++ b/deploy/lib/fame-pool-state.ts
@@ -11,6 +11,7 @@ import { buildSync, type BuildOptions } from "esbuild";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { Construct } from "constructs";
+import { createLambdaLogGroup } from "./lambda-log-groups.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -128,6 +129,11 @@ export class FamePoolState extends Construct {
       architecture: lambda.Architecture.ARM_64,
       code: lambda.Code.fromAsset(indexerCodeDir),
       handler: "index.handler",
+      logGroup: createLambdaLogGroup(
+        this,
+        "FamePoolStateIndexerLogGroup",
+        "replayTick",
+      ),
       timeout: cdk.Duration.seconds(60),
       memorySize: 512,
       reservedConcurrentExecutions: 1,
@@ -229,6 +235,11 @@ export class FamePoolState extends Construct {
         architecture: lambda.Architecture.ARM_64,
         code: lambda.Code.fromAsset(apiAuthorizerCodeDir),
         handler: "index.handler",
+        logGroup: createLambdaLogGroup(
+          this,
+          "FamePoolStateApiAuthorizerLogGroup",
+          "replayTick",
+        ),
         timeout: cdk.Duration.seconds(5),
         memorySize: 128,
         environment: {
@@ -243,6 +254,11 @@ export class FamePoolState extends Construct {
       architecture: lambda.Architecture.ARM_64,
       code: lambda.Code.fromAsset(apiCodeDir),
       handler: "index.handler",
+      logGroup: createLambdaLogGroup(
+        this,
+        "FamePoolStateApiLogGroup",
+        "replayTick",
+      ),
       timeout: cdk.Duration.seconds(5),
       memorySize: 256,
       reservedConcurrentExecutions: props.apiReservedConcurrency ?? 5,

--- a/deploy/lib/image-lambdas.ts
+++ b/deploy/lib/image-lambdas.ts
@@ -4,14 +4,11 @@ import { buildSync, type BuildOptions } from "esbuild";
 import { Construct } from "constructs";
 import * as ecrAssets from "aws-cdk-lib/aws-ecr-assets";
 import * as s3 from "aws-cdk-lib/aws-s3";
-import * as apigw2 from "aws-cdk-lib/aws-apigatewayv2";
-import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as route53 from "aws-cdk-lib/aws-route53";
-import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
 import * as fs from "fs";
+import { createLambdaLogGroup } from "./lambda-log-groups.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export interface Props {
@@ -60,9 +57,6 @@ export class ImageLambdas extends Construct {
 
     const domains = domain instanceof Array ? domain : [domain];
     const domainName = domains.join(".");
-    const hostedZone = route53.HostedZone.fromLookup(this, "HostedZone", {
-      domainName: domain.length === 2 ? domains[1] : domains[0],
-    });
 
     const fameThumbCodeDir = compile(
       path.join(__dirname, "../../src/lambda/fame/thumb.ts"),
@@ -75,6 +69,11 @@ export class ImageLambdas extends Construct {
       code: lambda.DockerImageCode.fromImageAsset(fameThumbCodeDir, {
         platform: ecrAssets.Platform.LINUX_AMD64,
       }),
+      logGroup: createLambdaLogGroup(
+        this,
+        "FameThumbLogGroup",
+        "baseOperational",
+      ),
       timeout: cdk.Duration.seconds(5),
       memorySize: 512,
       environment: {
@@ -98,6 +97,7 @@ export class ImageLambdas extends Construct {
       code: lambda.DockerImageCode.fromImageAsset(fameMosaicCodeDir, {
         platform: ecrAssets.Platform.LINUX_AMD64,
       }),
+      logGroup: createLambdaLogGroup(this, "MosaicLogGroup", "baseOperational"),
       timeout: cdk.Duration.seconds(15),
       memorySize: 1024,
       environment: {
@@ -121,6 +121,7 @@ export class ImageLambdas extends Construct {
       code: lambda.DockerImageCode.fromImageAsset(flsThumbCodeDir, {
         platform: ecrAssets.Platform.LINUX_AMD64,
       }),
+      logGroup: createLambdaLogGroup(this, "FlsThumbLogGroup", "ethereum"),
       timeout: cdk.Duration.seconds(5),
       memorySize: 512,
       environment: {
@@ -144,6 +145,7 @@ export class ImageLambdas extends Construct {
       code: lambda.DockerImageCode.fromImageAsset(flsMosaicCodeDir, {
         platform: ecrAssets.Platform.LINUX_AMD64,
       }),
+      logGroup: createLambdaLogGroup(this, "FlsMosaicLogGroup", "ethereum"),
       timeout: cdk.Duration.seconds(15),
       memorySize: 1024,
       environment: {

--- a/deploy/lib/lambda-log-groups.ts
+++ b/deploy/lib/lambda-log-groups.ts
@@ -1,0 +1,38 @@
+import * as cdk from "aws-cdk-lib";
+import * as logs from "aws-cdk-lib/aws-logs";
+import { Construct } from "constructs";
+
+export type LambdaLogRetentionClass =
+  | "appAudit"
+  | "baseOperational"
+  | "ethereum"
+  | "mixedEthereumBase"
+  | "replayTick";
+
+const retentionDaysByClass: Record<
+  LambdaLogRetentionClass,
+  logs.RetentionDays
+> = {
+  appAudit: logs.RetentionDays.ONE_MONTH,
+  baseOperational: logs.RetentionDays.ONE_WEEK,
+  ethereum: logs.RetentionDays.ONE_MONTH,
+  mixedEthereumBase: logs.RetentionDays.ONE_MONTH,
+  replayTick: logs.RetentionDays.ONE_WEEK,
+};
+
+export function retentionDaysForClass(
+  retentionClass: LambdaLogRetentionClass,
+): logs.RetentionDays {
+  return retentionDaysByClass[retentionClass];
+}
+
+export function createLambdaLogGroup(
+  scope: Construct,
+  id: string,
+  retentionClass: LambdaLogRetentionClass,
+): logs.LogGroup {
+  return new logs.LogGroup(scope, id, {
+    retention: retentionDaysForClass(retentionClass),
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  });
+}

--- a/deploy/test/fame-pool-state.test.ts
+++ b/deploy/test/fame-pool-state.test.ts
@@ -72,6 +72,10 @@ describe("FamePoolState infrastructure", () => {
       },
     });
     template.resourceCountIs("AWS::Lambda::Function", 3);
+    template.resourceCountIs("AWS::Logs::LogGroup", 3);
+    template.hasResourceProperties("AWS::Logs::LogGroup", {
+      RetentionInDays: 7,
+    });
     template.hasResourceProperties("AWS::Events::Rule", {
       ScheduleExpression: "rate(1 minute)",
       State: "ENABLED",
@@ -287,6 +291,7 @@ describe("FamePoolState infrastructure", () => {
 
       template.resourceCountIs("AWS::DynamoDB::Table", 1);
       template.resourceCountIs("AWS::Lambda::Function", 3);
+      template.resourceCountIs("AWS::Logs::LogGroup", 3);
       template.resourceCountIs("AWS::ApiGatewayV2::Api", 1);
       template.hasResourceProperties("AWS::ApiGatewayV2::Route", {
         RouteKey: "POST /fame/pool-state",

--- a/deploy/test/log-retention.test.ts
+++ b/deploy/test/log-retention.test.ts
@@ -1,0 +1,153 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { readdirSync, readFileSync } from "fs";
+import { EventLambdas } from "../lib/events-lambdas.js";
+import { FamePoolState } from "../lib/fame-pool-state.js";
+import { ImageLambdas } from "../lib/image-lambdas.js";
+import { createLambdaLogGroup } from "../lib/lambda-log-groups.js";
+
+interface CfnResource {
+  readonly DeletionPolicy?: string;
+  readonly Properties?: Record<string, unknown>;
+  readonly UpdateReplacePolicy?: string;
+}
+
+function resources(template: Template, type: string): CfnResource[] {
+  return Object.values(template.findResources(type)) as CfnResource[];
+}
+
+function logGroups(template: Template): CfnResource[] {
+  return resources(template, "AWS::Logs::LogGroup");
+}
+
+function lambdaFunctions(template: Template): CfnResource[] {
+  return resources(template, "AWS::Lambda::Function");
+}
+
+function assertManagedLogGroups(
+  template: Template,
+  expectedRetentionDays: readonly number[],
+): void {
+  const groups = logGroups(template);
+  expect(groups).toHaveLength(expectedRetentionDays.length);
+  expect(
+    groups.map((group) => group.Properties?.RetentionInDays).sort(),
+  ).toEqual([...expectedRetentionDays].sort());
+
+  for (const group of groups) {
+    expect(group.DeletionPolicy).toBe("Delete");
+    expect(group.UpdateReplacePolicy).toBe("Delete");
+  }
+}
+
+function assertEveryLambdaUsesManagedLogGroup(template: Template): void {
+  for (const resource of lambdaFunctions(template)) {
+    expect(resource.Properties).toEqual(
+      expect.objectContaining({
+        LoggingConfig: expect.objectContaining({
+          LogGroup: expect.anything(),
+        }),
+      }),
+    );
+  }
+}
+
+function activeLambdaConstructorLines(source: string): number[] {
+  return source.split("\n").flatMap((line, index) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("//")) return [];
+    return line.includes("new lambda.Function(") ||
+      line.includes("new lambda.DockerImageFunction(")
+      ? [index]
+      : [];
+  });
+}
+
+describe("Lambda CloudWatch log retention", () => {
+  test("helper creates managed log groups with explicit retention and deletion behavior", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack");
+
+    createLambdaLogGroup(stack, "ReplayTickLogGroup", "replayTick");
+    createLambdaLogGroup(stack, "AppAuditLogGroup", "appAudit");
+
+    assertManagedLogGroups(Template.fromStack(stack), [7, 30]);
+  });
+
+  test("FAME pool-state Lambdas use replay-tick seven-day log groups", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack");
+
+    new FamePoolState(stack, "FamePoolState", {
+      baseRpcsJson: JSON.stringify(["https://base.example"]),
+      serviceToken: "unit-token",
+    });
+
+    const template = Template.fromStack(stack);
+    expect(lambdaFunctions(template)).toHaveLength(3);
+    assertManagedLogGroups(template, [7, 7, 7]);
+    assertEveryLambdaUsesManagedLogGroup(template);
+  });
+
+  test("image Lambdas use Base seven-day and Ethereum thirty-day log groups", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack");
+
+    new ImageLambdas(stack, "ImageLambdas", {
+      baseRpcsJson: JSON.stringify(["https://base.example"]),
+      mainnetRpcsJson: JSON.stringify(["https://mainnet.example"]),
+      domain: ["images", "example.com"],
+      corsAllowedOriginsJson: JSON.stringify(["https://example.com"]),
+    });
+
+    const template = Template.fromStack(stack);
+    expect(lambdaFunctions(template)).toHaveLength(4);
+    assertManagedLogGroups(template, [7, 7, 30, 30]);
+    assertEveryLambdaUsesManagedLogGroup(template);
+  });
+
+  test("event Lambdas use app-audit, mixed-chain, and Ethereum thirty-day log groups", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "TestStack");
+
+    new EventLambdas(stack, "EventLambdas", {
+      baseRpcsJson: JSON.stringify(["https://base.example"]),
+      sepoliaRpcsJson: JSON.stringify(["https://sepolia.example"]),
+      mainnetRpcsJson: JSON.stringify(["https://mainnet.example"]),
+      domain: ["events", "example.com"],
+      discordChannelId: "discord-channel",
+      discordAppId: "discord-app",
+      discordBotToken: "discord-token",
+      discordPublicKey: "discord-public-key",
+      enableSchedules: false,
+    });
+
+    const template = Template.fromStack(stack);
+    expect(lambdaFunctions(template)).toHaveLength(4);
+    assertManagedLogGroups(template, [30, 30, 30, 30]);
+    assertEveryLambdaUsesManagedLogGroup(template);
+  });
+
+  test("inactive Alchemy webhook construct keeps an explicit mixed-chain retention decision", () => {
+    const source = readFileSync("lib/alchemy-webhook.ts", "utf8");
+
+    expect(source).toContain("SwapSchwingLogGroup");
+    expect(source).toContain("mixedEthereumBase");
+  });
+
+  test("active Lambda constructor blocks in deploy/lib declare an explicit log group", () => {
+    const files = readdirSync("lib")
+      .filter((file) => file.endsWith(".ts"))
+      .filter((file) => file !== "lambda-log-groups.ts");
+
+    for (const file of files) {
+      const lines = readFileSync(`lib/${file}`, "utf8").split("\n");
+      for (const lineIndex of activeLambdaConstructorLines(lines.join("\n"))) {
+        const constructorBlock = lines
+          .slice(lineIndex, lineIndex + 40)
+          .join("\n");
+        expect(constructorBlock).toContain("logGroup:");
+      }
+    }
+  });
+});

--- a/docs/brainstorms/2026-05-23-cloudwatch-log-retention-hardening-requirements.md
+++ b/docs/brainstorms/2026-05-23-cloudwatch-log-retention-hardening-requirements.md
@@ -1,0 +1,147 @@
+---
+date: 2026-05-23
+topic: cloudwatch-log-retention-hardening
+---
+
+# CloudWatch Log Retention Hardening
+
+## Summary
+
+Add explicit, managed CloudWatch log groups for the active Lambda surfaces in `society-bots`. Every Lambda log group must have a deliberate retention class, with 30-day retention for Ethereum, mixed-chain, and user-facing app audit logs, and 7-day retention for replay-tick and Base operational/eventing logs.
+
+---
+
+## Problem Frame
+
+The FAME CL replay work made CloudWatch cost and signal quality more visible. Replay indexing can produce bulky diagnostic state, and the current pool-state API can become noisy once `www` leans on it more heavily. At the same time, the repo has several active Lambda surfaces outside pool-state, so fixing only one construct would leave the account with inconsistent retention behavior.
+
+On `origin/main`, the active Lambda constructs in `deploy/lib/fame-pool-state.ts`, `deploy/lib/image-lambdas.ts`, and `deploy/lib/events-lambdas.ts` do not yet assign explicit, managed CloudWatch log groups. The cleanup pass needs to make retention intentional across the repo without changing quote authority, route ranking, event maintenance, or broader logging architecture.
+
+---
+
+## Actors
+
+- A1. Infrastructure implementer: Adds retention classes, managed log groups, and assertions without disturbing unrelated Lambda behavior.
+- A2. Production operator: Inspects logs during deploy, smoke, and incident review and needs predictable retention windows.
+- A3. Pool-state/replay reviewer: Needs compact replay logs that prove freshness and failures without dumping raw tick payloads.
+- A4. Future maintainer: Adds or re-enables Lambda constructs and should not accidentally create infinite-retention logs.
+
+---
+
+## Key Flows
+
+- F1. Lambda log retention is synthesized
+  - **Trigger:** CDK synth runs for the main or pool-state dev stack.
+  - **Actors:** A1, A4
+  - **Steps:** Each active Lambda is assigned one retention class, receives a managed log group, and is covered by CDK assertions for retention and attachment.
+  - **Outcome:** A synthesized stack cannot quietly leave an active Lambda with the default unmanaged log group.
+  - **Covered by:** R1, R2, R3, R4, R5
+
+- F2. Runtime logs stay useful without ballooning
+  - **Trigger:** The pool-state indexer or helper API handles normal traffic or replay failures.
+  - **Actors:** A2, A3
+  - **Steps:** Success logs emit compact structured summaries, replay and stale states remain visible, and failures carry enough typed context for diagnosis without secrets or raw replay payloads.
+  - **Outcome:** Operators can diagnose replay/indexer health while routine traffic produces less INFO noise.
+  - **Covered by:** R7, R8, R9, R10
+
+- F3. Future Lambda surfaces are reviewed
+  - **Trigger:** A contributor adds or re-enables a Lambda construct such as the Alchemy webhook.
+  - **Actors:** A1, A4
+  - **Steps:** The contributor must pick a retention class, attach a managed log group, and update tests if the active Lambda inventory changes.
+  - **Outcome:** New CloudWatch log groups inherit the repo policy instead of becoming one-off defaults.
+  - **Covered by:** R4, R5, R6, R11
+
+---
+
+## Requirements
+
+**Retention policy**
+
+- R1. Every active Lambda created by this CDK app must have a managed CloudWatch `LogGroup` attached through infrastructure code, not only an implicit Lambda-created default log group.
+- R2. Managed log groups must carry explicit retention and explicit stack-deletion behavior so PR/dev cleanup and production behavior are intentional.
+- R3. The retention class map must be:
+  - Ethereum-only logs: 30 days.
+  - Mixed Ethereum/Base logs: 30 days, because retention is per log group.
+  - Discord/app-only user-facing logs: 30 days.
+  - Replay-tick logs: 7 days.
+  - Base eventing and Base-only operational logs: 7 days.
+- R4. The first implementation must classify the active Lambdas in `deploy/lib/image-lambdas.ts`, `deploy/lib/events-lambdas.ts`, and `deploy/lib/fame-pool-state.ts`; no active Lambda may remain unclassified.
+- R5. CDK tests must assert that active Lambdas have managed log groups and expected retention. The assertions must fail when a new active Lambda is added without an explicit retention decision.
+- R6. Currently inactive Lambda constructs, including `deploy/lib/alchemy-webhook.ts`, do not need deployed log groups in this pass, but re-enabling them must require an explicit retention class.
+
+**Pool-state log signal**
+
+- R7. Pool-state indexer and API logs must keep stable event names for existing operational signals, including `fame-pool-state-indexed` and `fame-pool-state-api-batch`.
+- R8. Pool-state success logs must be compact by default. They may include counts, block identity, state hashes, status counts, durations, and failure summaries, but must not include service tokens, full RPC URLs, raw tick arrays, raw request bodies, or raw replay payloads.
+- R9. Pool-state replay failures, stale replay requests, incomplete replay state, and unsupported replay surfaces must remain visible at INFO or error level according to operator value; ordinary all-fresh success traffic should not become a high-volume INFO stream.
+- R10. Structured application logs that are meant for CloudWatch filtering must include a clear level and event name.
+
+**Documentation and operation**
+
+- R11. The operational docs must state the retention classes, active Lambda classification, and how to verify the deployed log groups after a dev or PR deploy.
+- R12. This pass must preserve the existing passive-alarm posture. Adding metric filters or paging destinations is not required unless the implementation makes a narrow, low-risk metric filter nearly free.
+- R13. The work must not change `www` quote behavior, introduce a `society-bots` quote endpoint, alter route ranking, or change replay tick maintenance.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R5.** Given CDK synth runs for the main stack, when the template is inspected, every active Lambda has an attached managed log group with explicit retention and deletion behavior.
+- AE2. **Covers R3, R4.** Given `FlsThumb`, `FlsMosaic`, `WrapEvent`, or a mixed Ethereum/Base event Lambda is synthesized, when retention is inspected, the associated log group retains logs for 30 days.
+- AE3. **Covers R3, R4.** Given the pool-state indexer, pool-state API, or pool-state authorizer is synthesized, when retention is inspected, the associated log group retains logs for 7 days.
+- AE4. **Covers R3, R4.** Given Discord interaction or deferred-message Lambdas are synthesized, when retention is inspected, the associated log groups retain logs for 30 days.
+- AE5. **Covers R3, R4.** Given Base-only image or eventing Lambdas are synthesized, when retention is inspected, the associated log groups retain logs for 7 days unless deliberately reclassified.
+- AE6. **Covers R5, R6.** Given a new active Lambda is added or an inactive webhook construct is re-enabled without retention classification, when tests run, the infrastructure assertions fail.
+- AE7. **Covers R7, R8, R9, R10.** Given a normal pool-state API batch has only fresh, non-replay data, when it logs success, the log is compact or gated; given replay state is stale, incomplete, or failed, the log keeps an operator-visible event with no raw tick payload.
+- AE8. **Covers R11, R12, R13.** Given the cleanup PR is reviewed, when a reviewer checks docs and tests, they can verify retention without seeing unrelated quote, route, or paging behavior changes.
+
+---
+
+## Success Criteria
+
+- Every active Lambda log group produced by this repo has a deliberate retention policy after deploy.
+- CDK assertions protect against future unclassified Lambda log groups.
+- Replay-tick and Base operational logs are bounded to 7 days, while Ethereum, mixed-chain, and user-facing app audit logs retain 30 days.
+- Pool-state logging remains useful for replay/freshness diagnosis without raw tick payloads or repetitive low-value INFO traffic.
+- A downstream planner can build the cleanup without re-deciding retention classes, `LogGroup` vs `logRetention`, or the quote-surface boundary.
+
+---
+
+## Scope Boundaries
+
+- Do not split mixed-chain Lambdas only to get per-chain retention.
+- Do not add a backend quote endpoint, alter `www` quote behavior, or change route ranking.
+- Do not change replay tick maintenance strategy or CL quote math.
+- Do not migrate the entire repo to a new logging framework in this pass.
+- Do not add paging destinations or broad alerting policy changes.
+- Do not require metric filters, dashboards, or Logs Insights query packs for the first implementation.
+
+---
+
+## Key Decisions
+
+- Managed log groups: Use explicit CDK-owned log groups instead of Lambda `logRetention`, because log group ownership, cleanup, and future metric-filter attachment are clearer.
+- Longest retention for mixed-chain logs: If Ethereum and Base logs share one Lambda log group, the log group gets 30-day retention.
+- App audit class: Discord/app-only user-facing logs get 30-day retention because they may explain user-visible bot behavior later.
+- Short replay and Base operational retention: Replay-tick, Base eventing, and Base-only operational/image logs get 7-day retention to cap high-volume operational noise.
+- Narrow log-noise cleanup: Improve pool-state/replay log compactness now, but defer any broad logging framework rewrite.
+
+---
+
+## Dependencies / Assumptions
+
+- The active Lambda inventory for this pass is the set created by `deploy/lib/image-lambdas.ts`, `deploy/lib/events-lambdas.ts`, and `deploy/lib/fame-pool-state.ts` on `origin/main`.
+- The inactive Alchemy webhook construct is not deployed today; if it is re-enabled, it should be treated as mixed-chain unless the implementation separates chain-specific logging.
+- Base-only image Lambdas are treated as Base operational logs and receive 7-day retention unless a future product decision reclassifies them as app audit logs.
+- Existing pool-state event names are useful enough to preserve for current docs, smoke checks, and operator searches.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1, R2, R5][Technical] Decide the exact helper shape for creating managed log groups without duplicating boilerplate across construct files.
+- [Affects R2][Technical] Decide the deletion policy for production-managed log groups when a stack is destroyed.
+- [Affects R7, R8, R9, R10][Technical] Decide whether pool-state log compactness should be implemented with a tiny local logger helper, direct structured logging cleanup, or both.
+- [Affects R11][Technical] Decide the exact docs location for the retention-class table and deployment verification checklist.

--- a/docs/fame-pool-state-index.md
+++ b/docs/fame-pool-state-index.md
@@ -17,6 +17,7 @@
 - The replay snapshot lane reads slot0, current liquidity, dynamic pool fee, the full initialized tick bitmap word range, and initialized tick liquidity records at one safe block. It writes bitmap/tick chunks first, then publishes the latest replay pointer so the API never returns a partial snapshot as fresh replay state.
 - The API serves bounded batch reads to server-side `www` callers. API Gateway uses a Lambda authorizer for the same service token before invoking the API Lambda, and the API Lambda keeps its own token check as defense in depth. The token must be supplied through `Authorization: Bearer <token>`.
 - The indexer has SQS-backed async failure destinations plus passive CloudWatch alarms for Lambda errors, Lambda throttles, missed invocations, and non-empty failure queue depth. These alarms have no notification action by default; they are an inspectable health surface for a free community service.
+- The CloudWatch log groups for active Lambdas are CDK-owned with explicit retention and destroy-on-stack-deletion behavior. This hardening does not change `www` quote authority, helper response contracts, route ranking, fallback behavior, or replay tick maintenance.
 
 ## Freshness
 
@@ -41,9 +42,11 @@ Freshness is based on `observedThroughBlock`, not `lastReserveChangeBlock`.
 
 ## Logs
 
-Indexer logs use `event: "fame-pool-state-indexed"` with chain id, block range, event counts, seeded pool count, reconciled pool count, observed pool count, replay snapshot success/failure counts, replay sizing metrics, duration, and registry id.
+Pool-state Lambda logs use compact JSON envelopes with `level`, `event`, `timestamp`, and event-specific metadata. Do not log service tokens, authorization headers, full RPC URLs, raw request bodies, raw tick arrays, or raw replay payloads.
 
-API logs use `event: "fame-pool-state-api-batch"` with registry id, current block, effective freshness, batch size, and status counts.
+Indexer logs use `event: "fame-pool-state-indexed"` with chain id, block range, event counts, seeded pool count, reconciled pool count, observed pool count, replay snapshot success/failure counts, replay sizing metrics, duration, and registry id. Replay snapshot failures use `level: "error"` and preserve fail-fast Lambda behavior.
+
+API success logs use `event: "fame-pool-state-api-batch"` with registry id, current block, effective freshness, batch size, status counts, and compact replay counts when `cl-replay-v1` state is returned. Ordinary all-fresh non-replay batches are not logged at INFO. Replay responses, stale rows, unknown rows, unsupported rows, malformed requests, and dependency failures remain operator-visible.
 
 API transport failures are classified separately from per-pool fallback statuses:
 
@@ -52,6 +55,20 @@ API transport failures are classified separately from per-pool fallback statuses
 - `5xx`: internal or dependency failure, including incomplete DynamoDB batch reads.
 
 `fresh`, `stale`, `unknown`, and `unsupported` stay inside successful batch responses. `www` should treat non-successful transport responses as non-authoritative helper output and fall back to live reads.
+
+## CloudWatch Retention
+
+The deploy app creates managed `AWS::Logs::LogGroup` resources and passes them to Lambda through `LoggingConfig`. Short-lived PR/dev stack deletion also deletes those managed log groups; retention bounds log storage while stacks exist.
+
+| Surface                              | Lambdas                                                                  | Retention |
+| ------------------------------------ | ------------------------------------------------------------------------ | --------: |
+| Base image and Base-only operational | `FameThumb`, `Mosaic`                                                    |    7 days |
+| Ethereum/FLS image                   | `FlsThumb`, `FlsMosaic`                                                  |   30 days |
+| Discord/app audit                    | `interactionHandler`, `deferredMessage`                                  |   30 days |
+| Mixed Base/Ethereum eventing         | `FameEvent`                                                              |   30 days |
+| Ethereum wrapper eventing            | `WrapEvent`                                                              |   30 days |
+| Replay-tick pool-state               | `FamePoolStateIndexer`, `FamePoolStateApi`, `FamePoolStateApiAuthorizer` |    7 days |
+| Dormant mixed-chain webhook          | `SwapSchwing` if re-enabled                                              |   30 days |
 
 ## Passive Health Signals
 
@@ -62,6 +79,8 @@ Before enabling `www` production helper env, inspect the deployed stack for:
 - Indexer Lambda `Invocations` alarm: OK after the schedule has had time to run.
 - Indexer failure queue depth alarm: OK and queue depth `0`.
 - Recent `fame-pool-state-indexed` success logs with advancing or non-regressing `observedThroughBlock`.
+- Managed replay-tick log groups exist for the indexer, API, and authorizer with 7-day retention.
+- Managed Ethereum/app-audit log groups exist for eventing and Discord surfaces with 30-day retention.
 
 Do not add email, pager, or chat notification actions for the first release unless the project ownership model changes.
 
@@ -71,13 +90,14 @@ Do not add email, pager, or chat notification actions for the first release unle
 2. Copy the artifact into `src/fame-swap-pool-state/registry/base-v1-pools.json`.
 3. Run registry, indexer, API, and CDK tests.
 4. Confirm main deploy provides `FAME_POOL_STATE_SERVICE_TOKEN`, PR deploy provides a separate `FAME_POOL_STATE_PR_SERVICE_TOKEN`, and both fail before CDK deploy when the token or structurally valid `BASE_RPCS_JSON` is missing.
-5. Confirm PR deploy uses `STAGE=PR-<number>` and cleanup targets only `Bot-PR-<number>` / `BotCert-PR-<number>`.
-6. Set or generate the dev service token first as `FAME_POOL_STATE_DEV_SERVICE_TOKEN`.
-7. For pool-state-only pre-merge validation, add the PR label `DEPLOY_POOL_STATE_DEV`. This deploys `BotPoolStateDev` with only `BASE_RPCS_JSON` and `FAME_POOL_STATE_DEV_SERVICE_TOKEN`; it does not require image, Discord, Farcaster, custom domain, or cert env.
-8. Copy the emitted `FamePoolStateDevEndpointUrl` `/fame/pool-state` endpoint into `www` dev as server-only `FAME_POOL_STATE_API_URL`, and set the matching `FAME_POOL_STATE_SERVICE_TOKEN`.
-9. For full messy app validation, add the PR label `DEPLOY_DEV` to update `Bot-dev` / `BotCert-dev` at `dev.fame.support` with event schedules disabled.
-10. Deploy `society-bots` with Base RPCs and the correct environment-scoped FAME pool-state service token.
-11. Capture smoke evidence:
+5. Confirm the synthesized or deployed stack includes managed CloudWatch log groups with 7-day retention for replay-tick/Base operational logs and 30-day retention for Ethereum/mixed/app-audit logs.
+6. Confirm PR deploy uses `STAGE=PR-<number>` and cleanup targets only `Bot-PR-<number>` / `BotCert-PR-<number>`.
+7. Set or generate the dev service token first as `FAME_POOL_STATE_DEV_SERVICE_TOKEN`.
+8. For pool-state-only pre-merge validation, add the PR label `DEPLOY_POOL_STATE_DEV`. This deploys `BotPoolStateDev` with only `BASE_RPCS_JSON` and `FAME_POOL_STATE_DEV_SERVICE_TOKEN`; it does not require image, Discord, Farcaster, custom domain, or cert env.
+9. Copy the emitted `FamePoolStateDevEndpointUrl` `/fame/pool-state` endpoint into `www` dev as server-only `FAME_POOL_STATE_API_URL`, and set the matching `FAME_POOL_STATE_SERVICE_TOKEN`.
+10. For full messy app validation, add the PR label `DEPLOY_DEV` to update `Bot-dev` / `BotCert-dev` at `dev.fame.support` with event schedules disabled.
+11. Deploy `society-bots` with Base RPCs and the correct environment-scoped FAME pool-state service token.
+12. Capture smoke evidence:
 
 - endpoint or stack name;
 - timestamp;
@@ -86,8 +106,10 @@ Do not add email, pager, or chat notification actions for the first release unle
 - at least one `fresh` quote-model pool;
 - returned `observedThroughBlock`.
 - for the replay proof, a `fresh` `cl-replay-v1` row for `slipstream-usdc-weth-100` with state hash, dynamic fee, bitmap word count, initialized tick count, block hash, and matching source registry id.
+- replay-tick CloudWatch log group retention;
+- Ethereum or app-audit CloudWatch log group retention.
 
-12. Capture short soak evidence across at least five scheduled intervals:
+13. Capture short soak evidence across at least five scheduled intervals:
 
 - recent success log timestamps;
 - `observedThroughBlock` values, with no regression;
@@ -96,11 +118,11 @@ Do not add email, pager, or chat notification actions for the first release unle
 - failure queue depth;
 - any RPC timeout, throttle, or cursor-lag notes.
 
-13. Run `www` route lab with `--indexed`, `BASE_RPC_URL` or `FAME_POOL_STATE_CURRENT_BLOCK`, and production-like helper env. Confirm the indexed summary reports `cl replay slipstream-usdc-weth-100 ...` while selected CL quotes remain live or recorded in shadow mode.
-14. Run `www` CL replay parity with `bun scripts/fame-swap-cl-replay-parity.ts` and production-like helper/RPC env. Promotion requires exact same-block `amountOut` equality for both WETH -> USDC and USDC -> WETH amount bands.
-15. Run a `www` quote API smoke check.
-16. Record route-lab and parity evidence locations in the PR or release checklist. Evidence must cover indexed success plus fallback-relevant stale, unknown, unsupported, malformed, incomplete replay, and unavailable-helper cases.
-17. Enable `www` server env `FAME_POOL_STATE_API_URL` and `FAME_POOL_STATE_SERVICE_TOKEN` only after route-lab and parity proof are attached. Do not create `NEXT_PUBLIC_` variants.
+14. Run `www` route lab with `--indexed`, `BASE_RPC_URL` or `FAME_POOL_STATE_CURRENT_BLOCK`, and production-like helper env. Confirm the indexed summary reports `cl replay slipstream-usdc-weth-100 ...` while selected CL quotes remain live or recorded in shadow mode.
+15. Run `www` CL replay parity with `bun scripts/fame-swap-cl-replay-parity.ts` and production-like helper/RPC env. Promotion requires exact same-block `amountOut` equality for both WETH -> USDC and USDC -> WETH amount bands.
+16. Run a `www` quote API smoke check.
+17. Record route-lab and parity evidence locations in the PR or release checklist. Evidence must cover indexed success plus fallback-relevant stale, unknown, unsupported, malformed, incomplete replay, and unavailable-helper cases.
+18. Enable `www` server env `FAME_POOL_STATE_API_URL` and `FAME_POOL_STATE_SERVICE_TOKEN` only after route-lab and parity proof are attached. Do not create `NEXT_PUBLIC_` variants.
 
 ## Durable Follow-Ups
 

--- a/docs/ideation/2026-05-23-fame-pool-state-cleanup-hardening-ideation.md
+++ b/docs/ideation/2026-05-23-fame-pool-state-cleanup-hardening-ideation.md
@@ -1,0 +1,254 @@
+---
+date: 2026-05-23
+topic: cloudwatch-log-retention-cleanup-hardening
+focus: repo-wide CloudWatch log retention, structured logging, and operational hardening after the first FAME CL replay slice
+mode: repo-grounded
+---
+
+# Ideation: CloudWatch Log Retention And FAME Pool-State Hardening
+
+## Grounding Context
+
+The FAME pool-state helper has moved from release-readiness into a post-merge hardening phase. `main` now includes the first replayable `slipstream-usdc-weth-100` slice, including `cl-replay-v1` snapshots, registry schema v3, replay chunk TTLs, metadata-only stale replay responses, and Lambda failure semantics for CL replay capture failures.
+
+The cleanup scope is now broader than the pool-state helper alone: every active CloudWatch log group created by this CDK app should have an explicit retention posture. The requested policy is:
+
+- **Ethereum-related logs:** 30-day retention.
+- **Replay-tick-related logs:** 7-day retention.
+- **Base eventing-related logs:** 7-day retention.
+- **Everything else:** explicitly classified during implementation; do not leave default infinite retention by accident.
+
+Current active Lambda inventory from `deploy/lib`:
+
+| Construct file | Lambda | Chain or domain signal | Proposed retention class |
+|---|---|---|---|
+| `deploy/lib/image-lambdas.ts` | `FameThumb` | `BASE_RPCS_JSON` image route | Base-related, 7 days unless split from eventing |
+| `deploy/lib/image-lambdas.ts` | `Mosaic` | `BASE_RPCS_JSON` image route | Base-related, 7 days unless split from eventing |
+| `deploy/lib/image-lambdas.ts` | `FlsThumb` | `MAINNET_RPCS_JSON` image route | Ethereum, 30 days |
+| `deploy/lib/image-lambdas.ts` | `FlsMosaic` | `MAINNET_RPCS_JSON` image route | Ethereum, 30 days |
+| `deploy/lib/events-lambdas.ts` | `interactionHandler` | Discord interaction and notification tables | App/Discord, explicitly classify |
+| `deploy/lib/events-lambdas.ts` | `deferredMessage` | Discord deferred message queue | App/Discord, explicitly classify |
+| `deploy/lib/events-lambdas.ts` | `FameEvent` | `BASE_RPCS_JSON`, `SEPOLIA_RPCS_JSON`, `MAINNET_RPCS_JSON` | Mixed chain/eventing, choose 30 days or split later |
+| `deploy/lib/events-lambdas.ts` | `WrapEvent` | `SEPOLIA_RPCS_JSON`, `MAINNET_RPCS_JSON` | Ethereum, 30 days |
+| `deploy/lib/fame-pool-state.ts` | `FamePoolStateIndexer` | Base CL replay and tick snapshots | Replay-tick, 7 days |
+| `deploy/lib/fame-pool-state.ts` | `FamePoolStateApi` | Base CL replay helper API | Replay-tick, 7 days |
+| `deploy/lib/fame-pool-state.ts` | `FamePoolStateApiAuthorizer` | Pool-state API auth | Replay-tick support, 7 days |
+| `deploy/lib/alchemy-webhook.ts` | `SwapSchwing` | `MAINNET_RPCS_JSON`, `SEPOLIA_RPCS_JSON`, `BASE_RPCS_JSON` | Inactive today; if re-enabled, mixed chain, choose 30 days or split later |
+
+Important current facts:
+
+- The DynamoDB table has TTL on replay chunk rows through `expiresAt`.
+- The indexer failure queue has a 7-day SQS retention period.
+- The indexer has passive CloudWatch alarms for Lambda errors, Lambda throttles, missed invocations, and non-empty failure queue depth.
+- The clean worktree from `origin/main` has no explicit retention policy on the active Lambda log groups yet, including the pool-state indexer, API, and authorizer Lambdas.
+- The pool-state, image, event, and currently inactive webhook Lambda constructs all need explicit retention policy decisions before the repo can say CloudWatch logs are managed intentionally.
+- The indexer logs one structured `fame-pool-state-indexed` payload per run; API logs one `fame-pool-state-api-batch` payload per request; CL replay failures log an error payload and then throw.
+- Docs already separate `www` quote authority from `society-bots` state production. This cleanup pass should not drift into route ranking, backend CL quote endpoints, or public quote-surface optimization.
+
+External grounding:
+
+- AWS CDK Lambda `FunctionProps` supports a user-provided `logGroup`; the local CDK docs note that Lambda-created default log groups cannot be customized through CDK, and recommend `logGroup` for a fully customizable log group.
+- AWS CDK `aws_logs.LogGroup` supports `retention` and `removalPolicy`; `RetentionDays` includes `ONE_WEEK`, `ONE_MONTH`, and `INFINITE`.
+- AWS CDK `aws_logs.LogRetention` also exists but is a custom-resource retention controller. The Lambda docs describe `logRetention` as the legacy approach and `logGroup` as the fuller user-controlled approach.
+- AWS Lambda supports JSON log format and application/system log level filtering. For custom JSON logs to participate in application-level filtering, log events need a valid `level` field.
+
+Primary external sources:
+
+- AWS CDK `LogGroup`: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_logs.LogGroup.html
+- AWS CDK `LogRetention`: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_logs.LogRetention.html
+- AWS CDK `RetentionDays`: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_logs.RetentionDays.html
+- AWS Lambda log-level filtering: https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-log-level.html
+- AWS Lambda log format: https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-logformat.html
+
+## Topic Axes
+
+- Repo-wide CloudWatch retention and cost controls
+- Log signal quality
+- Deploy and smoke guardrails
+- Operational metrics and inspection
+- Existing cleanup debt
+
+## Ranked Ideas
+
+### 1. Repo-Wide Lambda Retention Class Helper
+
+**Description:** Add a small CDK helper for Lambda log retention classes and require every active Lambda construct to opt into one class: `ethereum` maps to `RetentionDays.ONE_MONTH`, `replayTick` maps to `RetentionDays.ONE_WEEK`, `baseEventing` maps to `RetentionDays.ONE_WEEK`, and `app` or `discord` is explicitly chosen rather than implicit. The first implementation should create managed `LogGroup` resources rather than using Lambda `logRetention`, because managed groups give the next metric-filter and cleanup pass a clearer foundation.
+
+**Axis:** Repo-wide CloudWatch retention and cost controls
+
+**Basis:** `direct:` `deploy/lib/fame-pool-state.ts`, `deploy/lib/image-lambdas.ts`, and `deploy/lib/events-lambdas.ts` create active Lambdas without explicit retention on `origin/main`. `external:` AWS CDK documents both `logRetention` and user-provided `logGroup`, with `logGroup` as the fuller customization path.
+
+**Rationale:** This matches the expanded requirement: all CloudWatch logs get an explicit policy, Ethereum logs keep enough history for slower incident review, and replay/base-eventing logs stay short because they can become high-volume. A helper makes future Lambdas fail code review if they lack a retention classification.
+
+**Downsides:** Mixed-chain Lambdas like `FameEvent` do not fit cleanly into per-chain retention because CloudWatch retention is per log group, not per log event. For the first pass, classify mixed-chain Lambdas by the longest required retention, then consider function split or separate log streams later if log cost proves meaningful.
+
+**Confidence:** 98%
+
+**Complexity:** Low-Medium
+
+**Status:** Strong candidate
+
+### 2. Managed Log Groups For Retention Plus Future Metrics
+
+**Description:** Instead of only using Lambda `logRetention`, create CDK-managed `aws_logs.LogGroup` resources and pass them to each Lambda through `logGroup`. Name them consistently, attach the same retention classes, and use `RemovalPolicy.DESTROY` for dev/PR stacks unless production requirements call for retention across stack deletion.
+
+**Axis:** Repo-wide CloudWatch retention and cost controls
+
+**Basis:** `direct:` the pool-state construct already imports `aws-logs`, but currently uses per-Lambda `logRetention`; other constructs do not import logs at all. `external:` the CDK Lambda docs note that default Lambda-created log groups cannot be customized through CDK and recommend the `logGroup` property for customization.
+
+**Rationale:** Managed log groups are a cleaner long-term base for metric filters, explicit names, and predictable cleanup. This is especially attractive if the next pass also adds replay/freshness metric filters.
+
+**Downsides:** It is slightly more invasive than `logRetention` and needs careful logical IDs/names to avoid replacement surprises on existing stacks. If the goal is the fastest deployable cleanup, a `logRetention` helper is smaller.
+
+**Confidence:** 90%
+
+**Complexity:** Medium
+
+**Status:** Good follow-through path
+
+### 3. Chain-Aware Retention Map With Mixed-Lambda Policy
+
+**Description:** Document and encode a retention decision table for ambiguous Lambdas. Use 30 days when a Lambda handles both Ethereum and Base in one log group, use 7 days when it is replay-tick or Base-only, and mark app/Discord-only Lambdas with a deliberate default. Add comments near `FameEvent` explaining why mixed-chain currently chooses the longer retention.
+
+**Axis:** Repo-wide CloudWatch retention and cost controls
+
+**Basis:** `direct:` `FameEvent` receives Base, Sepolia, and Mainnet RPC JSON in one Lambda, while `WrapEvent` is Sepolia/Mainnet-only and image Lambdas are split by collection/chain. `reasoned:` CloudWatch cannot retain Base log events for 7 days and Ethereum log events for 30 days inside the same log group.
+
+**Rationale:** The tricky part is not the CDK property. It is preventing retention classes from becoming vibes. This decision table keeps the policy auditable and makes the tradeoff visible.
+
+**Downsides:** Mixed Lambdas may retain more Base/eventing logs than strictly desired. Splitting `FameEvent` by chain would be a larger architectural change and should not be bundled into the first cleanup pass.
+
+**Confidence:** 94%
+
+**Complexity:** Low
+
+**Status:** Strong candidate
+
+### 4. Pool-State Logger With Levels, Redaction, And Stable Event Names
+
+**Description:** Add a tiny pool-state logging helper used by the indexer and API Lambdas. The helper should emit one JSON object per line with `level`, `event`, `timestamp`, and compact event-specific fields; redact or omit request bodies, service tokens, full URLs, calldata, and raw tick payloads. Keep `fame-pool-state-indexed`, `fame-pool-state-api-batch`, `fame-pool-state-api-error`, and replay failure events as stable names.
+
+**Axis:** Log signal quality
+
+**Basis:** `direct:` the current Lambdas manually call `console.log(JSON.stringify(...))` and `console.error(JSON.stringify(...))`; the payloads are structured but do not consistently carry a `level` field. `external:` AWS Lambda log-level filtering expects JSON logs with a valid `level` field when application logs are filtered.
+
+**Rationale:** A small typed helper prevents the next cleanup pass from becoming scattered `console.*` edits. It also makes it easier to use Lambda JSON logging or metric filters later because every event has a predictable envelope.
+
+**Downsides:** If Lambda `loggingFormat: JSON` is enabled at the same time, verify whether console output is wrapped or nested before relying on CloudWatch query shapes. Start with the application-level envelope and only enable Lambda JSON format when tests/smokes confirm the observed log shape.
+
+**Confidence:** 92%
+
+**Complexity:** Low-Medium
+
+**Status:** Strong candidate
+
+### 5. API Batch Log Volume Gate
+
+**Description:** Reduce normal API request log volume by making success logging conditional and deterministic. Always log errors. Always log replay-surface requests and any response with stale, unknown, or unsupported rows. For all-fresh constant-product-only batches, either log at debug level or sample through an explicit environment variable such as `FAME_POOL_STATE_API_SUCCESS_LOG_MODE=all|interesting|off`.
+
+**Axis:** Log signal quality
+
+**Basis:** `direct:` `src/fame-swap-pool-state/lambdas/api.ts` logs `fame-pool-state-api-batch` for every successful request. `reasoned:` once `www` starts leaning on the helper, quote traffic can make per-request INFO logs noisy even when nothing needs operator attention.
+
+**Rationale:** This keeps operationally interesting API behavior visible while avoiding a pile of identical fresh batch logs. It also leaves a deliberate switch for dev investigations without making production noisy by default.
+
+**Downsides:** Over-aggressive suppression can hide traffic shape during early rollout. The first implementation should keep replay-surface requests and non-fresh status counts at INFO so the CL replay rollout remains easy to inspect.
+
+**Confidence:** 84%
+
+**Complexity:** Low-Medium
+
+**Status:** Strong candidate
+
+### 6. Log-Derived Metric Filters For Replay And Freshness Health
+
+**Description:** Add CloudWatch metric filters on the managed indexer log group for `clReplayFailedPools > 0`, `clReplaySnapshots`, `clReplayWrittenPools`, and high `durationMs`. Optionally add a second metric for API batches with stale/unknown counts. Keep existing passive alarms, but make replay failure and slow-indexer signals easier to inspect from metrics without reading raw logs.
+
+**Axis:** Operational metrics and inspection
+
+**Basis:** `direct:` `indexFamePoolStates` already returns `durationMs`, `observedThroughBlock`, CL replay counts, failures, and sizing metrics; the Lambda logs the whole payload once per run. `reasoned:` the passive alarms catch Lambda-level failure, but replay-specific degradation can be visible before the whole Lambda fails.
+
+**Rationale:** The hardening goal is not paging; it is a sharper health surface. Metric filters let the release owner check whether replay succeeded, whether the indexer slowed down, and whether stale output increased without scraping CloudWatch Logs manually.
+
+**Downsides:** Metric filters depend on stable log JSON shape and are easier to attach to explicitly managed log groups. Do this after retention and the logging envelope are made explicit.
+
+**Confidence:** 78%
+
+**Complexity:** Medium
+
+**Status:** Defer until log groups/log shape stabilize
+
+### 7. Dev Smoke Script For Pool-State Health Evidence
+
+**Description:** Add a focused smoke script that takes `FAME_POOL_STATE_API_URL`, `FAME_POOL_STATE_SERVICE_TOKEN`, `BASE_RPC_URL`, and optional `FAME_POOL_STATE_CURRENT_BLOCK`; calls `/fame/pool-state`; requests both reserve and `cl-replay-v1` surfaces; and prints a compact pass/fail report with source registry id, current block, status counts, replay state hash, bitmap/tick counts, and stale-metadata checks.
+
+**Axis:** Deploy and smoke guardrails
+
+**Basis:** `direct:` `docs/fame-pool-state-index.md` requires authenticated helper smoke evidence, fresh quote-model state, replay row details, and short soak evidence before `www` consumes the helper. `reasoned:` humans should not have to reconstruct the same curl plus jq plus CloudWatch checklist each dev deploy.
+
+**Rationale:** This creates a single backend-owned proof command for the cleanup lane. It complements, but does not replace, `www` route-lab and parity checks.
+
+**Downsides:** It touches live AWS/RPC state, so it cannot be the only test. Keep it as a smoke and give it safe redaction for URLs and tokens.
+
+**Confidence:** 86%
+
+**Complexity:** Medium
+
+**Status:** Good follow-up
+
+### 8. PR Cleanup Hardening For Dev Artifacts
+
+**Description:** Fix the existing cleanup debt around PR stack deletion: delete `BotCert-PR-<number>` in `us-east-1`, stop hiding unexpected CloudFormation delete/wait failures behind blanket `|| true`, and make managed log groups part of the cleanup checklist if they are PR-scoped.
+
+**Axis:** Existing cleanup debt
+
+**Basis:** `direct:` both `docs/fame-pool-state-index.md` and `docs/fame-pool-state-handoff.md` list PR cleanup debt: `BotCert-PR-<number>` is not deleted in `us-east-1`, and unexpected delete/wait failures are swallowed. `reasoned:` unmanaged log groups and PR cleanup gaps compound into AWS account clutter.
+
+**Rationale:** This is the same hygiene theme: short-lived validation environments should leave little residue and should fail visibly when cleanup is incomplete.
+
+**Downsides:** It may involve GitHub workflow and cross-region AWS command details beyond the CloudWatch retention helper. Keep it a separate commit from log retention if implemented.
+
+**Confidence:** 76%
+
+**Complexity:** Medium
+
+**Status:** Good follow-up
+
+### 9. Operator-Facing Runbook Refresh
+
+**Description:** After log retention and logging changes land, refresh `docs/fame-pool-state-index.md` with exact CloudWatch log group names, expected retention classes, key Logs Insights queries, smoke command, and what healthy enough for dev means. Keep it backend-specific and leave `www` optimization details out.
+
+**Axis:** Deploy and smoke guardrails
+
+**Basis:** `direct:` current docs describe passive alarms, indexer/API event names, and rollout checks, but they do not yet name managed log groups or concrete query snippets. `reasoned:` the next operator should be able to answer whether a dev deploy is healthy without reading implementation code or chat history.
+
+**Rationale:** Runtime hardening is only useful if someone can operate it. The runbook is the handoff surface for the next deploy attempt.
+
+**Downsides:** This should trail the code changes; otherwise the docs will guess at names and fields that may still shift.
+
+**Confidence:** 82%
+
+**Complexity:** Low
+
+**Status:** Follow-up after implementation
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Add pager/email actions to all passive alarms | Scope overrun for the community-service ownership model; current docs intentionally use no-action passive alarms. |
+| 2 | Move all Lambda logs to a third-party observability vendor | Too expensive and not grounded in the current deploy surface. CloudWatch retention and log shape are the immediate gap. |
+| 3 | Stop API success logging entirely | Too aggressive during CL replay rollout; replay-surface and non-fresh responses still need INFO-level visibility. |
+| 4 | Store every indexer run as a DynamoDB history row | Interesting later, but log retention plus metric filters are cheaper and enough for this cleanup pass. |
+| 5 | Build the backend CL quote endpoint in this pass | Important, but explicitly belongs to the separate optimization/quote-surface lane. |
+| 6 | Split mixed-chain event Lambdas just to get per-chain retention | Too invasive for cleanup; classify mixed-chain log groups by the longest required retention first. |
+| 7 | Event-driven tick maintenance as hardening | Not cleanup; it changes the replay maintenance model and belongs after the quote/payload design stabilizes. |
+| 8 | Leave non-pool-state Lambdas for later | Rejected by the expanded scope: all CloudWatch log groups should now be explicitly classified. |
+
+## Recommended Next Brainstorm Seed
+
+Start with ideas 1, 3, and 4 as the first cleanup milestone:
+
+> Add a repo-wide managed `LogGroup` helper, classify every active Lambda into an explicit retention class, apply 30-day retention to Ethereum or mixed Ethereum log groups, apply 7-day retention to replay-tick and Base eventing log groups, and keep pool-state INFO logs compact with a tiny structured logging helper.
+
+This should be the first implementation chunk because it directly addresses the expanded CloudWatch concern and creates a durable guardrail for future Lambdas without drifting into quote endpoint or route-ranking work.

--- a/docs/plans/2026-05-23-001-feat-cloudwatch-log-retention-hardening-plan.md
+++ b/docs/plans/2026-05-23-001-feat-cloudwatch-log-retention-hardening-plan.md
@@ -1,0 +1,383 @@
+---
+title: "feat: Add CloudWatch Log Retention Hardening"
+type: feat
+status: completed
+date: 2026-05-23
+origin: docs/brainstorms/2026-05-23-cloudwatch-log-retention-hardening-requirements.md
+---
+
+# feat: Add CloudWatch Log Retention Hardening
+
+## Summary
+
+Introduce a CDK-owned log group path for the repo's active Lambda constructs, backed by an explicit retention-class helper and CDK assertions. Pair the infrastructure hardening with narrow pool-state log cleanup so replay diagnostics remain visible without raw tick payloads or routine high-volume INFO noise.
+
+---
+
+## Problem Frame
+
+The CL replay slice made two operational gaps more expensive: Lambda log groups are currently implicit/unmanaged, and pool-state replay/API logs can become noisy as `www` leans harder on indexed state. This plan implements the retention policy from the origin requirements while preserving the existing quote-authority boundary and passive-alarm posture.
+
+---
+
+## Requirements
+
+- R1. Every active Lambda created by this CDK app has a managed CloudWatch `LogGroup` attached through infrastructure code.
+- R2. Managed log groups carry explicit retention and stack-deletion behavior.
+- R3. Retention classes are preserved: Ethereum-only, mixed Ethereum/Base, and Discord/app-audit logs retain 30 days; replay-tick and Base operational/eventing logs retain 7 days.
+- R4. Active Lambdas in `deploy/lib/image-lambdas.ts`, `deploy/lib/events-lambdas.ts`, and `deploy/lib/fame-pool-state.ts` are classified with no omissions.
+- R5. CDK tests assert active Lambda log groups and expected retention, and fail when a new active Lambda lacks a retention decision.
+- R6. Inactive Lambda constructs such as `deploy/lib/alchemy-webhook.ts` are not deployed in this pass, but re-enabling them requires explicit retention classification.
+- R7. Pool-state indexer and API logs keep stable operational event names.
+- R8. Pool-state success logs are compact by default and exclude secrets, raw RPC URLs, raw request bodies, raw tick arrays, and raw replay payloads.
+- R9. Replay failures, stale replay requests, incomplete replay state, and unsupported replay surfaces remain operator-visible; ordinary all-fresh traffic should not become a high-volume INFO stream.
+- R10. Structured application logs intended for filtering include a clear `level` and `event`.
+- R11. Operational docs state retention classes, active Lambda classification, and deployed verification steps.
+- R12. Existing passive-alarm posture is preserved; metric filters and paging destinations are not required.
+- R13. The work does not change `www` quote behavior, add a `society-bots` quote endpoint, alter route ranking, or change replay tick maintenance.
+
+**Origin actors:** A1 infrastructure implementer, A2 production operator, A3 pool-state/replay reviewer, A4 future maintainer.
+**Origin flows:** F1 Lambda log retention is synthesized, F2 runtime logs stay useful without ballooning, F3 future Lambda surfaces are reviewed.
+**Origin acceptance examples:** AE1 managed log groups with retention and deletion behavior; AE2 Ethereum/mixed log groups retain 30 days; AE3 replay-tick log groups retain 7 days; AE4 Discord/app log groups retain 30 days; AE5 Base-only operational log groups retain 7 days; AE6 new active Lambdas without retention fail tests; AE7 pool-state logs stay compact and replay failures visible; AE8 retention review shows no quote/route behavior changes.
+
+---
+
+## Scope Boundaries
+
+- Do not split mixed-chain Lambdas just to get per-chain retention.
+- Do not add a backend quote endpoint, alter `www` quote behavior, change route ranking, or change replay tick maintenance.
+- Do not migrate all repo logging to a new framework.
+- Do not enable Lambda native JSON logging format in the first pass; keep the first logging cleanup at the application-envelope level.
+- Do not add paging destinations, broad alerting policy changes, dashboards, or Logs Insights query packs.
+- Do not deploy or re-enable `deploy/lib/alchemy-webhook.ts` in this pass.
+
+### Deferred to Follow-Up Work
+
+- Metric filters for replay failures, stale replay responses, and slow indexer runs.
+- Logs Insights query pack or dashboard once managed log group names stabilize.
+- Broader logging-framework cleanup for image, Discord, eventing, and webhook Lambdas.
+- Environment-aware log group removal policy if the project later needs production stack deletion to retain logs after stack teardown.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `deploy/lib/fame-pool-state.ts` creates three active Lambdas, passive alarms, a 7-day failure queue, and the pool-state dev stack's core construct.
+- `deploy/lib/image-lambdas.ts` creates four active Docker image Lambdas: two Base image endpoints and two Ethereum/FLS image endpoints.
+- `deploy/lib/events-lambdas.ts` creates active Discord interaction, deferred-message, Fame event, and wrapper event Lambdas.
+- `deploy/lib/alchemy-webhook.ts` contains an inactive mixed-chain webhook construct; `deploy/lib/deploy-stack.ts` currently comments it out.
+- `deploy/test/fame-pool-state.test.ts` is the current CDK assertion suite and should be extended or complemented rather than replaced.
+- `src/fame-swap-pool-state/lambdas/indexer.ts` and `src/fame-swap-pool-state/lambdas/api.ts` currently emit JSON strings manually with stable pool-state event names.
+- `src/fame-swap-pool-state/lambdas/api.test.ts` already spies on `console.error` for API transport failures and is the natural place for compact/gated API log assertions.
+- `docs/fame-pool-state-index.md` is the existing operational runbook for pool-state logs, passive health signals, rollout checks, and durable follow-ups.
+
+### Institutional Learnings
+
+- FAME indexed state work should keep `society-bots` as state/provenance producer and `www` as quote authority; this plan intentionally avoids quote endpoints and route behavior.
+- Replay chunk payloads are large and should stay out of stale/helper diagnostics unless explicitly fresh and requested by the consuming API path.
+- The strongest operational evidence for CL replay is structured, compact proof of freshness, state identity, and fallback reasons rather than raw tick payloads.
+
+### External References
+
+- AWS CDK `FunctionProps.logGroup` supports a user-provided log group and notes that Lambda-created default log groups cannot have CDK-managed retention; `logRetention` is deprecated/legacy in favor of `logGroup`: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.FunctionProps.html
+- AWS Lambda log-level filtering requires JSON log format and uses `level` when filtering application logs: https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-log-level.html
+- AWS Lambda JSON log format can wrap supported runtime console output and can increase log message size, so this plan avoids switching Lambda logging format until the app-level envelope is stable: https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-logformat.html
+
+---
+
+## Key Technical Decisions
+
+- **Managed log groups over `logRetention`:** Use `aws_logs.LogGroup` plus Lambda `logGroup` because the current CDK API describes `logRetention` as legacy and managed log groups are better for future metric filters.
+- **Central retention helper:** Add one CDK helper that names retention classes and creates log groups, then require each Lambda constructor to opt into a class at the creation site.
+- **Destroy on stack deletion for this pass:** Use explicit destroy behavior for managed log groups so PR/dev stack cleanup does not leave unmanaged residue; rely on CloudWatch retention while stacks exist.
+- **Mixed-chain uses longest retention:** Any Lambda that emits both Ethereum and Base logs gets the 30-day class.
+- **Discord/app audit uses 30 days:** User-facing Discord/app-only logs retain long enough to explain bot-visible incidents.
+- **Base/replay operational logs use 7 days:** Base-only image/eventing and replay-tick pool-state logs retain briefly to bound high-volume operational data.
+- **Application envelope before Lambda JSON format:** Add `level` and `event` to pool-state logs without enabling Lambda native JSON format in this pass.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Exact helper shape for managed log groups: create a small CDK helper module that exposes retention classes and a log-group factory, then pass the returned log group into each Lambda.
+- Stack deletion behavior: use explicit destroy behavior in this first pass so short-lived PR/dev stacks clean up after themselves.
+- Pool-state log compactness approach: add a small pool-state logging helper or direct equivalent envelope in the pool-state Lambda layer; do not broaden this into a repo-wide logging framework.
+- Docs location: update `docs/fame-pool-state-index.md` because it is already the operator-facing runtime and rollout document for this surface.
+
+### Deferred to Implementation
+
+- Exact helper function names and physical log group name format are deferred to implementation, but the synthesized resources must be deterministic and assertion-friendly.
+- Exact API success-log gating condition is deferred to implementation, but replay/stale/incomplete/unsupported behavior must remain operator-visible.
+- Whether to split CDK log retention assertions into a new test file or extend `deploy/test/fame-pool-state.test.ts` is deferred to implementation, based on construct testability.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TD
+    classMap["Retention class map"]
+    helper["Managed LogGroup helper"]
+    image["ImageLambdas"]
+    events["EventLambdas"]
+    pool["FamePoolState"]
+    tests["CDK assertions"]
+    docs["Operational docs"]
+    logs["Pool-state log envelope"]
+
+    classMap --> helper
+    helper --> image
+    helper --> events
+    helper --> pool
+    image --> tests
+    events --> tests
+    pool --> tests
+    pool --> logs
+    tests --> docs
+    logs --> docs
+```
+
+Retention classification for active Lambdas:
+
+| Surface | Lambdas | Retention class |
+|---|---|---|
+| Base image/operational | `FameThumb`, `Mosaic` | 7 days |
+| Ethereum/FLS image | `FlsThumb`, `FlsMosaic` | 30 days |
+| Discord/app audit | `interactionHandler`, `deferredMessage` | 30 days |
+| Mixed Base/Ethereum eventing | `FameEvent` | 30 days |
+| Ethereum wrapper eventing | `WrapEvent` | 30 days |
+| Replay-tick pool-state | `FamePoolStateIndexer`, `FamePoolStateApi`, `FamePoolStateApiAuthorizer` | 7 days |
+
+---
+
+## Implementation Units
+
+### U1. Add Managed Log Group Retention Helper
+
+**Goal:** Create a single typed CDK helper for retention classes and managed log group creation.
+
+**Requirements:** R1, R2, R3, R5, R6.
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `deploy/lib/lambda-log-groups.ts`
+- Test: `deploy/test/log-retention.test.ts`
+
+**Approach:**
+- Define a small retention class vocabulary for `ethereum`, `mixedEthereumBase`, `appAudit`, `baseOperational`, and `replayTick`.
+- Map those classes to `aws_logs.RetentionDays.ONE_MONTH` or `aws_logs.RetentionDays.ONE_WEEK`.
+- Provide a helper that creates an `aws_logs.LogGroup` with explicit retention and removal policy and returns it for use in Lambda constructors.
+- Keep the helper simple and construct-local; do not introduce stage parsing, environment-variable policy, or a global registry service.
+
+**Patterns to follow:**
+- CDK construct style in `deploy/lib/fame-pool-state.ts`.
+- Existing assertive test style using `Template.fromStack` and `Match` in `deploy/test/fame-pool-state.test.ts`.
+
+**Test scenarios:**
+- Happy path: helper-created log groups synthesize as `AWS::Logs::LogGroup` resources with expected `RetentionInDays`.
+- Happy path: a replay-tick log group uses 7-day retention.
+- Happy path: an Ethereum/app-audit log group uses 30-day retention.
+- Edge case: helper creation always sets explicit deletion behavior so the synthesized template is not relying on CloudFormation defaults.
+
+**Verification:**
+- The helper provides the only retention vocabulary used by active Lambda constructs, and tests can assert retention without inspecting implementation internals.
+
+---
+
+### U2. Attach Managed Log Groups To Active Lambdas
+
+**Goal:** Apply the retention helper to every active Lambda in the current deploy surface.
+
+**Requirements:** R1, R2, R3, R4, R6.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `deploy/lib/image-lambdas.ts`
+- Modify: `deploy/lib/events-lambdas.ts`
+- Modify: `deploy/lib/fame-pool-state.ts`
+- Modify: `deploy/lib/alchemy-webhook.ts`
+- Test: `deploy/test/log-retention.test.ts`
+
+**Approach:**
+- Attach 7-day Base operational log groups to `FameThumb` and `Mosaic`.
+- Attach 30-day Ethereum log groups to `FlsThumb`, `FlsMosaic`, and `WrapEvent`.
+- Attach 30-day app-audit log groups to `interactionHandler` and `deferredMessage`.
+- Attach 30-day mixed-chain log group to `FameEvent`.
+- Attach 7-day replay-tick log groups to the pool-state indexer, API, and authorizer.
+- Update the inactive Alchemy webhook construct to use a mixed-chain retention class if it is later re-enabled, without wiring it into the deploy stack.
+- If `ImageLambdas` cannot synthesize cleanly in tests because of unused lookup/imports, remove or isolate only the unused lookup needed to make retention assertions deterministic.
+
+**Patterns to follow:**
+- Existing Lambda construction blocks in `deploy/lib/image-lambdas.ts`, `deploy/lib/events-lambdas.ts`, and `deploy/lib/fame-pool-state.ts`.
+- Existing PR/dev stack hygiene expectation in `docs/fame-pool-state-index.md`.
+
+**Test scenarios:**
+- Covers AE2. Happy path: Ethereum/FLS and wrapper-event Lambdas synthesize log groups with 30-day retention.
+- Covers AE3. Happy path: pool-state indexer, API, and authorizer synthesize log groups with 7-day retention.
+- Covers AE4. Happy path: Discord interaction and deferred-message Lambdas synthesize log groups with 30-day retention.
+- Covers AE5. Happy path: Base image Lambdas synthesize log groups with 7-day retention.
+- Covers AE6. Integration: the inactive webhook construct, when directly instantiated in a unit test or helper-level assertion, has a mixed-chain retention class ready before any future deploy-stack re-enable.
+
+**Verification:**
+- All active Lambda constructors pass a managed log group, and the retention classification table in the plan matches the synthesized resources.
+
+---
+
+### U3. Add CDK Guardrail Assertions For All Active Lambdas
+
+**Goal:** Make missing or incorrect retention fail in tests instead of relying on code review memory.
+
+**Requirements:** R1, R2, R3, R4, R5, R6.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Create: `deploy/test/log-retention.test.ts`
+- Modify: `deploy/test/fame-pool-state.test.ts`
+
+**Approach:**
+- Add focused CDK assertions that count active `AWS::Lambda::Function` resources and managed `AWS::Logs::LogGroup` resources for the constructs under test.
+- Assert each retention class by synthesized retention days rather than by brittle logical IDs alone.
+- Assert Lambda logging configuration points at a managed log group where CDK exposes that relationship in the synthesized template.
+- Prefer direct construct tests for `ImageLambdas`, `EventLambdas`, and `FamePoolState` over full `DeployInfraStack` tests if full-stack context lookups make tests noisy.
+- Include a deliberately useful failure mode: if a future active Lambda is added without a log group, resource counts or attachment assertions should fail.
+- Keep existing pool-state dev stack tests in `deploy/test/fame-pool-state.test.ts` and extend them only where needed to prove the shared `FamePoolState` construct still synthesizes correctly with managed log groups.
+
+**Execution note:** Add or update assertions before changing every construct so missing coverage is visible while implementing U2.
+
+**Patterns to follow:**
+- `deploy/test/fame-pool-state.test.ts` resource-count and property assertion style.
+- Existing workflow-config tests in `deploy/test/fame-pool-state.test.ts` that enforce operational guardrails through text/template assertions.
+
+**Test scenarios:**
+- Covers AE1. Happy path: the pool-state construct synthesizes three Lambdas and three managed log groups with explicit retention/deletion behavior.
+- Covers AE2-AE5. Happy path: image and event constructs synthesize retention groups matching the classification table.
+- Covers AE6. Error path: adding a Lambda to an active construct without updating the expected retention assertion causes the test suite to fail through resource count or unmatched Lambda/log-group attachment.
+- Integration: `FamePoolStateDevStack` still synthesizes the pool-state API route while using managed log groups from the shared construct.
+
+**Verification:**
+- CDK tests prove the active Lambda inventory is covered and make retention drift hard to miss.
+
+---
+
+### U4. Compact Pool-State Structured Logs
+
+**Goal:** Keep pool-state replay/indexer diagnostics useful while reducing routine INFO noise and preventing heavy or sensitive payloads from entering logs.
+
+**Requirements:** R7, R8, R9, R10, R13.
+
+**Dependencies:** None, but can land after U1-U3 if infrastructure is the first priority.
+
+**Files:**
+- Create: `src/fame-swap-pool-state/lambdas/logging.ts`
+- Create: `src/fame-swap-pool-state/lambdas/logging.test.ts`
+- Modify: `src/fame-swap-pool-state/lambdas/indexer.ts`
+- Modify: `src/fame-swap-pool-state/lambdas/api.ts`
+- Modify: `src/fame-swap-pool-state/lambdas/api.test.ts`
+
+**Approach:**
+- Add a tiny pool-state Lambda logging helper that emits a JSON object with `level`, `event`, timestamp, and compact event-specific fields.
+- Preserve existing event names: `fame-pool-state-indexed`, `fame-pool-state-api-batch`, and `fame-pool-state-api-error`.
+- Log indexer replay failure summaries at error level and avoid double-logging the same payload as both error and success when the Lambda is about to throw.
+- Gate low-value API success logs so ordinary all-fresh non-replay batches do not always emit INFO; keep replay-surface requests, stale/unknown/unsupported counts, malformed/dependency errors, and incomplete replay conditions visible.
+- Explicitly omit service tokens, authorization headers, full RPC URLs, raw request bodies, raw tick arrays, and raw replay payloads from log fields.
+
+**Patterns to follow:**
+- Existing pool-state API status count helper in `src/fame-swap-pool-state/lambdas/api.ts`.
+- Existing request/error tests in `src/fame-swap-pool-state/lambdas/api.test.ts`.
+- Existing `src/utils/logging.ts` log-level normalization concept, but keep this pool-state helper small instead of adopting a broad repo logger.
+
+**Test scenarios:**
+- Covers AE7. Happy path: an all-fresh non-replay API batch either emits no INFO success log or emits a compact gated success event without pool payloads.
+- Covers AE7. Happy path: a replay-surface API request emits compact replay-relevant counts and metadata, not bitmap words or initialized ticks.
+- Covers AE7. Error path: a dependency error logs `level: "error"` with `event: "fame-pool-state-api-error"` and no raw request body.
+- Covers AE7. Error path: an indexer result with replay failures formats one error-level `fame-pool-state-indexed` event and the handler still preserves existing fail-fast behavior.
+- Edge case: structured log entries include both `level` and `event` so CloudWatch filtering can target them later.
+
+**Verification:**
+- Pool-state Lambda tests prove compact logging behavior, existing event names remain stable, and no test fixture with raw tick payloads appears in emitted logs.
+
+---
+
+### U5. Update Operational Documentation And Verification Checklist
+
+**Goal:** Document the retention policy and runtime verification path where operators already look for pool-state rollout evidence.
+
+**Requirements:** R11, R12, R13.
+
+**Dependencies:** U1, U2, U3, U4.
+
+**Files:**
+- Modify: `docs/fame-pool-state-index.md`
+- Modify: `docs/brainstorms/2026-05-23-cloudwatch-log-retention-hardening-requirements.md` only if implementation invalidates a requirement assumption
+
+**Approach:**
+- Add a CloudWatch retention section with the active Lambda classification table and retention windows.
+- Add a deploy verification checklist item that confirms managed log groups and retention in the deployed stack.
+- Update the Logs section to describe `level` and compact event envelopes for pool-state logs.
+- Preserve the passive health signal guidance: no pager/email/chat destinations in this pass.
+- Keep the docs clear that this hardening does not change quote authority or `www` fallback behavior.
+
+**Patterns to follow:**
+- Existing `docs/fame-pool-state-index.md` sections for Runtime, Logs, Passive Health Signals, Rollout Check, and Durable Follow-Ups.
+
+**Test scenarios:**
+- Test expectation: none -- documentation-only unit. CDK and Lambda tests in U3/U4 carry the behavioral assertions.
+
+**Verification:**
+- A reviewer can read the docs and verify which log groups should retain 7 days versus 30 days, how to check the deployed stack, and which log events remain operationally important.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** CDK constructs now create log groups before Lambda functions and pass those groups into Lambda logging configuration. Runtime behavior should otherwise remain unchanged except for pool-state log volume/content.
+- **Error propagation:** Pool-state replay/indexer failures continue to throw/fail as they do today; the log cleanup changes their envelope, not failure semantics.
+- **State lifecycle risks:** Managed log groups become stack-owned resources; explicit deletion behavior avoids orphaned PR/dev log groups, while retention windows bound live log storage.
+- **API surface parity:** No public API response shape, registry contract, quote behavior, or `www` caller contract changes are planned.
+- **Integration coverage:** CDK assertion coverage is the key cross-layer guard because retention only becomes meaningful after synthesis/deploy.
+- **Unchanged invariants:** SQS failure queue retention, DynamoDB replay chunk TTL, passive alarms, helper auth, and `observedThroughBlock` freshness semantics remain intact.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Managed log group names or logical IDs cause deployment replacement surprises | Keep names deterministic but avoid unnecessary hardcoded physical names; validate synthesized templates before deploy. |
+| Existing Lambda log streams move to new managed groups and operators search the old default group | Document the managed log group names/verification path in `docs/fame-pool-state-index.md`. |
+| CDK tests for image/event constructs are brittle because those constructs were not previously unit-tested | Prefer direct construct assertions and remove only unused lookup/import behavior needed for deterministic synth. |
+| Pool-state log gating hides useful early rollout evidence | Keep replay-surface, stale/unknown/unsupported, and failure cases visible; gate only low-value all-fresh non-replay success traffic. |
+| Switching Lambda native JSON logging format changes output shape or increases log size | Defer Lambda logging-format changes; emit app-level JSON envelopes first. |
+| Destroying log groups on stack deletion loses post-destroy production logs | Accept for this first PR/dev-focused hardening pass; revisit environment-aware removal policy if production teardown audit requirements appear. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `docs/fame-pool-state-index.md` before PR review so CloudWatch expectations are not trapped in the plan.
+- The deploy smoke should include a retention check for replay-tick 7-day groups and Ethereum/app-audit 30-day groups.
+- Metric filters and Logs Insights queries should be added later only after managed log group names and compact event envelopes have settled.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-23-cloudwatch-log-retention-hardening-requirements.md](../brainstorms/2026-05-23-cloudwatch-log-retention-hardening-requirements.md)
+- **Ideation document:** [docs/ideation/2026-05-23-fame-pool-state-cleanup-hardening-ideation.md](../ideation/2026-05-23-fame-pool-state-cleanup-hardening-ideation.md)
+- Related code: `deploy/lib/fame-pool-state.ts`
+- Related code: `deploy/lib/image-lambdas.ts`
+- Related code: `deploy/lib/events-lambdas.ts`
+- Related tests: `deploy/test/fame-pool-state.test.ts`
+- Related runtime docs: `docs/fame-pool-state-index.md`
+- AWS CDK Lambda `FunctionProps`: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_lambda.FunctionProps.html
+- AWS Lambda log-level filtering: https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-log-level.html
+- AWS Lambda JSON/plain text log format: https://docs.aws.amazon.com/lambda/latest/dg/monitoring-cloudwatchlogs-logformat.html

--- a/src/fame-swap-pool-state/lambdas/api.test.ts
+++ b/src/fame-swap-pool-state/lambdas/api.test.ts
@@ -4,7 +4,14 @@ import type {
   APIGatewayProxyResultV2,
   APIGatewayProxyStructuredResultV2,
 } from "aws-lambda";
+import type { Address, Hex } from "viem";
+import type { FamePoolStateBatchResponse } from "../api.ts";
 import type { FamePoolStateBatchHandler } from "./api.ts";
+
+const ADDRESS_A = "0x0000000000000000000000000000000000000001" as Address;
+const ADDRESS_B = "0x0000000000000000000000000000000000000002" as Address;
+const HEX_32 =
+  "0x0000000000000000000000000000000000000000000000000000000000000000" as Hex;
 
 function eventFixture({
   body,
@@ -67,6 +74,98 @@ function jsonBody(response: APIGatewayProxyResultV2): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
+function parseLogLine(line: unknown): Record<string, unknown> {
+  if (typeof line !== "string") throw new Error("Expected a log string.");
+  const parsed: unknown = JSON.parse(line);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Expected a JSON object log line.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function freshReserveBatchResponse(): FamePoolStateBatchResponse {
+  return {
+    sourceRegistryId: "registry",
+    currentBlock: 125,
+    producerMaxFreshnessBlocks: 120,
+    effectiveMaxFreshnessBlocks: 120,
+    pools: [
+      {
+        status: "fresh",
+        poolId: "constant-product-pool",
+        chainId: 8453,
+        poolAddress: ADDRESS_A,
+        token0: ADDRESS_A,
+        token1: ADDRESS_B,
+        reserve0: "100",
+        reserve1: "200",
+        k: "20000",
+        observedThroughBlock: 124,
+        lastReserveChangeBlock: 123,
+        source: "getReserves",
+        quoteModel: "constant-product-reserves",
+        maxFreshnessBlocks: 120,
+      },
+    ],
+  };
+}
+
+function freshReplayBatchResponse(): FamePoolStateBatchResponse {
+  return {
+    sourceRegistryId: "registry",
+    currentBlock: 125,
+    producerMaxFreshnessBlocks: 120,
+    effectiveMaxFreshnessBlocks: 120,
+    pools: [
+      {
+        status: "fresh",
+        stateKind: "cl-replay-v1",
+        poolId: "slipstream-usdc-weth-100",
+        chainId: 8453,
+        poolAddress: ADDRESS_A,
+        token0: ADDRESS_A,
+        token1: ADDRESS_B,
+        venueFamily: "Slipstream",
+        tickSpacing: 1,
+        sqrtPriceX96: "100",
+        tick: 1,
+        liquidity: "1000",
+        fee: "100",
+        feeSource: "pool-fee",
+        observedThroughBlock: 124,
+        blockHash: HEX_32,
+        parentHash: HEX_32,
+        snapshotId: "cl-replay-v1:slipstream-usdc-weth-100:124",
+        stateHash: HEX_32,
+        source: "slipstream-pool-state",
+        sourceRegistryId: "registry",
+        maxFreshnessBlocks: 120,
+        bitmapWordCount: 2,
+        initializedTickCount: 3,
+        bitmapChunkCount: 1,
+        tickChunkCount: 1,
+        minWordPosition: -1,
+        maxWordPosition: 1,
+        minTick: -100,
+        maxTick: 100,
+        bitmapWords: [
+          {
+            wordPosition: 0,
+            bitmap: HEX_32,
+          },
+        ],
+        initializedTicks: [
+          {
+            tick: -100,
+            liquidityGross: "1",
+            liquidityNet: "1",
+          },
+        ],
+      },
+    ],
+  };
+}
+
 async function loadApiModule(): Promise<typeof import("./api.ts")> {
   jest.resetModules();
   process.env.FAME_POOL_STATE_TABLE_NAME = "PoolState";
@@ -91,43 +190,67 @@ async function requestHandler(
 
 describe("FAME pool-state API Lambda transport", () => {
   test("returns request failure for malformed JSON without calling DynamoDB", async () => {
-    let called = false;
-    const response = await requestHandler(
-      async () => {
-        called = true;
-        throw new Error("should not call batch handler");
-      },
-      eventFixture({ body: "{" }),
-    );
-
-    expect(structuredResponse(response).statusCode).toBe(400);
-    expect(jsonBody(response)).toMatchObject({
-      error: "invalid-request",
-      message: expect.stringContaining("expected valid JSON"),
+    const warnLog = jest.spyOn(console, "warn").mockImplementation(() => {
+      return undefined;
     });
-    expect(called).toBe(false);
+    let called = false;
+
+    try {
+      const response = await requestHandler(
+        async () => {
+          called = true;
+          throw new Error("should not call batch handler");
+        },
+        eventFixture({ body: '{"secret":"do-not-log"' }),
+      );
+
+      expect(structuredResponse(response).statusCode).toBe(400);
+      expect(jsonBody(response)).toMatchObject({
+        error: "invalid-request",
+        message: expect.stringContaining("expected valid JSON"),
+      });
+      expect(called).toBe(false);
+      expect(warnLog).toHaveBeenCalledTimes(1);
+      const entry = parseLogLine(warnLog.mock.calls[0]?.[0]);
+      expect(entry).toMatchObject({
+        level: "warn",
+        event: "fame-pool-state-api-error",
+        errorType: "invalid-request",
+      });
+      expect(warnLog.mock.calls[0]?.[0]).not.toContain("do-not-log");
+    } finally {
+      warnLog.mockRestore();
+    }
   });
 
   test("returns request failure for structurally invalid payload", async () => {
     const { handleFamePoolStateApiEvent } = await loadApiModule();
-    const response = await handleFamePoolStateApiEvent({
-      event: eventFixture({
-        body: JSON.stringify({
-          currentBlock: 125,
-          pools: "bad",
-        }),
-      }),
-      serviceToken: "unit-token",
-      tableName: "PoolState",
-      producerMaxFreshnessBlocks: 120,
-      maxBatchSize: 64,
+    const warnLog = jest.spyOn(console, "warn").mockImplementation(() => {
+      return undefined;
     });
 
-    expect(structuredResponse(response).statusCode).toBe(400);
-    expect(jsonBody(response)).toMatchObject({
-      error: "invalid-request",
-      message: expect.stringContaining("$.pools"),
-    });
+    try {
+      const response = await handleFamePoolStateApiEvent({
+        event: eventFixture({
+          body: JSON.stringify({
+            currentBlock: 125,
+            pools: "bad",
+          }),
+        }),
+        serviceToken: "unit-token",
+        tableName: "PoolState",
+        producerMaxFreshnessBlocks: 120,
+        maxBatchSize: 64,
+      });
+
+      expect(structuredResponse(response).statusCode).toBe(400);
+      expect(jsonBody(response)).toMatchObject({
+        error: "invalid-request",
+        message: expect.stringContaining("$.pools"),
+      });
+    } finally {
+      warnLog.mockRestore();
+    }
   });
 
   test("returns unauthorized before batch handling", async () => {
@@ -171,11 +294,77 @@ describe("FAME pool-state API Lambda transport", () => {
 
       expect(structuredResponse(response).statusCode).toBe(500);
       expect(jsonBody(response)).toEqual({ error: "internal-error" });
-      expect(errorLog).toHaveBeenCalledWith(
-        expect.stringContaining("fame-pool-state-api-error"),
-      );
+      expect(errorLog).toHaveBeenCalledTimes(1);
+      const entry = parseLogLine(errorLog.mock.calls[0]?.[0]);
+      expect(entry).toMatchObject({
+        level: "error",
+        event: "fame-pool-state-api-error",
+        errorType: "dependency",
+        message: "DynamoDB unavailable",
+      });
+      expect(errorLog.mock.calls[0]?.[0]).not.toContain("currentBlock");
     } finally {
       errorLog.mockRestore();
+    }
+  });
+
+  test("does not log ordinary all-fresh non-replay success batches", async () => {
+    const infoLog = jest.spyOn(console, "log").mockImplementation(() => {
+      return undefined;
+    });
+
+    try {
+      const response = await requestHandler(
+        async () => freshReserveBatchResponse(),
+        eventFixture({
+          body: JSON.stringify({
+            currentBlock: 125,
+            pools: [{ poolId: "constant-product-pool" }],
+          }),
+        }),
+      );
+
+      expect(structuredResponse(response).statusCode).toBe(200);
+      expect(infoLog).not.toHaveBeenCalled();
+    } finally {
+      infoLog.mockRestore();
+    }
+  });
+
+  test("logs compact replay success batches without raw tick payloads", async () => {
+    const infoLog = jest.spyOn(console, "log").mockImplementation(() => {
+      return undefined;
+    });
+
+    try {
+      const response = await requestHandler(
+        async () => freshReplayBatchResponse(),
+        eventFixture({
+          body: JSON.stringify({
+            currentBlock: 125,
+            stateSurfaces: ["cl-replay-v1"],
+            pools: [{ poolId: "slipstream-usdc-weth-100" }],
+          }),
+        }),
+      );
+
+      expect(structuredResponse(response).statusCode).toBe(200);
+      expect(infoLog).toHaveBeenCalledTimes(1);
+      const line = infoLog.mock.calls[0]?.[0];
+      expect(line).not.toContain("bitmapWords");
+      expect(line).not.toContain("initializedTicks");
+      expect(parseLogLine(line)).toMatchObject({
+        level: "info",
+        event: "fame-pool-state-api-batch",
+        clReplay: {
+          returned: 1,
+          fresh: 1,
+          bitmapWordCount: 2,
+          initializedTickCount: 3,
+        },
+      });
+    } finally {
+      infoLog.mockRestore();
     }
   });
 });

--- a/src/fame-swap-pool-state/lambdas/api.ts
+++ b/src/fame-swap-pool-state/lambdas/api.ts
@@ -14,6 +14,7 @@ import {
 } from "../api.ts";
 import type { FamePoolStateBatchResponse } from "../api.ts";
 import { poolStateRequestAuthorized } from "../auth.ts";
+import { logPoolStateApiBatch, writePoolStateLog } from "./logging.ts";
 
 export type FamePoolStateBatchHandler = (
   options: Parameters<typeof handleFamePoolStateBatchRequest>[0],
@@ -38,14 +39,6 @@ function jsonResponse(
     },
     body: JSON.stringify(body),
   };
-}
-
-function statusCounts(response: { pools: Array<{ status: string }> }) {
-  const counts: Record<string, number> = {};
-  for (const pool of response.pools) {
-    counts[pool.status] = (counts[pool.status] ?? 0) + 1;
-  }
-  return counts;
 }
 
 function parseJsonBody(body: string | undefined): unknown {
@@ -90,31 +83,24 @@ export async function handleFamePoolStateApiEvent({
       producerMaxFreshnessBlocks,
       maxBatchSize,
     });
-    console.log(
-      JSON.stringify({
-        event: "fame-pool-state-api-batch",
-        sourceRegistryId: response.sourceRegistryId,
-        currentBlock: response.currentBlock,
-        effectiveMaxFreshnessBlocks: response.effectiveMaxFreshnessBlocks,
-        batchSize: response.pools.length,
-        statusCounts: statusCounts(response),
-      }),
-    );
+    logPoolStateApiBatch(response);
     return jsonResponse(200, response);
   } catch (error) {
     if (isFamePoolStateRequestError(error)) {
+      writePoolStateLog("warn", "fame-pool-state-api-error", {
+        errorType: "invalid-request",
+        message: error.message,
+      });
       return jsonResponse(400, {
         error: "invalid-request",
         message: error.message,
       });
     }
 
-    console.error(
-      JSON.stringify({
-        event: "fame-pool-state-api-error",
-        message: errorMessage(error),
-      }),
-    );
+    writePoolStateLog("error", "fame-pool-state-api-error", {
+      errorType: "dependency",
+      message: errorMessage(error),
+    });
     return jsonResponse(500, {
       error: "internal-error",
     });
@@ -128,8 +114,7 @@ export async function handler(
     event,
     serviceToken: serviceToken(),
     tableName: FAME_POOL_STATE_TABLE_NAME,
-    producerMaxFreshnessBlocks:
-      FAME_POOL_STATE_DEFAULT_MAX_FRESHNESS_BLOCKS,
+    producerMaxFreshnessBlocks: FAME_POOL_STATE_DEFAULT_MAX_FRESHNESS_BLOCKS,
     maxBatchSize: FAME_POOL_STATE_MAX_BATCH_SIZE,
   });
 }

--- a/src/fame-swap-pool-state/lambdas/indexer.test.ts
+++ b/src/fame-swap-pool-state/lambdas/indexer.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, jest, test } from "@jest/globals";
+
+function parseLogLine(line: unknown): Record<string, unknown> {
+  if (typeof line !== "string") throw new Error("Expected a log string.");
+  const parsed: unknown = JSON.parse(line);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Expected a JSON object log line.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+async function loadIndexerModule(): Promise<typeof import("./indexer.ts")> {
+  jest.resetModules();
+  process.env.FAME_POOL_STATE_TABLE_NAME = "PoolState";
+  return import("./indexer.ts");
+}
+
+describe("FAME pool-state indexer Lambda", () => {
+  test("sanitizes top-level indexer crashes before rethrowing", async () => {
+    const { handleFamePoolStateIndexer } = await loadIndexerModule();
+    const errorLog = jest.spyOn(console, "error").mockImplementation(() => {
+      return undefined;
+    });
+    const providerError = new Error(
+      'HTTP request failed. URL: https://base.example/super-secret-token Request body: {"method":"eth_getLogs"}',
+    );
+    providerError.name = "HttpRequestError";
+    Object.defineProperty(providerError, "statusCode", {
+      value: 429,
+    });
+
+    try {
+      await expect(
+        handleFamePoolStateIndexer({
+          tableName: "PoolState",
+          confirmationBlocks: 2,
+          indexPools: async () => {
+            throw providerError;
+          },
+        }),
+      ).rejects.toThrow("FAME pool-state indexer failed");
+
+      expect(errorLog).toHaveBeenCalledTimes(1);
+      const line = errorLog.mock.calls[0]?.[0];
+      expect(line).not.toContain("super-secret-token");
+      expect(line).not.toContain("eth_getLogs");
+      expect(parseLogLine(line)).toMatchObject({
+        level: "error",
+        event: "fame-pool-state-indexed",
+        errorType: "indexer-crash",
+        errorClass: "HttpRequestError",
+        statusCode: 429,
+      });
+    } finally {
+      errorLog.mockRestore();
+    }
+  });
+});

--- a/src/fame-swap-pool-state/lambdas/indexer.ts
+++ b/src/fame-swap-pool-state/lambdas/indexer.ts
@@ -7,16 +7,112 @@ import {
   assertNoClReplaySnapshotFailures,
   createViemPoolStateIndexerClient,
   indexFamePoolStates,
+  type FamePoolStateIndexerClient,
+  type FamePoolStateIndexerResult,
 } from "../indexer.ts";
-import { logPoolStateIndexerResult } from "./logging.ts";
+import {
+  logPoolStateIndexerResult,
+  writePoolStateLog,
+  type PoolStateLogFields,
+} from "./logging.ts";
 
-export async function handler(): Promise<void> {
-  const result = await indexFamePoolStates({
-    client: createViemPoolStateIndexerClient(baseClient),
-    tableName: FAME_POOL_STATE_TABLE_NAME,
-    confirmationBlocks: FAME_POOL_STATE_CONFIRMATION_BLOCKS,
+export type FamePoolStateIndexRunner = (options: {
+  client?: FamePoolStateIndexerClient;
+  tableName: string;
+  confirmationBlocks: number;
+}) => Promise<FamePoolStateIndexerResult>;
+
+function defaultIndexPools({
+  client,
+  tableName,
+  confirmationBlocks,
+}: {
+  client?: FamePoolStateIndexerClient;
+  tableName: string;
+  confirmationBlocks: number;
+}): Promise<FamePoolStateIndexerResult> {
+  return indexFamePoolStates({
+    client: client ?? createViemPoolStateIndexerClient(baseClient),
+    tableName,
+    confirmationBlocks,
   });
+}
+
+function safeErrorClass(error: unknown): string {
+  const candidate =
+    error instanceof Error
+      ? error.name
+      : typeof error === "object" && error !== null
+        ? Reflect.get(error, "name")
+        : undefined;
+  if (typeof candidate !== "string") return "UnknownError";
+  const trimmed = candidate.trim();
+  if (!/^[A-Za-z][A-Za-z0-9_.-]{0,79}$/.test(trimmed)) {
+    return "UnknownError";
+  }
+  return trimmed;
+}
+
+function safeErrorStatusCode(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  for (const key of ["status", "statusCode"]) {
+    const value = Reflect.get(error, key);
+    if (
+      typeof value === "number" &&
+      Number.isSafeInteger(value) &&
+      value >= 100 &&
+      value <= 599
+    ) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function indexerCrashLogFields(error: unknown): PoolStateLogFields {
+  const fields: PoolStateLogFields = {
+    errorType: "indexer-crash",
+    errorClass: safeErrorClass(error),
+  };
+  const statusCode = safeErrorStatusCode(error);
+  if (statusCode !== undefined) fields.statusCode = statusCode;
+  return fields;
+}
+
+export async function handleFamePoolStateIndexer({
+  client,
+  tableName,
+  confirmationBlocks,
+  indexPools = defaultIndexPools,
+}: {
+  client?: FamePoolStateIndexerClient;
+  tableName: string;
+  confirmationBlocks: number;
+  indexPools?: FamePoolStateIndexRunner;
+}): Promise<void> {
+  let result: FamePoolStateIndexerResult;
+  try {
+    result = await indexPools({
+      client,
+      tableName,
+      confirmationBlocks,
+    });
+  } catch (error) {
+    writePoolStateLog(
+      "error",
+      "fame-pool-state-indexed",
+      indexerCrashLogFields(error),
+    );
+    throw new Error("FAME pool-state indexer failed");
+  }
 
   logPoolStateIndexerResult(result);
   assertNoClReplaySnapshotFailures(result);
+}
+
+export async function handler(): Promise<void> {
+  await handleFamePoolStateIndexer({
+    tableName: FAME_POOL_STATE_TABLE_NAME,
+    confirmationBlocks: FAME_POOL_STATE_CONFIRMATION_BLOCKS,
+  });
 }

--- a/src/fame-swap-pool-state/lambdas/indexer.ts
+++ b/src/fame-swap-pool-state/lambdas/indexer.ts
@@ -8,6 +8,7 @@ import {
   createViemPoolStateIndexerClient,
   indexFamePoolStates,
 } from "../indexer.ts";
+import { logPoolStateIndexerResult } from "./logging.ts";
 
 export async function handler(): Promise<void> {
   const result = await indexFamePoolStates({
@@ -16,15 +17,6 @@ export async function handler(): Promise<void> {
     confirmationBlocks: FAME_POOL_STATE_CONFIRMATION_BLOCKS,
   });
 
-  const payload = {
-    event: "fame-pool-state-indexed",
-    ...result,
-  };
-
-  if (result.clReplayFailedPools > 0) {
-    console.error(JSON.stringify(payload));
-    assertNoClReplaySnapshotFailures(result);
-  }
-
-  console.log(JSON.stringify(payload));
+  logPoolStateIndexerResult(result);
+  assertNoClReplaySnapshotFailures(result);
 }

--- a/src/fame-swap-pool-state/lambdas/logging.test.ts
+++ b/src/fame-swap-pool-state/lambdas/logging.test.ts
@@ -160,6 +160,30 @@ describe("FAME pool-state Lambda logging", () => {
     }
   });
 
+  test("keeps envelope fields authoritative over payload fields", () => {
+    const infoLog = jest.spyOn(console, "log").mockImplementation(() => {
+      return undefined;
+    });
+
+    try {
+      writePoolStateLog("info", "fame-pool-state-api-batch", {
+        level: "error",
+        event: "fame-pool-state-api-error",
+        timestamp: "1970-01-01T00:00:00.000Z",
+      });
+
+      expect(infoLog).toHaveBeenCalledTimes(1);
+      const entry = parseLogLine(infoLog.mock.calls[0]?.[0]);
+      expect(entry).toMatchObject({
+        level: "info",
+        event: "fame-pool-state-api-batch",
+      });
+      expect(entry.timestamp).not.toBe("1970-01-01T00:00:00.000Z");
+    } finally {
+      infoLog.mockRestore();
+    }
+  });
+
   test("skips ordinary all-fresh non-replay API success logs", () => {
     const response = batchResponse([freshReservePool()]);
     const infoLog = jest.spyOn(console, "log").mockImplementation(() => {

--- a/src/fame-swap-pool-state/lambdas/logging.test.ts
+++ b/src/fame-swap-pool-state/lambdas/logging.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import type { Address, Hex } from "viem";
+import type {
+  FamePoolStateBatchResponse,
+  FamePoolStateResponseEntry,
+} from "../api.ts";
+import type { FamePoolStateIndexerResult } from "../indexer.ts";
+import {
+  logPoolStateApiBatch,
+  logPoolStateIndexerResult,
+  poolStateApiBatchLogFields,
+  shouldLogPoolStateApiBatch,
+  writePoolStateLog,
+} from "./logging.ts";
+
+const ADDRESS_A = "0x0000000000000000000000000000000000000001" as Address;
+const ADDRESS_B = "0x0000000000000000000000000000000000000002" as Address;
+const HEX_32 =
+  "0x0000000000000000000000000000000000000000000000000000000000000000" as Hex;
+
+function parseLogLine(line: unknown): Record<string, unknown> {
+  if (typeof line !== "string") throw new Error("Expected a log string.");
+  const parsed: unknown = JSON.parse(line);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Expected a JSON object log line.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function freshReservePool(): FamePoolStateResponseEntry {
+  return {
+    status: "fresh",
+    poolId: "constant-product-pool",
+    chainId: 8453,
+    poolAddress: ADDRESS_A,
+    token0: ADDRESS_A,
+    token1: ADDRESS_B,
+    reserve0: "100",
+    reserve1: "200",
+    k: "20000",
+    observedThroughBlock: 120,
+    lastReserveChangeBlock: 119,
+    source: "getReserves",
+    quoteModel: "constant-product-reserves",
+    maxFreshnessBlocks: 120,
+  };
+}
+
+function freshReplayPool(): FamePoolStateResponseEntry {
+  return {
+    status: "fresh",
+    stateKind: "cl-replay-v1",
+    poolId: "slipstream-usdc-weth-100",
+    chainId: 8453,
+    poolAddress: ADDRESS_A,
+    token0: ADDRESS_A,
+    token1: ADDRESS_B,
+    venueFamily: "Slipstream",
+    tickSpacing: 1,
+    sqrtPriceX96: "100",
+    tick: 1,
+    liquidity: "1000",
+    fee: "100",
+    feeSource: "pool-fee",
+    observedThroughBlock: 120,
+    blockHash: HEX_32,
+    parentHash: HEX_32,
+    snapshotId: "cl-replay-v1:slipstream-usdc-weth-100:120",
+    stateHash: HEX_32,
+    source: "slipstream-pool-state",
+    sourceRegistryId: "registry",
+    maxFreshnessBlocks: 120,
+    bitmapWordCount: 2,
+    initializedTickCount: 3,
+    bitmapChunkCount: 1,
+    tickChunkCount: 1,
+    minWordPosition: -1,
+    maxWordPosition: 1,
+    minTick: -100,
+    maxTick: 100,
+    bitmapWords: [
+      {
+        wordPosition: 0,
+        bitmap: HEX_32,
+      },
+    ],
+    initializedTicks: [
+      {
+        tick: -100,
+        liquidityGross: "1",
+        liquidityNet: "1",
+      },
+    ],
+  };
+}
+
+function batchResponse(
+  pools: FamePoolStateResponseEntry[],
+): FamePoolStateBatchResponse {
+  return {
+    sourceRegistryId: "registry",
+    currentBlock: 121,
+    producerMaxFreshnessBlocks: 120,
+    effectiveMaxFreshnessBlocks: 120,
+    pools,
+  };
+}
+
+function indexerResult(
+  overrides: Partial<FamePoolStateIndexerResult> = {},
+): FamePoolStateIndexerResult {
+  return {
+    chainId: 8453,
+    durationMs: 100,
+    fromBlock: 100,
+    observedThroughBlock: 120,
+    syncEvents: 1,
+    writtenEvents: 1,
+    ignoredEvents: 0,
+    seededPools: 0,
+    reconciledPools: 1,
+    observedPools: 1,
+    clHeadSnapshots: 1,
+    clHeadWrittenPools: 1,
+    clHeadFailedPools: 0,
+    clHeadFailures: [],
+    clReplaySnapshots: 1,
+    clReplayWrittenPools: 1,
+    clReplayFailedPools: 0,
+    clReplayFailures: [],
+    clReplayMetrics: [],
+    sourceRegistryId: "registry",
+    ...overrides,
+  };
+}
+
+describe("FAME pool-state Lambda logging", () => {
+  test("writes structured log envelopes with level, event, and timestamp", () => {
+    const infoLog = jest.spyOn(console, "log").mockImplementation(() => {
+      return undefined;
+    });
+
+    try {
+      writePoolStateLog("info", "fame-pool-state-api-batch", {
+        sourceRegistryId: "registry",
+        batchSize: 1,
+      });
+
+      expect(infoLog).toHaveBeenCalledTimes(1);
+      const entry = parseLogLine(infoLog.mock.calls[0]?.[0]);
+      expect(entry).toMatchObject({
+        level: "info",
+        event: "fame-pool-state-api-batch",
+        sourceRegistryId: "registry",
+        batchSize: 1,
+      });
+      expect(typeof entry.timestamp).toBe("string");
+    } finally {
+      infoLog.mockRestore();
+    }
+  });
+
+  test("skips ordinary all-fresh non-replay API success logs", () => {
+    const response = batchResponse([freshReservePool()]);
+    const infoLog = jest.spyOn(console, "log").mockImplementation(() => {
+      return undefined;
+    });
+
+    try {
+      expect(shouldLogPoolStateApiBatch(response)).toBe(false);
+      logPoolStateApiBatch(response);
+      expect(infoLog).not.toHaveBeenCalled();
+    } finally {
+      infoLog.mockRestore();
+    }
+  });
+
+  test("summarizes fresh replay API responses without raw tick payloads", () => {
+    const response = batchResponse([freshReplayPool()]);
+    const infoLog = jest.spyOn(console, "log").mockImplementation(() => {
+      return undefined;
+    });
+
+    try {
+      expect(shouldLogPoolStateApiBatch(response)).toBe(true);
+      expect(poolStateApiBatchLogFields(response)).toMatchObject({
+        clReplay: {
+          returned: 1,
+          fresh: 1,
+          stale: 0,
+          bitmapWordCount: 2,
+          initializedTickCount: 3,
+        },
+      });
+
+      logPoolStateApiBatch(response);
+
+      expect(infoLog).toHaveBeenCalledTimes(1);
+      const line = infoLog.mock.calls[0]?.[0];
+      expect(line).not.toContain("bitmapWords");
+      expect(line).not.toContain("initializedTicks");
+      expect(parseLogLine(line)).toMatchObject({
+        level: "info",
+        event: "fame-pool-state-api-batch",
+        statusCounts: {
+          fresh: 1,
+        },
+      });
+    } finally {
+      infoLog.mockRestore();
+    }
+  });
+
+  test("keeps stale, unknown, and unsupported API responses visible", () => {
+    const response = batchResponse([
+      {
+        status: "unsupported",
+        poolId: "stable-pool",
+        chainId: 8453,
+        poolAddress: ADDRESS_A,
+        unsupportedReason: "stable-pool",
+      },
+    ]);
+
+    expect(shouldLogPoolStateApiBatch(response)).toBe(true);
+    expect(poolStateApiBatchLogFields(response)).toMatchObject({
+      statusCounts: {
+        unsupported: 1,
+      },
+    });
+  });
+
+  test("logs indexer replay failures once at error level", () => {
+    const errorLog = jest.spyOn(console, "error").mockImplementation(() => {
+      return undefined;
+    });
+    const infoLog = jest.spyOn(console, "log").mockImplementation(() => {
+      return undefined;
+    });
+
+    try {
+      logPoolStateIndexerResult(
+        indexerResult({
+          clReplayFailedPools: 1,
+          clReplayFailures: [
+            {
+              poolId: "slipstream-usdc-weth-100",
+              message: "snapshot failed",
+            },
+          ],
+        }),
+      );
+
+      expect(errorLog).toHaveBeenCalledTimes(1);
+      expect(infoLog).not.toHaveBeenCalled();
+      expect(parseLogLine(errorLog.mock.calls[0]?.[0])).toMatchObject({
+        level: "error",
+        event: "fame-pool-state-indexed",
+        clReplayFailedPools: 1,
+      });
+    } finally {
+      errorLog.mockRestore();
+      infoLog.mockRestore();
+    }
+  });
+});

--- a/src/fame-swap-pool-state/lambdas/logging.ts
+++ b/src/fame-swap-pool-state/lambdas/logging.ts
@@ -107,10 +107,10 @@ export function writePoolStateLog(
   fields: PoolStateLogFields,
 ): void {
   const line = JSON.stringify({
+    ...fields,
     level,
     event,
     timestamp: new Date().toISOString(),
-    ...fields,
   });
 
   if (level === "error") {

--- a/src/fame-swap-pool-state/lambdas/logging.ts
+++ b/src/fame-swap-pool-state/lambdas/logging.ts
@@ -1,0 +1,190 @@
+import type {
+  FamePoolStateBatchResponse,
+  FamePoolStateResponseEntry,
+} from "../api.ts";
+import type { FamePoolStateIndexerResult } from "../indexer.ts";
+
+export type PoolStateLogLevel = "error" | "info" | "warn";
+export type PoolStateLogEvent =
+  | "fame-pool-state-api-batch"
+  | "fame-pool-state-api-error"
+  | "fame-pool-state-indexed";
+
+type PoolStateLogValue =
+  | boolean
+  | null
+  | number
+  | string
+  | PoolStateLogValue[]
+  | PoolStateLogFields;
+
+export interface PoolStateLogFields {
+  [key: string]: PoolStateLogValue;
+}
+
+interface ClReplayLogSummary extends PoolStateLogFields {
+  returned: number;
+  fresh: number;
+  stale: number;
+  bitmapWordCount: number;
+  initializedTickCount: number;
+  bitmapChunkCount: number;
+  tickChunkCount: number;
+}
+
+type ClReplayResponseEntry = Extract<
+  FamePoolStateResponseEntry,
+  { stateKind: "cl-replay-v1" }
+>;
+
+function statusCounts(response: Pick<FamePoolStateBatchResponse, "pools">) {
+  const counts: Record<string, number> = {};
+  for (const pool of response.pools) {
+    counts[pool.status] = (counts[pool.status] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function isClReplayResponse(
+  pool: FamePoolStateResponseEntry,
+): pool is ClReplayResponseEntry {
+  return "stateKind" in pool && pool.stateKind === "cl-replay-v1";
+}
+
+function clReplaySummary(
+  response: Pick<FamePoolStateBatchResponse, "pools">,
+): ClReplayLogSummary | null {
+  const summary: ClReplayLogSummary = {
+    returned: 0,
+    fresh: 0,
+    stale: 0,
+    bitmapWordCount: 0,
+    initializedTickCount: 0,
+    bitmapChunkCount: 0,
+    tickChunkCount: 0,
+  };
+
+  for (const pool of response.pools) {
+    if (!isClReplayResponse(pool)) continue;
+    summary.returned += 1;
+    if (pool.status === "fresh") summary.fresh += 1;
+    if (pool.status === "stale") summary.stale += 1;
+    summary.bitmapWordCount += pool.bitmapWordCount;
+    summary.initializedTickCount += pool.initializedTickCount;
+    summary.bitmapChunkCount += pool.bitmapChunkCount;
+    summary.tickChunkCount += pool.tickChunkCount;
+  }
+
+  return summary.returned > 0 ? summary : null;
+}
+
+export function shouldLogPoolStateApiBatch(
+  response: FamePoolStateBatchResponse,
+): boolean {
+  return response.pools.some(
+    (pool) => pool.status !== "fresh" || isClReplayResponse(pool),
+  );
+}
+
+export function poolStateApiBatchLogFields(
+  response: FamePoolStateBatchResponse,
+): PoolStateLogFields {
+  const fields: PoolStateLogFields = {
+    sourceRegistryId: response.sourceRegistryId,
+    currentBlock: response.currentBlock,
+    effectiveMaxFreshnessBlocks: response.effectiveMaxFreshnessBlocks,
+    batchSize: response.pools.length,
+    statusCounts: statusCounts(response),
+  };
+  const replay = clReplaySummary(response);
+  if (replay) fields.clReplay = replay;
+  return fields;
+}
+
+export function writePoolStateLog(
+  level: PoolStateLogLevel,
+  event: PoolStateLogEvent,
+  fields: PoolStateLogFields,
+): void {
+  const line = JSON.stringify({
+    level,
+    event,
+    timestamp: new Date().toISOString(),
+    ...fields,
+  });
+
+  if (level === "error") {
+    console.error(line);
+    return;
+  }
+
+  if (level === "warn") {
+    console.warn(line);
+    return;
+  }
+
+  console.log(line);
+}
+
+function indexerResultLogFields(
+  result: FamePoolStateIndexerResult,
+): PoolStateLogFields {
+  return {
+    chainId: result.chainId,
+    durationMs: result.durationMs,
+    fromBlock: result.fromBlock,
+    observedThroughBlock: result.observedThroughBlock,
+    syncEvents: result.syncEvents,
+    writtenEvents: result.writtenEvents,
+    ignoredEvents: result.ignoredEvents,
+    seededPools: result.seededPools,
+    reconciledPools: result.reconciledPools,
+    observedPools: result.observedPools,
+    clHeadSnapshots: result.clHeadSnapshots,
+    clHeadWrittenPools: result.clHeadWrittenPools,
+    clHeadFailedPools: result.clHeadFailedPools,
+    clHeadFailures: result.clHeadFailures.map((failure) => ({
+      poolId: failure.poolId,
+      message: failure.message,
+    })),
+    clReplaySnapshots: result.clReplaySnapshots,
+    clReplayWrittenPools: result.clReplayWrittenPools,
+    clReplayFailedPools: result.clReplayFailedPools,
+    clReplayFailures: result.clReplayFailures.map((failure) => ({
+      poolId: failure.poolId,
+      message: failure.message,
+    })),
+    clReplayMetrics: result.clReplayMetrics.map((metric) => ({
+      poolId: metric.poolId,
+      bitmapWordCount: metric.bitmapWordCount,
+      initializedTickCount: metric.initializedTickCount,
+      bitmapChunkCount: metric.bitmapChunkCount,
+      tickChunkCount: metric.tickChunkCount,
+      providerReadCount: metric.providerReadCount,
+      durationMs: metric.durationMs,
+      stateHash: metric.stateHash,
+    })),
+    sourceRegistryId: result.sourceRegistryId,
+  };
+}
+
+export function logPoolStateApiBatch(
+  response: FamePoolStateBatchResponse,
+): void {
+  if (!shouldLogPoolStateApiBatch(response)) return;
+  writePoolStateLog(
+    "info",
+    "fame-pool-state-api-batch",
+    poolStateApiBatchLogFields(response),
+  );
+}
+
+export function logPoolStateIndexerResult(
+  result: FamePoolStateIndexerResult,
+): void {
+  writePoolStateLog(
+    result.clReplayFailedPools > 0 ? "error" : "info",
+    "fame-pool-state-indexed",
+    indexerResultLogFields(result),
+  );
+}


### PR DESCRIPTION
## Summary

FAME pool-state and eventing logs now have an explicit retention policy instead of relying on Lambda-created default log groups. The replay-tick and Base-heavy surfaces are bounded to 7 days, while Ethereum, mixed-chain, and Discord/app-audit surfaces keep 30 days for incident review.

This also makes the pool-state replay logs less chunky: routine all-fresh reserve helper traffic no longer emits INFO, replay responses log compact counts instead of tick payloads, and failures keep stable `level`/`event` envelopes for CloudWatch filtering. The quote-helper contract and `www` fallback behavior are unchanged.

## What Changed

| Area | Result |
| --- | --- |
| CDK retention | Active Lambda constructs now pass CDK-owned `LogGroup` resources through Lambda `LoggingConfig`. |
| Retention classes | Replay-tick and Base operational logs retain 7 days; Ethereum, mixed-chain, and app-audit logs retain 30 days. |
| Guardrails | CDK tests assert retention, deletion behavior, Lambda/log-group wiring, and future active Lambda constructor blocks with no `logGroup`. |
| Pool-state logs | API/indexer logs keep stable event names while adding `level` and `timestamp`; raw replay ticks and raw request bodies stay out of logs. |
| Runbook | The pool-state index doc now includes the retention table and deploy smoke checks. |

## Validation

- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn test --runInBand --runTestsByPath src/fame-swap-pool-state/lambdas/logging.test.ts src/fame-swap-pool-state/lambdas/api.test.ts src/fame-swap-pool-state/api.test.ts src/fame-swap-pool-state/indexer.test.ts src/fame-swap-pool-state/dynamodb/pool-state.test.ts src/fame-swap-pool-state/registry/index.test.ts`
- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn test --runTestsByPath test/log-retention.test.ts test/fame-pool-state.test.ts` from `deploy/`
- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn types`
- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn build` from `deploy/`
- `git diff --cached --check`

## Post-Deploy Monitoring & Validation

Validation window: first pool-state dev deploy plus one short soak of at least five scheduled indexer intervals. Owner: PR deploy operator.

Healthy signals:

- CloudWatch log groups for `FamePoolStateIndexer`, `FamePoolStateApi`, and `FamePoolStateApiAuthorizer` show 7-day retention.
- Base image operational log groups show 7-day retention.
- Discord/app-audit, Ethereum, and mixed-chain eventing log groups show 30-day retention.
- `fame-pool-state-indexed` logs continue to advance or hold `observedThroughBlock` without regression.
- Replay API success logs include compact `clReplay` counts and do not contain `bitmapWords` or `initializedTicks`.
- Ordinary all-fresh non-replay API helper batches do not produce high-volume INFO logs.

Failure signals and mitigation:

- Missing managed log group or wrong retention: halt promotion and correct the construct classification before enabling the deploy.
- Lambda logging points back to an implicit default group: halt promotion; the retention guard should be extended for the missed surface.
- Replay failures rise after deploy: inspect `level:error event:fame-pool-state-indexed` and fall back to live quote behavior on the `www` side as designed.
- API dependency errors appear: inspect `level:error event:fame-pool-state-api-error`, confirm DynamoDB/table permissions and helper auth, and leave `www` on live fallback until resolved.

Useful CloudWatch searches:

- `event = "fame-pool-state-indexed"`
- `level = "error" and event = "fame-pool-state-indexed"`
- `event = "fame-pool-state-api-batch" and clReplay.returned > 0`
- `event = "fame-pool-state-api-error"`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
