### PR TITLE
feat(fame): expose compact CL pool quotes

### DIFF
--- a/deploy/lib/fame-pool-state-dev-stack.ts
+++ b/deploy/lib/fame-pool-state-dev-stack.ts
@@ -48,6 +48,9 @@ export class FamePoolStateDevStack extends cdk.Stack {
       authorizer,
     });
 
+    new cdk.CfnOutput(this, "FamePoolApiDevBaseUrl", {
+      value: httpApi.apiEndpoint,
+    });
     new cdk.CfnOutput(this, "FamePoolStateDevEndpointUrl", {
       value: cdk.Fn.join("", [httpApi.apiEndpoint, "/fame/pool-state"]),
     });

--- a/deploy/lib/fame-pool-state-dev-stack.ts
+++ b/deploy/lib/fame-pool-state-dev-stack.ts
@@ -38,8 +38,21 @@ export class FamePoolStateDevStack extends cdk.Stack {
       authorizer,
     });
 
+    httpApi.addRoutes({
+      path: "/fame/pool-quotes",
+      methods: [apigw2.HttpMethod.POST],
+      integration: new HttpLambdaIntegration(
+        "fame-pool-quotes-dev",
+        poolState.apiLambda,
+      ),
+      authorizer,
+    });
+
     new cdk.CfnOutput(this, "FamePoolStateDevEndpointUrl", {
       value: cdk.Fn.join("", [httpApi.apiEndpoint, "/fame/pool-state"]),
+    });
+    new cdk.CfnOutput(this, "FamePoolQuotesDevEndpointUrl", {
+      value: cdk.Fn.join("", [httpApi.apiEndpoint, "/fame/pool-quotes"]),
     });
   }
 }

--- a/deploy/lib/http-api.ts
+++ b/deploy/lib/http-api.ts
@@ -116,6 +116,16 @@ export class HttpApi extends Construct {
       authorizer: famePoolStateAuthorizer,
     });
 
+    httpApi.addRoutes({
+      path: "/fame/pool-quotes",
+      methods: [apigw2.HttpMethod.POST],
+      integration: new HttpLambdaIntegration(
+        "fame-pool-quotes",
+        famePoolStateHandler,
+      ),
+      authorizer: famePoolStateAuthorizer,
+    });
+
     new route53.ARecord(this, "AliasIPv4Record", {
       zone: hostedZone,
       target: route53.RecordTarget.fromAlias(

--- a/deploy/test/fame-pool-state.test.ts
+++ b/deploy/test/fame-pool-state.test.ts
@@ -226,7 +226,7 @@ describe("FamePoolState infrastructure", () => {
     expectOutputMatching(template, "FamePoolStateIndexerFailureQueueAlarmName");
   });
 
-  test("wires the FAME pool-state API route", () => {
+  test("wires the FAME pool-state API routes", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "TestStack", {
       env: {
@@ -262,6 +262,10 @@ describe("FamePoolState infrastructure", () => {
       RouteKey: "POST /fame/pool-state",
       AuthorizationType: "CUSTOM",
     });
+    template.hasResourceProperties("AWS::ApiGatewayV2::Route", {
+      RouteKey: "POST /fame/pool-quotes",
+      AuthorizationType: "CUSTOM",
+    });
     template.hasResourceProperties("AWS::ApiGatewayV2::Authorizer", {
       IdentitySource: ["$request.header.Authorization"],
     });
@@ -292,10 +296,15 @@ describe("FamePoolState infrastructure", () => {
         RouteKey: "POST /fame/pool-state",
         AuthorizationType: "CUSTOM",
       });
+      template.hasResourceProperties("AWS::ApiGatewayV2::Route", {
+        RouteKey: "POST /fame/pool-quotes",
+        AuthorizationType: "CUSTOM",
+      });
       template.hasResourceProperties("AWS::ApiGatewayV2::Authorizer", {
         IdentitySource: ["$request.header.Authorization"],
       });
       expectOutputMatching(template, "FamePoolStateDevEndpointUrl");
+      expectOutputMatching(template, "FamePoolQuotesDevEndpointUrl");
     } finally {
       if (previousBaseRpcsJson === undefined) delete process.env.BASE_RPCS_JSON;
       else process.env.BASE_RPCS_JSON = previousBaseRpcsJson;

--- a/deploy/test/fame-pool-state.test.ts
+++ b/deploy/test/fame-pool-state.test.ts
@@ -308,6 +308,7 @@ describe("FamePoolState infrastructure", () => {
       template.hasResourceProperties("AWS::ApiGatewayV2::Authorizer", {
         IdentitySource: ["$request.header.Authorization"],
       });
+      expectOutputMatching(template, "FamePoolApiDevBaseUrl");
       expectOutputMatching(template, "FamePoolStateDevEndpointUrl");
       expectOutputMatching(template, "FamePoolQuotesDevEndpointUrl");
     } finally {

--- a/docs/fame-pool-state-index.md
+++ b/docs/fame-pool-state-index.md
@@ -5,6 +5,7 @@
 ## Scope
 
 - Quote-model reserve pools: Uniswap V2, volatile Solidly/Equalizer, and volatile Aerodrome V2.
+- Compact quote rows: `/fame/pool-quotes` returns `constant-product-quote-v1` rows for quote-model reserve pools and `cl-quote-v1` rows for `slipstream-usdc-weth-100`.
 - Concentrated-liquidity head snapshots: Slipstream, Slipstream2, Uniswap V3, and Uniswap V4 pools with reviewed fee metadata.
 - Concentrated-liquidity replay snapshots: exactly `slipstream-usdc-weth-100` with complete safe-block `cl-replay-v1` state for the first proof.
 - Tracked-only pools: stable Solidly, native wrap, pools missing reviewed CL metadata, and unknown unsupported invariants.
@@ -16,6 +17,7 @@
 - The indexer scans Base `Sync` logs for quote-model pools, reconciles every quote-model pool with `getReserves` at the safe block, writes monotonic latest rows when reserves drift or rows are missing, updates `observedThroughBlock`, records complete CL head snapshots at the same safe block, captures a full `cl-replay-v1` Slipstream snapshot for `slipstream-usdc-weth-100`, and advances a cursor only after reserve reconciliation succeeds.
 - The replay snapshot lane reads slot0, current liquidity, dynamic pool fee, the full initialized tick bitmap word range, and initialized tick liquidity records at one safe block. It writes bitmap/tick chunks first, then publishes the latest replay pointer so the API never returns a partial snapshot as fresh replay state.
 - The API serves bounded batch reads to server-side `www` callers. API Gateway uses a Lambda authorizer for the same service token before invoking the API Lambda, and the API Lambda keeps its own token check as defense in depth. The token must be supplied through `Authorization: Bearer <token>`.
+- The API Lambda dispatches only `/fame/pool-state` and `/fame/pool-quotes`; unknown paths return an invalid-request error instead of falling through to pool-state handling.
 - The indexer has SQS-backed async failure destinations plus passive CloudWatch alarms for Lambda errors, Lambda throttles, missed invocations, and non-empty failure queue depth. These alarms have no notification action by default; they are an inspectable health surface for a free community service.
 - The CloudWatch log groups for active Lambdas are CDK-owned with explicit retention and destroy-on-stack-deletion behavior. This hardening does not change `www` quote authority, helper response contracts, route ranking, fallback behavior, or replay tick maintenance.
 
@@ -30,6 +32,7 @@ Freshness is based on `observedThroughBlock`, not `lastReserveChangeBlock`.
 - CL head snapshots intentionally do not include tick boundary warnings. They are a head state surface, not local CL replay authority; clients still fall back to live reads whenever they cannot use indexed state.
 - `cl-replay-v1` snapshots use the same freshness rule, but they are a separate opt-in state surface. A complete replay response includes block hash, parent hash, state hash, dynamic fee, head state, bitmap word range, initialized tick range, chunk counts, bitmap words, and initialized tick liquidity data.
 - Missing chunks, mismatched block/hash/provenance, malformed fee or liquidity strings, stale/future block state, or a source registry mismatch make replay state unavailable to `www`; `www` must fall back to its live quoter.
+- Reserve compact quotes use the same freshness rule as reserve pool-state rows. Missing rows, stale/future rows, source registry mismatches, token direction mismatches, malformed reserves, or zero-output reserve math return `unavailable` quote rows so `www` can fall back live per edge.
 - The producer default is `FAME_POOL_STATE_DEFAULT_MAX_FRESHNESS_BLOCKS`, currently deployed as `120` unless overridden.
 - Callers may request stricter freshness; they cannot loosen the producer default.
 
@@ -39,6 +42,17 @@ Freshness is based on `observedThroughBlock`, not `lastReserveChangeBlock`.
 - `stale`: indexed row exists but is outside the freshness bound, including rows whose `observedThroughBlock` is greater than the caller's `currentBlock`. `www` should fall back to live reads.
 - `unknown`: pool is absent from the registry or has no indexed row yet.
 - `unsupported`: pool is reviewed but not eligible for the requested indexed state surface.
+- `/fame/pool-quotes` uses quote-specific row statuses: `quoted` rows contain compact quote output and provenance; `unavailable` rows contain the original request, enum reason, and bounded pool/freshness metadata when available.
+
+## Compact Quote Rows
+
+`/fame/pool-quotes` is the hot-path quote surface. It does not return raw reserve pairs, `k`, raw tick arrays, bitmap words, helper URLs, service tokens, or request/response bodies.
+
+Reserve quote-model pools return `constant-product-quote-v1` rows when fresh matching reserve state is available. Each row includes pool identity, token direction, `amountIn`, `amountOut`, `quoteModel: "constant-product-reserves"`, `quoteModelVersion: 1`, `feeBps`, `feeSource: "registry-fee"`, `stateSource`, `observedThroughBlock`, source registry id, price-impact fields, and safe protocol evidence. The quote math matches the existing `www` constant-product reserve adapter: input fee in basis points is applied before the invariant quote, while price-impact evidence uses full input amount against pre/post reserves.
+
+`slipstream-usdc-weth-100` keeps its existing `cl-quote-v1` compact row shape and still omits raw replay arrays. Other reviewed-but-unquoted pools return `unavailable` with an enum reason such as `unsupported-pool`, `missing-indexed-state`, `stale-indexed-state`, `source-registry-mismatch`, `token-direction-mismatch`, `malformed-reserve-state`, `reserve-quote-failed`, `malformed-replay-state`, `outside-indexed-tick-range`, or `replay-failed`.
+
+The versioned producer fixture at `src/fame-swap-pool-state/fixtures/pool-quotes-v1.json` locks the reserve quote row shape and exact amount/price-impact semantics for every reserve quote-model pool in both directions.
 
 ## Logs
 
@@ -48,13 +62,14 @@ Indexer logs use `event: "fame-pool-state-indexed"` with chain id, block range, 
 
 API success logs use `event: "fame-pool-state-api-batch"` with registry id, current block, effective freshness, batch size, status counts, and compact replay counts when `cl-replay-v1` state is returned. Ordinary all-fresh non-replay batches are not logged at INFO. Replay responses, stale rows, unknown rows, unsupported rows, malformed requests, and dependency failures remain operator-visible.
 
-API transport failures are classified separately from per-pool fallback statuses:
+API transport failures are classified separately from per-pool or per-quote fallback statuses:
 
 - `400`: malformed JSON, invalid request shape, or batch limit violations.
 - `401`: missing or incorrect service token.
 - `5xx`: internal or dependency failure, including incomplete DynamoDB batch reads.
+- unknown routes: `400` invalid request; the Lambda never defaults an unknown path to pool-state handling.
 
-`fresh`, `stale`, `unknown`, and `unsupported` stay inside successful batch responses. `www` should treat non-successful transport responses as non-authoritative helper output and fall back to live reads.
+`fresh`, `stale`, `unknown`, and `unsupported` stay inside successful pool-state batch responses. `quoted` and `unavailable` stay inside successful pool-quote batch responses. `www` should treat non-successful transport responses as non-authoritative helper output and fall back to live reads.
 
 ## CloudWatch Retention
 
@@ -94,7 +109,7 @@ Do not add email, pager, or chat notification actions for the first release unle
 6. Confirm PR deploy uses `STAGE=PR-<number>` and cleanup targets only `Bot-PR-<number>` / `BotCert-PR-<number>`.
 7. Set or generate the dev service token first as `FAME_POOL_STATE_DEV_SERVICE_TOKEN`.
 8. For pool-state-only pre-merge validation, add the PR label `DEPLOY_POOL_STATE_DEV`. This deploys `BotPoolStateDev` with only `BASE_RPCS_JSON` and `FAME_POOL_STATE_DEV_SERVICE_TOKEN`; it does not require image, Discord, Farcaster, custom domain, or cert env.
-9. Copy the emitted `FamePoolStateDevEndpointUrl` `/fame/pool-state` endpoint into `www` dev as server-only `FAME_POOL_STATE_API_URL`, and set the matching `FAME_POOL_STATE_SERVICE_TOKEN`.
+9. Copy the emitted `FamePoolApiDevBaseUrl` value into `www` dev as server-only `FAME_POOL_API_URL`, and set the matching `FAME_POOL_STATE_SERVICE_TOKEN`. Do not copy an endpoint-specific `/fame/pool-state` or `/fame/pool-quotes` URL into `FAME_POOL_API_URL`.
 10. For full messy app validation, add the PR label `DEPLOY_DEV` to update `Bot-dev` / `BotCert-dev` at `dev.fame.support` with event schedules disabled.
 11. Deploy `society-bots` with Base RPCs and the correct environment-scoped FAME pool-state service token.
 12. Capture smoke evidence:
@@ -118,15 +133,17 @@ Do not add email, pager, or chat notification actions for the first release unle
 - failure queue depth;
 - any RPC timeout, throttle, or cursor-lag notes.
 
-14. Run `www` route lab with `--indexed`, `BASE_RPC_URL` or `FAME_POOL_STATE_CURRENT_BLOCK`, and production-like helper env. Confirm the indexed summary reports `cl replay slipstream-usdc-weth-100 ...` while selected CL quotes remain live or recorded in shadow mode.
-15. Run `www` CL replay parity with `bun scripts/fame-swap-cl-replay-parity.ts` and production-like helper/RPC env. Promotion requires exact same-block `amountOut` equality for both WETH -> USDC and USDC -> WETH amount bands.
-16. Run a `www` quote API smoke check.
+14. Run `www` route lab with `--indexed`, `BASE_RPC_URL` or `FAME_POOL_STATE_CURRENT_BLOCK`, and production-like helper env. The tool derives proof-only raw-state reads from `FAME_POOL_API_URL` plus `/fame/pool-state`; confirm the indexed summary reports `cl replay slipstream-usdc-weth-100 ...` while selected CL quotes remain live or recorded in shadow mode.
+15. Run `www` CL replay parity with `bun scripts/fame-swap-cl-replay-parity.ts` and production-like helper/RPC env. The tool also derives `/fame/pool-state` from the same `FAME_POOL_API_URL` base. Promotion requires exact same-block `amountOut` equality for both WETH -> USDC and USDC -> WETH amount bands.
+16. Run a `www` quote API smoke check against `/fame/pool-quotes`.
 17. Record route-lab and parity evidence locations in the PR or release checklist. Evidence must cover indexed success plus fallback-relevant stale, unknown, unsupported, malformed, incomplete replay, and unavailable-helper cases.
-18. Enable `www` server env `FAME_POOL_STATE_API_URL` and `FAME_POOL_STATE_SERVICE_TOKEN` only after route-lab and parity proof are attached. Do not create `NEXT_PUBLIC_` variants.
+18. Enable `www` server env `FAME_POOL_API_URL` and `FAME_POOL_STATE_SERVICE_TOKEN` only after route-lab and parity proof are attached. Do not create `NEXT_PUBLIC_` variants.
 
 ## Durable Follow-Ups
 
 - Fix PR cleanup so `BotCert-PR-<number>` is deleted in `us-east-1`, and stop swallowing unexpected CloudFormation delete/wait failures with blanket `|| true`.
 - Make malformed V4 registry rows impossible or explicitly rejected when they contain both `poolAddress` and `poolKey`; V4 CL head state should remain pool-key keyed instead of address keyed.
 - Parallelize the independent reserve-state and CL head-state DynamoDB `BatchGet` calls if helper latency from CL opt-in becomes material.
+- Split reserve compact-quote unavailable reasons from CL replay reasons, and keep quoted reserve rows on a non-null post-swap price contract with fixture coverage for malformed reserves and zero-output math.
+- Bound dense CL quote replay work before broadening CL support: parse tick state once per pool/batch, use cursor or binary-search traversal rather than repeated full scans, and cap crossed ticks/work before Lambda timeout.
 - After exact same-block parity is proven for `slipstream-usdc-weth-100`, evaluate event-driven tick maintenance, bounded tick-window snapshots, shared CL math extraction, cached route pruning, quote heatmaps, historical liquidity charts, and route-level market-state dashboards.

--- a/src/fame-swap-pool-state/api.test.ts
+++ b/src/fame-swap-pool-state/api.test.ts
@@ -3,6 +3,7 @@ import { BatchGetCommand } from "@aws-sdk/lib-dynamodb";
 import type { Address } from "viem";
 import { handleFamePoolStateBatchRequest } from "./api.ts";
 import { poolStateRequestAuthorized } from "./auth.ts";
+import { handleFamePoolQuoteBatchRequest } from "./cl-quote.ts";
 import {
   clReplayStateRowsFromSnapshot,
   latestClHeadStateFromSnapshot,
@@ -237,6 +238,36 @@ function clReplayRowsForPool(pool: FameClReplayRegistryEntry) {
   });
 }
 
+function quoteClReplayRowsForPool(pool: FameClReplayRegistryEntry) {
+  return clReplayStateRowsFromSnapshot({
+    pool,
+    sqrtPriceX96: 2n ** 96n,
+    tick: 0,
+    liquidity: 1_000_000_000_000_000_000n,
+    fee: 100n,
+    observedThroughBlock: 120,
+    blockHash:
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    parentHash:
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    snapshotId: "unit-cl-quote",
+    stateHash:
+      "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    bitmapWords: [
+      { wordPosition: -1, bitmap: 1n << 255n },
+      { wordPosition: 0, bitmap: 2n },
+    ],
+    initializedTicks: [
+      { tick: -100, liquidityGross: 1_000n, liquidityNet: -1_000n },
+      { tick: 100, liquidityGross: 1_000n, liquidityNet: 1_000n },
+    ],
+    bitmapChunkSize: 1,
+    tickChunkSize: 1,
+  });
+}
+
 describe("FAME pool-state API contract", () => {
   test("authorizes bearer tokens from the Authorization header", () => {
     expect(
@@ -395,6 +426,248 @@ describe("FAME pool-state API contract", () => {
         { tick: 200_000, liquidityGross: "50", liquidityNet: "-15" },
       ],
     });
+  });
+
+  test("returns compact CL quotes without raw replay arrays", async () => {
+    const pool = clReplayPool();
+    const rows = quoteClReplayRowsForPool(pool);
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 125,
+        quotes: [
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "1000000",
+          },
+          {
+            poolId: pool.id,
+            tokenIn: pool.token1,
+            tokenOut: pool.token0,
+            amountIn: "1000000",
+          },
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "10000000000000000",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([
+        rows.latest,
+        ...rows.bitmapChunks,
+        ...rows.tickChunks,
+      ]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes).toHaveLength(3);
+    const [directQuote, reverseQuote, crossingQuote] = response.quotes.map(
+      (quote) => {
+        expect(quote).toMatchObject({
+          status: "quoted",
+          quoteKind: "cl-quote-v1",
+          poolId: pool.id,
+          poolAddress: pool.poolAddress,
+          sqrtPriceX96: (2n ** 96n).toString(),
+          observedThroughBlock: 120,
+          snapshotId: "unit-cl-quote",
+          sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+          maxFreshnessBlocks: 120,
+        });
+        expect(quote).not.toHaveProperty("bitmapWords");
+        expect(quote).not.toHaveProperty("initializedTicks");
+        if (quote.status !== "quoted") {
+          throw new Error("Expected quoted CL quote.");
+        }
+        return quote;
+      },
+    );
+    expect(directQuote).toMatchObject({
+      tokenIn: pool.token0,
+      tokenOut: pool.token1,
+      amountIn: "1000000",
+      amountOut: "999899",
+      sqrtPriceX96After: "79228162514185117353846016638",
+    });
+    expect(reverseQuote).toMatchObject({
+      tokenIn: pool.token1,
+      tokenOut: pool.token0,
+      amountIn: "1000000",
+      amountOut: "999899",
+      sqrtPriceX96After: "79228162514343557833241963247",
+    });
+    expect(crossingQuote).toMatchObject({
+      tokenIn: pool.token0,
+      tokenOut: pool.token1,
+      amountIn: "10000000000000000",
+      amountOut: "9900009801989901",
+      sqrtPriceX96After: "78443802928779472160203450183",
+    });
+  });
+
+  test("returns unavailable CL quotes for stale replay state without loading chunks", async () => {
+    const pool = clReplayPool();
+    const rows = quoteClReplayRowsForPool(pool);
+    const db = new BatchStateDb([rows.latest]);
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 500,
+        quotes: [
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "1000000",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db,
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes[0]).toMatchObject({
+      status: "unavailable",
+      reason: "stale-indexed-state",
+      requested: {
+        poolId: pool.id,
+        tokenIn: pool.token0,
+        tokenOut: pool.token1,
+        amountIn: "1000000",
+      },
+      observedThroughBlock: 120,
+      maxFreshnessBlocks: 120,
+    });
+    expect(db.readCount).toBe(1);
+  });
+
+  test("returns unavailable CL quotes for incomplete replay capsules", async () => {
+    const pool = clReplayPool();
+    const rows = quoteClReplayRowsForPool(pool);
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 125,
+        quotes: [
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "1000000",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([rows.latest, ...rows.bitmapChunks]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes[0]).toMatchObject({
+      status: "unavailable",
+      reason: "missing-indexed-state",
+      poolId: pool.id,
+      observedThroughBlock: 120,
+    });
+  });
+
+  test("returns unavailable CL quotes for unsupported or unknown pools", async () => {
+    const pool = quotePool("uniswap-v2-fame-direct");
+    const db = new BatchStateDb([]);
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 125,
+        quotes: [
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "1000000",
+          },
+          {
+            poolId: "missing-pool",
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "1000000",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db,
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes).toEqual([
+      expect.objectContaining({
+        status: "unavailable",
+        reason: "unsupported-pool",
+        poolId: pool.id,
+      }),
+      expect.objectContaining({
+        status: "unavailable",
+        reason: "missing-registry-entry",
+      }),
+    ]);
+    expect(db.readCount).toBe(0);
+  });
+
+  test("rejects oversized CL quote amount strings before DynamoDB access", async () => {
+    const pool = clReplayPool();
+    const db = new BatchStateDb([]);
+
+    await expect(
+      handleFamePoolQuoteBatchRequest({
+        request: {
+          currentBlock: 125,
+          quotes: [
+            {
+              poolId: pool.id,
+              tokenIn: pool.token0,
+              tokenOut: pool.token1,
+              amountIn: "1".repeat(79),
+            },
+          ],
+        },
+        tableName: "PoolState",
+        db,
+        producerMaxFreshnessBlocks: 120,
+      }),
+    ).rejects.toThrow(/uint256 decimal string/);
+    expect(db.readCount).toBe(0);
+  });
+
+  test("rejects CL quote batches larger than the configured maximum before parsing entries", async () => {
+    const pool = clReplayPool();
+    const db = new BatchStateDb([]);
+
+    await expect(
+      handleFamePoolQuoteBatchRequest({
+        request: {
+          currentBlock: 125,
+          quotes: [
+            {
+              poolId: pool.id,
+              tokenIn: pool.token0,
+              tokenOut: pool.token1,
+              amountIn: "1",
+            },
+            {
+              poolId: pool.id,
+              tokenIn: pool.token0,
+              tokenOut: pool.token1,
+              amountIn: "1".repeat(79),
+            },
+          ],
+        },
+        tableName: "PoolState",
+        db,
+        producerMaxFreshnessBlocks: 120,
+        maxBatchSize: 1,
+      }),
+    ).rejects.toThrow(/expected at most 1 quotes/);
+    expect(db.readCount).toBe(0);
   });
 
   test("returns unknown for incomplete CL replay capsules", async () => {

--- a/src/fame-swap-pool-state/api.test.ts
+++ b/src/fame-swap-pool-state/api.test.ts
@@ -1,9 +1,14 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { describe, expect, test } from "@jest/globals";
 import { BatchGetCommand } from "@aws-sdk/lib-dynamodb";
-import type { Address } from "viem";
+import { isAddress, type Address } from "viem";
 import { handleFamePoolStateBatchRequest } from "./api.ts";
 import { poolStateRequestAuthorized } from "./auth.ts";
-import { handleFamePoolQuoteBatchRequest } from "./cl-quote.ts";
+import {
+  handleFamePoolQuoteBatchRequest,
+  type FamePoolQuoteRequest,
+} from "./cl-quote.ts";
 import {
   clReplayStateRowsFromSnapshot,
   latestClHeadStateFromSnapshot,
@@ -24,6 +29,10 @@ import { famePoolStateRegistry } from "./registry/index.ts";
 import type { FamePoolStateRegistryEntry } from "./types.ts";
 
 type SentCommand = Parameters<PoolStateDocumentClient["send"]>[0];
+
+const ADDRESS_A = "0x0000000000000000000000000000000000000001" as Address;
+const POOL_QUOTES_V1_FIXTURE_SHA256 =
+  "492e125de5f865f2ef88dd63d5965bd835c3c068d2565cfd355ef93fb28fe763";
 
 class BatchStateDb implements PoolStateDocumentClient {
   public readCount = 0;
@@ -129,6 +138,15 @@ function quotePool(
   };
 }
 
+function quoteModelPools(): (FamePoolStateRegistryEntry & {
+  poolAddress: Address;
+})[] {
+  return famePoolStateRegistry.pools.filter(
+    (pool): pool is FamePoolStateRegistryEntry & { poolAddress: Address } =>
+      pool.capability === "quote-model" && pool.poolAddress !== null,
+  );
+}
+
 function clHeadPool(id: string): FameClHeadSnapshotRegistryEntry {
   const entry = famePoolStateRegistry.pools.find((pool) => pool.id === id);
   if (
@@ -172,11 +190,17 @@ function clReplayPool(): FameClReplayRegistryEntry {
 function stateForPool(
   pool: FamePoolStateRegistryEntry & { poolAddress: Address },
   observedThroughBlock: number,
+  options: {
+    reserve0?: bigint;
+    reserve1?: bigint;
+    source?: FamePoolLatestState["source"];
+    sourceRegistryId?: string;
+  } = {},
 ): FamePoolLatestState {
   return latestStateFromReserves({
     pool,
-    reserve0: 100n,
-    reserve1: 250n,
+    reserve0: options.reserve0 ?? 100n,
+    reserve1: options.reserve1 ?? 250n,
     observedThroughBlock,
     version: {
       blockNumber: observedThroughBlock - 1,
@@ -184,8 +208,8 @@ function stateForPool(
       logIndex: 0,
     },
     transactionHash: null,
-    source: "getReserves",
-    sourceRegistryId: "unit",
+    source: options.source ?? "getReserves",
+    sourceRegistryId: options.sourceRegistryId ?? "unit",
     updatedAt: "2026-05-17T00:00:00.000Z",
   });
 }
@@ -266,6 +290,92 @@ function quoteClReplayRowsForPool(pool: FameClReplayRegistryEntry) {
     bitmapChunkSize: 1,
     tickChunkSize: 1,
   });
+}
+
+function parseFixtureObject(
+  value: unknown,
+  path: string,
+): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Expected fixture object at ${path}.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseFixtureString(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Expected fixture string at ${path}.`);
+  }
+  return value;
+}
+
+function parseFixtureNumber(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
+    throw new Error(`Expected fixture integer at ${path}.`);
+  }
+  return value;
+}
+
+function parseFixtureAddress(value: unknown, path: string): Address {
+  const parsed = parseFixtureString(value, path);
+  if (!isAddress(parsed, { strict: false })) {
+    throw new Error(`Expected fixture address at ${path}.`);
+  }
+  return parsed as Address;
+}
+
+function parseFixtureQuotes(
+  value: unknown,
+  path: string,
+): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected fixture quote array at ${path}.`);
+  }
+  return value.map((quote, index) =>
+    parseFixtureObject(quote, `${path}[${index.toString()}]`),
+  );
+}
+
+function poolQuotesFixtureResponse(): Record<string, unknown> {
+  const fixtureUrl = new URL("./fixtures/pool-quotes-v1.json", import.meta.url);
+  const parsed: unknown = JSON.parse(readFileSync(fixtureUrl, "utf8"));
+  const fixture = parseFixtureObject(parsed, "$");
+  return parseFixtureObject(fixture.response, "$.response");
+}
+
+function fixtureQuoteRequests(
+  response: Record<string, unknown>,
+): FamePoolQuoteRequest[] {
+  const quotes = parseFixtureQuotes(response.quotes, "$.response.quotes");
+  return quotes.map((quote, index) => ({
+    poolId: parseFixtureString(
+      quote.poolId,
+      `$.response.quotes[${index.toString()}].poolId`,
+    ),
+    tokenIn: parseFixtureAddress(
+      quote.tokenIn,
+      `$.response.quotes[${index.toString()}].tokenIn`,
+    ),
+    tokenOut: parseFixtureAddress(
+      quote.tokenOut,
+      `$.response.quotes[${index.toString()}].tokenOut`,
+    ),
+    amountIn: parseFixtureString(
+      quote.amountIn,
+      `$.response.quotes[${index.toString()}].amountIn`,
+    ),
+  }));
+}
+
+function fixtureReserveStates(): FamePoolLatestState[] {
+  const sourceRegistryId = sourceRegistryIdFor(famePoolStateRegistry.source);
+  return quoteModelPools().map((pool) =>
+    stateForPool(pool, 120, {
+      reserve0: 1000n,
+      reserve1: 2500n,
+      sourceRegistryId,
+    }),
+  );
 }
 
 describe("FAME pool-state API contract", () => {
@@ -509,6 +619,239 @@ describe("FAME pool-state API contract", () => {
     });
   });
 
+  test("matches the golden compact reserve quote fixture for every quote-model pool", async () => {
+    const fixtureBytes = readFileSync(
+      new URL("./fixtures/pool-quotes-v1.json", import.meta.url),
+    );
+    expect(createHash("sha256").update(fixtureBytes).digest("hex")).toBe(
+      POOL_QUOTES_V1_FIXTURE_SHA256,
+    );
+
+    const fixtureResponse = poolQuotesFixtureResponse();
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: parseFixtureNumber(
+          fixtureResponse.currentBlock,
+          "$.response.currentBlock",
+        ),
+        quotes: fixtureQuoteRequests(fixtureResponse),
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb(fixtureReserveStates()),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response).toEqual(fixtureResponse);
+    expect(response.quotes).toHaveLength(quoteModelPools().length * 2);
+    for (const quote of response.quotes) {
+      expect(quote).toMatchObject({
+        status: "quoted",
+        quoteKind: "constant-product-quote-v1",
+        quoteModel: "constant-product-reserves",
+        quoteModelVersion: 1,
+        source: "reserve-pool-state",
+      });
+      expect(quote).not.toHaveProperty("reserve0");
+      expect(quote).not.toHaveProperty("reserve1");
+      expect(quote).not.toHaveProperty("k");
+    }
+  });
+
+  test("quotes reserve and Slipstream compact rows in one batch", async () => {
+    const reservePool = quotePool("uniswap-v2-fame-direct");
+    const clPool = clReplayPool();
+    const clRows = quoteClReplayRowsForPool(clPool);
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 125,
+        quotes: [
+          {
+            poolId: reservePool.id,
+            tokenIn: reservePool.token0,
+            tokenOut: reservePool.token1,
+            amountIn: "500",
+          },
+          {
+            poolId: clPool.id,
+            tokenIn: clPool.token0,
+            tokenOut: clPool.token1,
+            amountIn: "1000000",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([
+        stateForPool(reservePool, 120, {
+          reserve0: 1000n,
+          reserve1: 2500n,
+          sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+        }),
+        clRows.latest,
+        ...clRows.bitmapChunks,
+        ...clRows.tickChunks,
+      ]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes).toEqual([
+      expect.objectContaining({
+        status: "quoted",
+        quoteKind: "constant-product-quote-v1",
+        poolId: reservePool.id,
+        amountIn: "500",
+        amountOut: "831",
+      }),
+      expect.objectContaining({
+        status: "quoted",
+        quoteKind: "cl-quote-v1",
+        poolId: clPool.id,
+        amountIn: "1000000",
+        amountOut: "999899",
+      }),
+    ]);
+  });
+
+  test("returns unavailable reserve quotes for token direction mismatch", async () => {
+    const pool = quotePool("uniswap-v2-fame-direct");
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 125,
+        quotes: [
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: ADDRESS_A,
+            amountIn: "500",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([
+        stateForPool(pool, 120, {
+          sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+        }),
+      ]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes[0]).toMatchObject({
+      status: "unavailable",
+      reason: "token-direction-mismatch",
+      poolId: pool.id,
+      chainId: pool.chainId,
+      poolAddress: pool.poolAddress,
+      observedThroughBlock: 120,
+      sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+      maxFreshnessBlocks: 120,
+    });
+  });
+
+  test("returns unavailable reserve quotes for stale reserve state", async () => {
+    const pool = quotePool("uniswap-v2-fame-direct");
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 500,
+        quotes: [
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "500",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([
+        stateForPool(pool, 120, {
+          sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+        }),
+      ]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes[0]).toMatchObject({
+      status: "unavailable",
+      reason: "stale-indexed-state",
+      requested: {
+        poolId: pool.id,
+        tokenIn: pool.token0,
+        tokenOut: pool.token1,
+        amountIn: "500",
+      },
+      observedThroughBlock: 120,
+      sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+      maxFreshnessBlocks: 120,
+    });
+  });
+
+  test("returns unavailable reserve quotes for source registry mismatch", async () => {
+    const pool = quotePool("uniswap-v2-fame-direct");
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 125,
+        quotes: [
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "500",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([
+        stateForPool(pool, 120, {
+          sourceRegistryId: "stale-registry",
+        }),
+      ]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes[0]).toMatchObject({
+      status: "unavailable",
+      reason: "source-registry-mismatch",
+      poolId: pool.id,
+      observedThroughBlock: 120,
+      sourceRegistryId: "stale-registry",
+      maxFreshnessBlocks: 120,
+    });
+  });
+
+  test("returns unavailable reserve quotes for malformed reserve state", async () => {
+    const pool = quotePool("uniswap-v2-fame-direct");
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 125,
+        quotes: [
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "500",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db: new BatchStateDb([
+        stateForPool(pool, 120, {
+          reserve0: 0n,
+          reserve1: 2500n,
+          sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+        }),
+      ]),
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes[0]).toMatchObject({
+      status: "unavailable",
+      reason: "malformed-reserve-state",
+      poolId: pool.id,
+      observedThroughBlock: 120,
+      sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
+      maxFreshnessBlocks: 120,
+    });
+  });
+
   test("returns unavailable CL quotes for stale replay state without loading chunks", async () => {
     const pool = clReplayPool();
     const rows = quoteClReplayRowsForPool(pool);
@@ -573,8 +916,8 @@ describe("FAME pool-state API contract", () => {
     });
   });
 
-  test("returns unavailable CL quotes for unsupported or unknown pools", async () => {
-    const pool = quotePool("uniswap-v2-fame-direct");
+  test("returns unavailable compact quotes for unsupported or unknown pools", async () => {
+    const pool = clHeadPool("uniswap-v3-usdc-weth-5bps");
     const db = new BatchStateDb([]);
     const response = await handleFamePoolQuoteBatchRequest({
       request: {

--- a/src/fame-swap-pool-state/cl-quote.ts
+++ b/src/fame-swap-pool-state/cl-quote.ts
@@ -3,14 +3,17 @@ import { FamePoolStateRequestError } from "./api.ts";
 import {
   batchGetClReplayStateCapsules,
   batchGetLatestClReplayPointers,
+  batchGetLatestPoolStates,
   sourceRegistryIdFor,
   type FameClReplayLatestState,
   type FameClReplayRegistryEntry,
   type FameClReplayStateCapsule,
+  type FamePoolLatestState,
   type PoolStateDocumentClient,
 } from "./dynamodb/pool-state.ts";
 import { famePoolStateRegistry } from "./registry/index.ts";
 import type {
+  FamePoolStateFeeDescriptor,
   FamePoolStateRegistryEntry,
   FamePoolStateRegistryFile,
   FamePoolStateVenueFamily,
@@ -36,6 +39,8 @@ export type FamePoolQuoteUnavailableReason =
   | "stale-indexed-state"
   | "source-registry-mismatch"
   | "token-direction-mismatch"
+  | "malformed-reserve-state"
+  | "reserve-quote-failed"
   | "malformed-replay-state"
   | "outside-indexed-tick-range"
   | "replay-failed";
@@ -82,8 +87,58 @@ interface FameSlipstreamClQuoteEntry {
   maxFreshnessBlocks: number;
 }
 
+interface FamePriceImpactEstimate {
+  preSwapPriceX18: string;
+  postSwapPriceX18: string;
+  executionPriceX18: string;
+  marketImpactBps: number | null;
+  method: "constant-product-reserves";
+}
+
+interface FameProtocolEvidenceItem {
+  status: "available" | "unavailable" | "not_applicable";
+  source: string;
+  value?: string;
+  reason?: string;
+}
+
+interface FameProtocolEvidence {
+  quote: FameProtocolEvidenceItem;
+  prePrice: FameProtocolEvidenceItem;
+  postPrice: FameProtocolEvidenceItem;
+  marketImpact: FameProtocolEvidenceItem;
+  activeLiquidity: FameProtocolEvidenceItem;
+}
+
+interface FameConstantProductQuoteEntry {
+  status: "quoted";
+  quoteKind: "constant-product-quote-v1";
+  quoteModel: "constant-product-reserves";
+  quoteModelVersion: 1;
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  token0: Address;
+  token1: Address;
+  tokenIn: Address;
+  tokenOut: Address;
+  venueFamily: FamePoolStateVenueFamily;
+  feeBps: number;
+  feeSource: "registry-fee";
+  source: "reserve-pool-state";
+  stateSource: FamePoolLatestState["source"];
+  amountIn: string;
+  amountOut: string;
+  observedThroughBlock: number;
+  sourceRegistryId: string;
+  maxFreshnessBlocks: number;
+  priceImpact: FamePriceImpactEstimate;
+  protocolEvidence: FameProtocolEvidence;
+}
+
 export type FamePoolQuoteResponseEntry =
   | FameSlipstreamClQuoteEntry
+  | FameConstantProductQuoteEntry
   | FamePoolQuoteUnavailableEntry;
 
 export interface FamePoolQuoteBatchResponse {
@@ -100,6 +155,13 @@ interface ReplayTick {
   liquidityNet: bigint;
 }
 
+type ReserveQuotePool = FamePoolStateRegistryEntry & {
+  capability: "quote-model";
+  stateSurface: "constant-product-reserves";
+  quoteModel: "constant-product-reserves";
+  poolAddress: Address;
+  fee: Extract<FamePoolStateFeeDescriptor, { status: "available" }>;
+};
 type ClReplayPool = FameClReplayRegistryEntry;
 type ReplayFailureReason = Extract<
   FamePoolQuoteUnavailableReason,
@@ -113,6 +175,8 @@ const MAX_SQRT_RATIO =
   1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342n;
 const Q96 = 2n ** 96n;
 const FEE_DENOMINATOR = 1_000_000n;
+const RESERVE_FEE_DENOMINATOR = 10_000n;
+const PRICE_SCALE = 1_000_000_000_000_000_000n;
 const MAX_UINT256 = 2n ** 256n - 1n;
 const MAX_UINT256_DECIMAL_LENGTH = MAX_UINT256.toString().length;
 
@@ -179,7 +243,10 @@ function parseQuoteRequest(value: unknown, path: string): FamePoolQuoteRequest {
       ["poolId", "tokenIn", "tokenOut", "amountIn"].includes(key),
     )
   ) {
-    quoteApiError(path, "expected only poolId, tokenIn, tokenOut, and amountIn");
+    quoteApiError(
+      path,
+      "expected only poolId, tokenIn, tokenOut, and amountIn",
+    );
   }
   return {
     poolId: parseString(optionalField(record, "poolId"), `${path}.poolId`),
@@ -205,14 +272,20 @@ export function parseFamePoolQuoteBatchRequest(
       ["currentBlock", "maxFreshnessBlocks", "quotes"].includes(key),
     )
   ) {
-    quoteApiError("$", "expected only currentBlock, maxFreshnessBlocks, and quotes");
+    quoteApiError(
+      "$",
+      "expected only currentBlock, maxFreshnessBlocks, and quotes",
+    );
   }
   const quotesValue = optionalField(record, "quotes");
   if (!Array.isArray(quotesValue)) {
     quoteApiError("$.quotes", "expected an array");
   }
   if (quotesValue.length > maxBatchSize) {
-    quoteApiError("$.quotes", `expected at most ${maxBatchSize.toString()} quotes`);
+    quoteApiError(
+      "$.quotes",
+      `expected at most ${maxBatchSize.toString()} quotes`,
+    );
   }
 
   const maxFreshnessBlocks = optionalField(record, "maxFreshnessBlocks");
@@ -251,8 +324,24 @@ function isClReplayPool(
   );
 }
 
+function isReserveQuotePool(
+  pool: FamePoolStateRegistryEntry,
+): pool is ReserveQuotePool {
+  return (
+    pool.capability === "quote-model" &&
+    pool.stateSurface === "constant-product-reserves" &&
+    pool.quoteModel === "constant-product-reserves" &&
+    pool.poolAddress !== null &&
+    pool.fee.status === "available"
+  );
+}
+
 function sameAddress(left: Address, right: Address): boolean {
   return left.toLowerCase() === right.toLowerCase();
+}
+
+function addressStateKey(chainId: number, poolAddress: Address): string {
+  return `${chainId.toString()}:${poolAddress.toLowerCase()}`;
 }
 
 function freshnessStatus(options: {
@@ -307,6 +396,25 @@ function clReplayStateMatchesRegistry({
   );
 }
 
+function reserveStateMatchesRegistry({
+  state,
+  entry,
+  sourceRegistryId,
+}: {
+  state: FamePoolLatestState;
+  entry: ReserveQuotePool;
+  sourceRegistryId: string;
+}): boolean {
+  return (
+    state.sourceRegistryId === sourceRegistryId &&
+    state.poolId === entry.id &&
+    state.chainId === entry.chainId &&
+    sameAddress(state.poolAddress, entry.poolAddress) &&
+    sameAddress(state.token0, entry.token0) &&
+    sameAddress(state.token1, entry.token1)
+  );
+}
+
 function parseUnsignedDecimal(value: string): bigint | null {
   if (!/^(0|[1-9][0-9]*)$/.test(value)) return null;
   return BigInt(value);
@@ -339,29 +447,46 @@ function getSqrtRatioAtTick(tick: number): bigint {
     (absTick & 0x1) !== 0
       ? 0xfffcb933bd6fad37aa2d162d1a594001n
       : 0x100000000000000000000000000000000n;
-  if ((absTick & 0x2) !== 0) ratio = (ratio * 0xfff97272373d413259a46990580e213an) >> 128n;
-  if ((absTick & 0x4) !== 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdccn) >> 128n;
-  if ((absTick & 0x8) !== 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0n) >> 128n;
-  if ((absTick & 0x10) !== 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644n) >> 128n;
-  if ((absTick & 0x20) !== 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0n) >> 128n;
-  if ((absTick & 0x40) !== 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861n) >> 128n;
-  if ((absTick & 0x80) !== 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053n) >> 128n;
-  if ((absTick & 0x100) !== 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4n) >> 128n;
-  if ((absTick & 0x200) !== 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54n) >> 128n;
-  if ((absTick & 0x400) !== 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3n) >> 128n;
-  if ((absTick & 0x800) !== 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9n) >> 128n;
-  if ((absTick & 0x1000) !== 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825n) >> 128n;
-  if ((absTick & 0x2000) !== 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5n) >> 128n;
-  if ((absTick & 0x4000) !== 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7n) >> 128n;
-  if ((absTick & 0x8000) !== 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6n) >> 128n;
-  if ((absTick & 0x10000) !== 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9n) >> 128n;
-  if ((absTick & 0x20000) !== 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604n) >> 128n;
-  if ((absTick & 0x40000) !== 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98n) >> 128n;
-  if ((absTick & 0x80000) !== 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2n) >> 128n;
+  if ((absTick & 0x2) !== 0)
+    ratio = (ratio * 0xfff97272373d413259a46990580e213an) >> 128n;
+  if ((absTick & 0x4) !== 0)
+    ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdccn) >> 128n;
+  if ((absTick & 0x8) !== 0)
+    ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0n) >> 128n;
+  if ((absTick & 0x10) !== 0)
+    ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644n) >> 128n;
+  if ((absTick & 0x20) !== 0)
+    ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0n) >> 128n;
+  if ((absTick & 0x40) !== 0)
+    ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861n) >> 128n;
+  if ((absTick & 0x80) !== 0)
+    ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053n) >> 128n;
+  if ((absTick & 0x100) !== 0)
+    ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4n) >> 128n;
+  if ((absTick & 0x200) !== 0)
+    ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54n) >> 128n;
+  if ((absTick & 0x400) !== 0)
+    ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3n) >> 128n;
+  if ((absTick & 0x800) !== 0)
+    ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9n) >> 128n;
+  if ((absTick & 0x1000) !== 0)
+    ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825n) >> 128n;
+  if ((absTick & 0x2000) !== 0)
+    ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5n) >> 128n;
+  if ((absTick & 0x4000) !== 0)
+    ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7n) >> 128n;
+  if ((absTick & 0x8000) !== 0)
+    ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6n) >> 128n;
+  if ((absTick & 0x10000) !== 0)
+    ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9n) >> 128n;
+  if ((absTick & 0x20000) !== 0)
+    ratio = (ratio * 0x5d6af8dedb81196699c329225ee604n) >> 128n;
+  if ((absTick & 0x40000) !== 0)
+    ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98n) >> 128n;
+  if ((absTick & 0x80000) !== 0)
+    ratio = (ratio * 0x48a170391f7dc42444e8fa2n) >> 128n;
   if (tick > 0) ratio = MAX_UINT256 / ratio;
-  return ratio % (2n ** 32n) === 0n
-    ? ratio >> 32n
-    : (ratio >> 32n) + 1n;
+  return ratio % 2n ** 32n === 0n ? ratio >> 32n : (ratio >> 32n) + 1n;
 }
 
 function amount0Delta(
@@ -380,7 +505,7 @@ function amount0Delta(
       lower,
     );
   }
-  return ((numerator1 * numerator2) / upper) / lower;
+  return (numerator1 * numerator2) / upper / lower;
 }
 
 function amount1Delta(
@@ -456,7 +581,12 @@ function computeSwapStep(options: {
     ? amountInAtTarget
     : options.zeroForOne
       ? amount0Delta(sqrtNextX96, options.sqrtPriceX96, options.liquidity, true)
-      : amount1Delta(options.sqrtPriceX96, sqrtNextX96, options.liquidity, true);
+      : amount1Delta(
+          options.sqrtPriceX96,
+          sqrtNextX96,
+          options.liquidity,
+          true,
+        );
   const amountOut = options.zeroForOne
     ? amount1Delta(sqrtNextX96, options.sqrtPriceX96, options.liquidity, false)
     : amount0Delta(options.sqrtPriceX96, sqrtNextX96, options.liquidity, false);
@@ -534,7 +664,8 @@ function replaySlipstreamExactInput(options: {
   while (amountRemaining > 0n) {
     if (liquidity <= 0n) return "outside-indexed-tick-range";
     const nextTick = nextInitializedTick(ticks, tick, options.zeroForOne);
-    const targetTick = nextTick?.tick ?? (options.zeroForOne ? MIN_TICK : MAX_TICK);
+    const targetTick =
+      nextTick?.tick ?? (options.zeroForOne ? MIN_TICK : MAX_TICK);
     const sqrtTarget = getSqrtRatioAtTick(targetTick);
     const step = computeSwapStep({
       sqrtPriceX96: sqrt,
@@ -584,6 +715,243 @@ function unavailable(
     requested,
     reason,
     ...metadata,
+  };
+}
+
+function constantProductAmountOut(options: {
+  amountIn: bigint;
+  reserveIn: bigint;
+  reserveOut: bigint;
+  feeBps: number;
+}): bigint | "malformed-reserve-state" {
+  if (
+    options.amountIn <= 0n ||
+    options.reserveIn <= 0n ||
+    options.reserveOut <= 0n ||
+    !Number.isSafeInteger(options.feeBps)
+  ) {
+    return "malformed-reserve-state";
+  }
+
+  const feeNumerator = RESERVE_FEE_DENOMINATOR - BigInt(options.feeBps);
+  if (feeNumerator <= 0n) return "malformed-reserve-state";
+
+  const amountInWithFee = options.amountIn * feeNumerator;
+  return (
+    (amountInWithFee * options.reserveOut) /
+    (options.reserveIn * RESERVE_FEE_DENOMINATOR + amountInWithFee)
+  );
+}
+
+function priceX18(amountOut: bigint, amountIn: bigint): bigint | null {
+  if (amountIn <= 0n || amountOut < 0n) return null;
+  return (amountOut * PRICE_SCALE) / amountIn;
+}
+
+function marketImpactBps(
+  preSwapPriceX18: bigint,
+  executionPriceX18: bigint,
+): number | null {
+  if (preSwapPriceX18 <= 0n || executionPriceX18 <= 0n) return null;
+  if (executionPriceX18 >= preSwapPriceX18) return 0;
+  return Number(
+    ((preSwapPriceX18 - executionPriceX18) * 10_000n) / preSwapPriceX18,
+  );
+}
+
+function constantProductPriceImpact(options: {
+  amountIn: bigint;
+  amountOut: bigint;
+  reserveIn: bigint;
+  reserveOut: bigint;
+}): FamePriceImpactEstimate | null {
+  const preSwapPrice = priceX18(options.reserveOut, options.reserveIn);
+  const executionPrice = priceX18(options.amountOut, options.amountIn);
+  if (preSwapPrice === null || executionPrice === null) return null;
+
+  const nextReserveIn = options.reserveIn + options.amountIn;
+  const nextReserveOut = options.reserveOut - options.amountOut;
+  const postSwapPrice =
+    nextReserveOut > 0n ? priceX18(nextReserveOut, nextReserveIn) : null;
+  if (postSwapPrice === null) return null;
+
+  return {
+    preSwapPriceX18: preSwapPrice.toString(),
+    postSwapPriceX18: postSwapPrice.toString(),
+    executionPriceX18: executionPrice.toString(),
+    marketImpactBps: marketImpactBps(preSwapPrice, executionPrice),
+    method: "constant-product-reserves",
+  };
+}
+
+function availableEvidence(
+  source: string,
+  value: bigint | number | string,
+): FameProtocolEvidenceItem {
+  return {
+    status: "available",
+    source,
+    value: value.toString(),
+  };
+}
+
+function unavailableEvidence(
+  source: string,
+  reason: string,
+): FameProtocolEvidenceItem {
+  return {
+    status: "unavailable",
+    source,
+    reason,
+  };
+}
+
+function notApplicableEvidence(
+  source: string,
+  reason: string,
+): FameProtocolEvidenceItem {
+  return {
+    status: "not_applicable",
+    source,
+    reason,
+  };
+}
+
+function protocolEvidenceFromPriceImpact(options: {
+  poolId: string;
+  amountOut: bigint;
+  priceImpact: FamePriceImpactEstimate;
+}): FameProtocolEvidence {
+  const source = `reserve-pool-state quote for ${options.poolId}`;
+  return {
+    quote: availableEvidence(source, options.amountOut),
+    prePrice: availableEvidence(source, options.priceImpact.preSwapPriceX18),
+    postPrice: availableEvidence(source, options.priceImpact.postSwapPriceX18),
+    marketImpact:
+      options.priceImpact.marketImpactBps === null
+        ? unavailableEvidence(
+            source,
+            "Constant-product reserve quote did not produce market-impact evidence.",
+          )
+        : availableEvidence(source, options.priceImpact.marketImpactBps),
+    activeLiquidity: notApplicableEvidence(
+      source,
+      "Constant-product reserve quote uses reserves, not active liquidity.",
+    ),
+  };
+}
+
+function reserveQuoteMetadata(
+  state: FamePoolLatestState,
+  maxFreshnessBlocks: number,
+): Omit<FamePoolQuoteUnavailableEntry, "status" | "requested" | "reason"> {
+  return {
+    poolId: state.poolId,
+    chainId: state.chainId,
+    poolAddress: state.poolAddress,
+    observedThroughBlock: state.observedThroughBlock,
+    sourceRegistryId: state.sourceRegistryId,
+    maxFreshnessBlocks,
+  };
+}
+
+function quoteFromReserveState(options: {
+  request: FamePoolQuoteRequest;
+  state: FamePoolLatestState;
+  entry: ReserveQuotePool;
+  maxFreshnessBlocks: number;
+}): FamePoolQuoteResponseEntry {
+  const { request, state, entry } = options;
+  const reserve0 = parseUnsignedDecimal(state.reserve0);
+  const reserve1 = parseUnsignedDecimal(state.reserve1);
+  if (reserve0 === null || reserve1 === null) {
+    return unavailable(
+      request,
+      "malformed-reserve-state",
+      reserveQuoteMetadata(state, options.maxFreshnessBlocks),
+    );
+  }
+
+  const direct =
+    sameAddress(request.tokenIn, state.token0) &&
+    sameAddress(request.tokenOut, state.token1);
+  const reverse =
+    sameAddress(request.tokenIn, state.token1) &&
+    sameAddress(request.tokenOut, state.token0);
+  if (!direct && !reverse) {
+    return unavailable(
+      request,
+      "token-direction-mismatch",
+      reserveQuoteMetadata(state, options.maxFreshnessBlocks),
+    );
+  }
+
+  const amountIn = BigInt(request.amountIn);
+  const reserveIn = direct ? reserve0 : reserve1;
+  const reserveOut = direct ? reserve1 : reserve0;
+  const amountOut = constantProductAmountOut({
+    amountIn,
+    reserveIn,
+    reserveOut,
+    feeBps: entry.fee.feeBps,
+  });
+  if (amountOut === "malformed-reserve-state") {
+    return unavailable(
+      request,
+      amountOut,
+      reserveQuoteMetadata(state, options.maxFreshnessBlocks),
+    );
+  }
+  if (amountOut <= 0n) {
+    return unavailable(
+      request,
+      "reserve-quote-failed",
+      reserveQuoteMetadata(state, options.maxFreshnessBlocks),
+    );
+  }
+
+  const priceImpact = constantProductPriceImpact({
+    amountIn,
+    amountOut,
+    reserveIn,
+    reserveOut,
+  });
+  if (priceImpact === null) {
+    return unavailable(
+      request,
+      "reserve-quote-failed",
+      reserveQuoteMetadata(state, options.maxFreshnessBlocks),
+    );
+  }
+
+  return {
+    status: "quoted",
+    quoteKind: "constant-product-quote-v1",
+    quoteModel: "constant-product-reserves",
+    quoteModelVersion: 1,
+    poolId: entry.id,
+    chainId: entry.chainId,
+    poolAddress: entry.poolAddress,
+    token0: entry.token0,
+    token1: entry.token1,
+    tokenIn: request.tokenIn,
+    tokenOut: request.tokenOut,
+    venueFamily: entry.venueFamily,
+    feeBps: entry.fee.feeBps,
+    feeSource: "registry-fee",
+    source: "reserve-pool-state",
+    stateSource: state.source,
+    amountIn: request.amountIn,
+    amountOut: amountOut.toString(),
+    observedThroughBlock: state.observedThroughBlock,
+    sourceRegistryId: state.sourceRegistryId,
+    maxFreshnessBlocks: options.maxFreshnessBlocks,
+    priceImpact,
+    protocolEvidence: protocolEvidenceFromPriceImpact({
+      poolId: entry.id,
+      amountOut,
+      priceImpact,
+    }),
   };
 }
 
@@ -685,6 +1053,15 @@ export async function handleFamePoolQuoteBatchRequest({
     request: quote,
     entry: registryById.get(quote.poolId),
   }));
+  const reservePoolsById = new Map(
+    entries
+      .map(({ entry }) => entry)
+      .filter(
+        (entry): entry is ReserveQuotePool =>
+          entry !== undefined && isReserveQuotePool(entry),
+      )
+      .map((entry) => [entry.id, entry]),
+  );
   const clReplayPoolsById = new Map(
     entries
       .map(({ entry }) => entry)
@@ -694,6 +1071,11 @@ export async function handleFamePoolQuoteBatchRequest({
       )
       .map((entry) => [entry.id, entry]),
   );
+  const reserveStates = await batchGetLatestPoolStates({
+    db,
+    tableName,
+    pools: [...reservePoolsById.values()],
+  });
   const latestStates = await batchGetLatestClReplayPointers({
     db,
     tableName,
@@ -719,6 +1101,12 @@ export async function handleFamePoolQuoteBatchRequest({
   const latestStatesByPoolId = new Map(
     latestStates.map((state) => [state.poolId, state]),
   );
+  const reserveStatesByAddress = new Map(
+    reserveStates.map((state) => [
+      addressStateKey(state.chainId, state.poolAddress),
+      state,
+    ]),
+  );
   const clReplayStatesByPoolId = new Map(
     clReplayStates.map((state) => [state.latest.poolId, state]),
   );
@@ -731,6 +1119,61 @@ export async function handleFamePoolQuoteBatchRequest({
     quotes: entries.map(({ request: requested, entry }) => {
       if (!entry) {
         return unavailable(requested, "missing-registry-entry");
+      }
+      if (isReserveQuotePool(entry)) {
+        const state = reserveStatesByAddress.get(
+          addressStateKey(entry.chainId, entry.poolAddress),
+        );
+        if (!state) {
+          return unavailable(requested, "missing-indexed-state", {
+            poolId: entry.id,
+            chainId: entry.chainId,
+            poolAddress: entry.poolAddress,
+          });
+        }
+        if (state.sourceRegistryId !== sourceRegistryId) {
+          return unavailable(requested, "source-registry-mismatch", {
+            poolId: entry.id,
+            chainId: entry.chainId,
+            poolAddress: entry.poolAddress,
+            observedThroughBlock: state.observedThroughBlock,
+            sourceRegistryId: state.sourceRegistryId,
+            maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+          });
+        }
+        if (!reserveStateMatchesRegistry({ state, entry, sourceRegistryId })) {
+          return unavailable(requested, "missing-indexed-state", {
+            poolId: entry.id,
+            chainId: entry.chainId,
+            poolAddress: entry.poolAddress,
+            observedThroughBlock: state.observedThroughBlock,
+            sourceRegistryId: state.sourceRegistryId,
+            maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+          });
+        }
+        if (
+          freshnessStatus({
+            state,
+            currentBlock: parsed.currentBlock,
+            maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+          }) === "stale"
+        ) {
+          return unavailable(requested, "stale-indexed-state", {
+            poolId: entry.id,
+            chainId: entry.chainId,
+            poolAddress: entry.poolAddress,
+            observedThroughBlock: state.observedThroughBlock,
+            sourceRegistryId: state.sourceRegistryId,
+            maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+          });
+        }
+
+        return quoteFromReserveState({
+          request: requested,
+          state,
+          entry,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+        });
       }
       if (!isClReplayPool(entry)) {
         return unavailable(requested, "unsupported-pool", {
@@ -758,7 +1201,9 @@ export async function handleFamePoolQuoteBatchRequest({
           maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
         });
       }
-      if (!clReplayLatestStateMatchesRegistry({ latest, entry, sourceRegistryId })) {
+      if (
+        !clReplayLatestStateMatchesRegistry({ latest, entry, sourceRegistryId })
+      ) {
         return unavailable(requested, "missing-indexed-state", {
           poolId: entry.id,
           chainId: entry.chainId,

--- a/src/fame-swap-pool-state/cl-quote.ts
+++ b/src/fame-swap-pool-state/cl-quote.ts
@@ -1,0 +1,810 @@
+import { isAddress, type Address, type Hex } from "viem";
+import { FamePoolStateRequestError } from "./api.ts";
+import {
+  batchGetClReplayStateCapsules,
+  batchGetLatestClReplayPointers,
+  sourceRegistryIdFor,
+  type FameClReplayLatestState,
+  type FameClReplayRegistryEntry,
+  type FameClReplayStateCapsule,
+  type PoolStateDocumentClient,
+} from "./dynamodb/pool-state.ts";
+import { famePoolStateRegistry } from "./registry/index.ts";
+import type {
+  FamePoolStateRegistryEntry,
+  FamePoolStateRegistryFile,
+  FamePoolStateVenueFamily,
+} from "./types.ts";
+
+export interface FamePoolQuoteRequest {
+  poolId: string;
+  tokenIn: Address;
+  tokenOut: Address;
+  amountIn: string;
+}
+
+export interface FamePoolQuoteBatchRequest {
+  currentBlock: number;
+  maxFreshnessBlocks?: number;
+  quotes: FamePoolQuoteRequest[];
+}
+
+export type FamePoolQuoteUnavailableReason =
+  | "missing-registry-entry"
+  | "unsupported-pool"
+  | "missing-indexed-state"
+  | "stale-indexed-state"
+  | "source-registry-mismatch"
+  | "token-direction-mismatch"
+  | "malformed-replay-state"
+  | "outside-indexed-tick-range"
+  | "replay-failed";
+
+interface FamePoolQuoteUnavailableEntry {
+  status: "unavailable";
+  requested: FamePoolQuoteRequest;
+  reason: FamePoolQuoteUnavailableReason;
+  poolId?: string;
+  chainId?: number;
+  poolAddress?: Address | null;
+  observedThroughBlock?: number;
+  sourceRegistryId?: string;
+  maxFreshnessBlocks?: number;
+}
+
+interface FameSlipstreamClQuoteEntry {
+  status: "quoted";
+  quoteKind: "cl-quote-v1";
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  token0: Address;
+  token1: Address;
+  tokenIn: Address;
+  tokenOut: Address;
+  venueFamily: FamePoolStateVenueFamily;
+  tickSpacing: number;
+  amountIn: string;
+  amountOut: string;
+  sqrtPriceX96: string;
+  sqrtPriceX96After: string;
+  tick: number;
+  liquidity: string;
+  fee: string;
+  feeSource: "pool-fee";
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  snapshotId: string;
+  stateHash: Hex;
+  source: "slipstream-pool-state";
+  sourceRegistryId: string;
+  maxFreshnessBlocks: number;
+}
+
+export type FamePoolQuoteResponseEntry =
+  | FameSlipstreamClQuoteEntry
+  | FamePoolQuoteUnavailableEntry;
+
+export interface FamePoolQuoteBatchResponse {
+  sourceRegistryId: string;
+  currentBlock: number;
+  producerMaxFreshnessBlocks: number;
+  effectiveMaxFreshnessBlocks: number;
+  quotes: FamePoolQuoteResponseEntry[];
+}
+
+interface ReplayTick {
+  tick: number;
+  liquidityGross: bigint;
+  liquidityNet: bigint;
+}
+
+type ClReplayPool = FameClReplayRegistryEntry;
+type ReplayFailureReason = Extract<
+  FamePoolQuoteUnavailableReason,
+  "malformed-replay-state" | "outside-indexed-tick-range" | "replay-failed"
+>;
+
+const MIN_TICK = -887_272;
+const MAX_TICK = 887_272;
+const MIN_SQRT_RATIO = 4_295_128_739n;
+const MAX_SQRT_RATIO =
+  1_461_446_703_485_210_103_287_273_052_203_988_822_378_723_970_342n;
+const Q96 = 2n ** 96n;
+const FEE_DENOMINATOR = 1_000_000n;
+const MAX_UINT256 = 2n ** 256n - 1n;
+const MAX_UINT256_DECIMAL_LENGTH = MAX_UINT256.toString().length;
+
+function quoteApiError(path: string, message: string): never {
+  throw new FamePoolStateRequestError(
+    `FAME pool-quotes request invalid at ${path}: ${message}.`,
+  );
+}
+
+function parseObject(value: unknown, path: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    quoteApiError(path, "expected an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function parseString(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    quoteApiError(path, "expected a non-empty string");
+  }
+  return value;
+}
+
+function parseInteger(value: unknown, path: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    quoteApiError(path, "expected a non-negative safe integer");
+  }
+  return value;
+}
+
+function parseAddress(value: unknown, path: string): Address {
+  const parsed = parseString(value, path);
+  if (!isAddress(parsed, { strict: false })) {
+    quoteApiError(path, "expected an EVM address");
+  }
+  return parsed as Address;
+}
+
+function parseUint256Decimal(value: unknown, path: string): string {
+  const parsed = parseString(value, path);
+  if (parsed.length > MAX_UINT256_DECIMAL_LENGTH) {
+    quoteApiError(path, "expected a uint256 decimal string");
+  }
+  if (!/^(0|[1-9][0-9]*)$/.test(parsed)) {
+    quoteApiError(path, "expected a canonical uint256 decimal string");
+  }
+  if (BigInt(parsed) > MAX_UINT256) {
+    quoteApiError(path, "expected a uint256 decimal string");
+  }
+  return parsed;
+}
+
+function optionalField(
+  record: Record<string, unknown>,
+  key: string,
+): unknown | undefined {
+  return Object.hasOwn(record, key) ? record[key] : undefined;
+}
+
+function parseQuoteRequest(value: unknown, path: string): FamePoolQuoteRequest {
+  const record = parseObject(value, path);
+  if (
+    !Object.keys(record).every((key) =>
+      ["poolId", "tokenIn", "tokenOut", "amountIn"].includes(key),
+    )
+  ) {
+    quoteApiError(path, "expected only poolId, tokenIn, tokenOut, and amountIn");
+  }
+  return {
+    poolId: parseString(optionalField(record, "poolId"), `${path}.poolId`),
+    tokenIn: parseAddress(optionalField(record, "tokenIn"), `${path}.tokenIn`),
+    tokenOut: parseAddress(
+      optionalField(record, "tokenOut"),
+      `${path}.tokenOut`,
+    ),
+    amountIn: parseUint256Decimal(
+      optionalField(record, "amountIn"),
+      `${path}.amountIn`,
+    ),
+  };
+}
+
+export function parseFamePoolQuoteBatchRequest(
+  value: unknown,
+  maxBatchSize = Number.MAX_SAFE_INTEGER,
+): FamePoolQuoteBatchRequest {
+  const record = parseObject(value, "$");
+  if (
+    !Object.keys(record).every((key) =>
+      ["currentBlock", "maxFreshnessBlocks", "quotes"].includes(key),
+    )
+  ) {
+    quoteApiError("$", "expected only currentBlock, maxFreshnessBlocks, and quotes");
+  }
+  const quotesValue = optionalField(record, "quotes");
+  if (!Array.isArray(quotesValue)) {
+    quoteApiError("$.quotes", "expected an array");
+  }
+  if (quotesValue.length > maxBatchSize) {
+    quoteApiError("$.quotes", `expected at most ${maxBatchSize.toString()} quotes`);
+  }
+
+  const maxFreshnessBlocks = optionalField(record, "maxFreshnessBlocks");
+  return {
+    currentBlock: parseInteger(
+      optionalField(record, "currentBlock"),
+      "$.currentBlock",
+    ),
+    ...(maxFreshnessBlocks === undefined
+      ? {}
+      : {
+          maxFreshnessBlocks: parseInteger(
+            maxFreshnessBlocks,
+            "$.maxFreshnessBlocks",
+          ),
+        }),
+    quotes: quotesValue.map((quote, index) =>
+      parseQuoteRequest(quote, `$.quotes[${index.toString()}]`),
+    ),
+  };
+}
+
+function registryMaps(registry: FamePoolStateRegistryFile) {
+  return new Map(registry.pools.map((pool) => [pool.id, pool]));
+}
+
+function isClReplayPool(
+  pool: FamePoolStateRegistryEntry,
+): pool is ClReplayPool {
+  return (
+    pool.replaySurface === "cl-replay-v1" &&
+    pool.stateSurface === "cl-head-snapshot" &&
+    pool.tickSpacing !== null &&
+    pool.poolAddress !== null &&
+    pool.venue === "aerodrome-slipstream"
+  );
+}
+
+function sameAddress(left: Address, right: Address): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function freshnessStatus(options: {
+  state: { observedThroughBlock: number };
+  currentBlock: number;
+  maxFreshnessBlocks: number;
+}): "fresh" | "stale" {
+  if (options.state.observedThroughBlock > options.currentBlock) {
+    return "stale";
+  }
+  return options.currentBlock - options.state.observedThroughBlock <=
+    options.maxFreshnessBlocks
+    ? "fresh"
+    : "stale";
+}
+
+function clReplayLatestStateMatchesRegistry({
+  latest,
+  entry,
+  sourceRegistryId,
+}: {
+  latest: FameClReplayLatestState;
+  entry: ClReplayPool;
+  sourceRegistryId: string;
+}): boolean {
+  return (
+    latest.sourceRegistryId === sourceRegistryId &&
+    latest.poolId === entry.id &&
+    latest.chainId === entry.chainId &&
+    sameAddress(latest.poolAddress, entry.poolAddress) &&
+    sameAddress(latest.token0, entry.token0) &&
+    sameAddress(latest.token1, entry.token1) &&
+    latest.venueFamily === entry.venueFamily &&
+    latest.tickSpacing === entry.tickSpacing
+  );
+}
+
+function clReplayStateMatchesRegistry({
+  state,
+  entry,
+  sourceRegistryId,
+}: {
+  state: FameClReplayStateCapsule;
+  entry: ClReplayPool;
+  sourceRegistryId: string;
+}): boolean {
+  const latest = state.latest;
+  return (
+    clReplayLatestStateMatchesRegistry({ latest, entry, sourceRegistryId }) &&
+    latest.bitmapWordCount === state.bitmapWords.length &&
+    latest.initializedTickCount === state.initializedTicks.length
+  );
+}
+
+function parseUnsignedDecimal(value: string): bigint | null {
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) return null;
+  return BigInt(value);
+}
+
+function parseSignedDecimal(value: string): bigint | null {
+  if (!/^-?(0|[1-9][0-9]*)$/.test(value) || value === "-0") return null;
+  return BigInt(value);
+}
+
+function divRoundingUp(numerator: bigint, denominator: bigint): bigint {
+  const quotient = numerator / denominator;
+  return numerator % denominator === 0n ? quotient : quotient + 1n;
+}
+
+function mulDivRoundingUp(
+  left: bigint,
+  right: bigint,
+  denominator: bigint,
+): bigint {
+  return divRoundingUp(left * right, denominator);
+}
+
+function getSqrtRatioAtTick(tick: number): bigint {
+  if (tick < MIN_TICK || tick > MAX_TICK) {
+    throw new Error("Tick is outside the supported CL range.");
+  }
+  const absTick = tick < 0 ? -tick : tick;
+  let ratio =
+    (absTick & 0x1) !== 0
+      ? 0xfffcb933bd6fad37aa2d162d1a594001n
+      : 0x100000000000000000000000000000000n;
+  if ((absTick & 0x2) !== 0) ratio = (ratio * 0xfff97272373d413259a46990580e213an) >> 128n;
+  if ((absTick & 0x4) !== 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdccn) >> 128n;
+  if ((absTick & 0x8) !== 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0n) >> 128n;
+  if ((absTick & 0x10) !== 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644n) >> 128n;
+  if ((absTick & 0x20) !== 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0n) >> 128n;
+  if ((absTick & 0x40) !== 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861n) >> 128n;
+  if ((absTick & 0x80) !== 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053n) >> 128n;
+  if ((absTick & 0x100) !== 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4n) >> 128n;
+  if ((absTick & 0x200) !== 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54n) >> 128n;
+  if ((absTick & 0x400) !== 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3n) >> 128n;
+  if ((absTick & 0x800) !== 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9n) >> 128n;
+  if ((absTick & 0x1000) !== 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825n) >> 128n;
+  if ((absTick & 0x2000) !== 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5n) >> 128n;
+  if ((absTick & 0x4000) !== 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7n) >> 128n;
+  if ((absTick & 0x8000) !== 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6n) >> 128n;
+  if ((absTick & 0x10000) !== 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9n) >> 128n;
+  if ((absTick & 0x20000) !== 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604n) >> 128n;
+  if ((absTick & 0x40000) !== 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98n) >> 128n;
+  if ((absTick & 0x80000) !== 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2n) >> 128n;
+  if (tick > 0) ratio = MAX_UINT256 / ratio;
+  return ratio % (2n ** 32n) === 0n
+    ? ratio >> 32n
+    : (ratio >> 32n) + 1n;
+}
+
+function amount0Delta(
+  sqrtA: bigint,
+  sqrtB: bigint,
+  liquidity: bigint,
+  roundUp: boolean,
+): bigint {
+  const lower = sqrtA < sqrtB ? sqrtA : sqrtB;
+  const upper = sqrtA < sqrtB ? sqrtB : sqrtA;
+  const numerator1 = liquidity << 96n;
+  const numerator2 = upper - lower;
+  if (roundUp) {
+    return divRoundingUp(
+      mulDivRoundingUp(numerator1, numerator2, upper),
+      lower,
+    );
+  }
+  return ((numerator1 * numerator2) / upper) / lower;
+}
+
+function amount1Delta(
+  sqrtA: bigint,
+  sqrtB: bigint,
+  liquidity: bigint,
+  roundUp: boolean,
+): bigint {
+  const lower = sqrtA < sqrtB ? sqrtA : sqrtB;
+  const upper = sqrtA < sqrtB ? sqrtB : sqrtA;
+  return roundUp
+    ? mulDivRoundingUp(liquidity, upper - lower, Q96)
+    : (liquidity * (upper - lower)) / Q96;
+}
+
+function nextSqrtPriceFromInput(
+  sqrtPriceX96: bigint,
+  liquidity: bigint,
+  amountIn: bigint,
+  zeroForOne: boolean,
+): bigint {
+  if (amountIn === 0n) return sqrtPriceX96;
+  if (zeroForOne) {
+    const numerator1 = liquidity << 96n;
+    return mulDivRoundingUp(
+      numerator1,
+      sqrtPriceX96,
+      numerator1 + amountIn * sqrtPriceX96,
+    );
+  }
+  return sqrtPriceX96 + (amountIn * Q96) / liquidity;
+}
+
+function computeSwapStep(options: {
+  sqrtPriceX96: bigint;
+  sqrtTargetX96: bigint;
+  liquidity: bigint;
+  amountRemaining: bigint;
+  feePips: bigint;
+  zeroForOne: boolean;
+}): {
+  sqrtNextX96: bigint;
+  amountIn: bigint;
+  amountOut: bigint;
+  feeAmount: bigint;
+} {
+  const amountRemainingLessFee =
+    (options.amountRemaining * (FEE_DENOMINATOR - options.feePips)) /
+    FEE_DENOMINATOR;
+  const amountInAtTarget = options.zeroForOne
+    ? amount0Delta(
+        options.sqrtTargetX96,
+        options.sqrtPriceX96,
+        options.liquidity,
+        true,
+      )
+    : amount1Delta(
+        options.sqrtPriceX96,
+        options.sqrtTargetX96,
+        options.liquidity,
+        true,
+      );
+  const reachesTarget = amountRemainingLessFee >= amountInAtTarget;
+  const sqrtNextX96 = reachesTarget
+    ? options.sqrtTargetX96
+    : nextSqrtPriceFromInput(
+        options.sqrtPriceX96,
+        options.liquidity,
+        amountRemainingLessFee,
+        options.zeroForOne,
+      );
+  const amountIn = reachesTarget
+    ? amountInAtTarget
+    : options.zeroForOne
+      ? amount0Delta(sqrtNextX96, options.sqrtPriceX96, options.liquidity, true)
+      : amount1Delta(options.sqrtPriceX96, sqrtNextX96, options.liquidity, true);
+  const amountOut = options.zeroForOne
+    ? amount1Delta(sqrtNextX96, options.sqrtPriceX96, options.liquidity, false)
+    : amount0Delta(options.sqrtPriceX96, sqrtNextX96, options.liquidity, false);
+  const feeAmount = reachesTarget
+    ? mulDivRoundingUp(
+        amountIn,
+        options.feePips,
+        FEE_DENOMINATOR - options.feePips,
+      )
+    : options.amountRemaining - amountIn;
+  return { sqrtNextX96, amountIn, amountOut, feeAmount };
+}
+
+function nextInitializedTick(
+  ticks: readonly ReplayTick[],
+  currentTick: number,
+  zeroForOne: boolean,
+): ReplayTick | null {
+  if (zeroForOne) {
+    for (let index = ticks.length - 1; index >= 0; index -= 1) {
+      const tick = ticks[index];
+      if (tick && tick.tick <= currentTick) return tick;
+    }
+    return null;
+  }
+  return ticks.find((tick) => tick.tick > currentTick) ?? null;
+}
+
+function replayTicks(state: FameClReplayStateCapsule): ReplayTick[] | null {
+  const ticks = state.initializedTicks.map((tick) => {
+    const liquidityGross = parseUnsignedDecimal(tick.liquidityGross);
+    const liquidityNet = parseSignedDecimal(tick.liquidityNet);
+    if (liquidityGross === null || liquidityNet === null) return null;
+    return {
+      tick: tick.tick,
+      liquidityGross,
+      liquidityNet,
+    };
+  });
+  if (ticks.some((tick) => tick === null)) return null;
+  return ticks
+    .filter((tick): tick is ReplayTick => tick !== null)
+    .sort((left, right) => left.tick - right.tick);
+}
+
+function replaySlipstreamExactInput(options: {
+  state: FameClReplayStateCapsule;
+  zeroForOne: boolean;
+  amountIn: bigint;
+}): { amountOut: bigint; sqrtPriceX96After: bigint } | ReplayFailureReason {
+  const sqrtPriceX96 = parseUnsignedDecimal(options.state.latest.sqrtPriceX96);
+  const liquidityStart = parseUnsignedDecimal(options.state.latest.liquidity);
+  const feePips = parseUnsignedDecimal(options.state.latest.fee);
+  const ticks = replayTicks(options.state);
+  if (
+    sqrtPriceX96 === null ||
+    liquidityStart === null ||
+    feePips === null ||
+    feePips >= FEE_DENOMINATOR ||
+    ticks === null ||
+    options.state.latest.tick < MIN_TICK ||
+    options.state.latest.tick > MAX_TICK ||
+    sqrtPriceX96 < MIN_SQRT_RATIO ||
+    sqrtPriceX96 > MAX_SQRT_RATIO
+  ) {
+    return "malformed-replay-state";
+  }
+
+  let sqrt = sqrtPriceX96;
+  let tick = options.state.latest.tick;
+  let liquidity = liquidityStart;
+  let amountRemaining = options.amountIn;
+  let amountOut = 0n;
+
+  while (amountRemaining > 0n) {
+    if (liquidity <= 0n) return "outside-indexed-tick-range";
+    const nextTick = nextInitializedTick(ticks, tick, options.zeroForOne);
+    const targetTick = nextTick?.tick ?? (options.zeroForOne ? MIN_TICK : MAX_TICK);
+    const sqrtTarget = getSqrtRatioAtTick(targetTick);
+    const step = computeSwapStep({
+      sqrtPriceX96: sqrt,
+      sqrtTargetX96: sqrtTarget,
+      liquidity,
+      amountRemaining,
+      feePips,
+      zeroForOne: options.zeroForOne,
+    });
+    if (
+      step.amountIn === 0n &&
+      step.amountOut === 0n &&
+      step.sqrtNextX96 !== sqrtTarget
+    ) {
+      return "replay-failed";
+    }
+    amountRemaining -= step.amountIn + step.feeAmount;
+    amountOut += step.amountOut;
+    sqrt = step.sqrtNextX96;
+    if (sqrt !== sqrtTarget) break;
+    if (!nextTick) {
+      return amountRemaining > 0n
+        ? "outside-indexed-tick-range"
+        : { amountOut, sqrtPriceX96After: sqrt };
+    }
+    liquidity = options.zeroForOne
+      ? liquidity - nextTick.liquidityNet
+      : liquidity + nextTick.liquidityNet;
+    tick = options.zeroForOne ? nextTick.tick - 1 : nextTick.tick;
+  }
+
+  return amountOut > 0n
+    ? { amountOut, sqrtPriceX96After: sqrt }
+    : "replay-failed";
+}
+
+function unavailable(
+  requested: FamePoolQuoteRequest,
+  reason: FamePoolQuoteUnavailableReason,
+  metadata: Omit<
+    FamePoolQuoteUnavailableEntry,
+    "status" | "requested" | "reason"
+  > = {},
+): FamePoolQuoteUnavailableEntry {
+  return {
+    status: "unavailable",
+    requested,
+    reason,
+    ...metadata,
+  };
+}
+
+function quoteFromReplayState(options: {
+  request: FamePoolQuoteRequest;
+  state: FameClReplayStateCapsule;
+  maxFreshnessBlocks: number;
+}): FamePoolQuoteResponseEntry {
+  const { request, state } = options;
+  const latest = state.latest;
+  const direct =
+    sameAddress(request.tokenIn, latest.token0) &&
+    sameAddress(request.tokenOut, latest.token1);
+  const reverse =
+    sameAddress(request.tokenIn, latest.token1) &&
+    sameAddress(request.tokenOut, latest.token0);
+  if (!direct && !reverse) {
+    return unavailable(request, "token-direction-mismatch", {
+      poolId: latest.poolId,
+      chainId: latest.chainId,
+      poolAddress: latest.poolAddress,
+      observedThroughBlock: latest.observedThroughBlock,
+      sourceRegistryId: latest.sourceRegistryId,
+      maxFreshnessBlocks: options.maxFreshnessBlocks,
+    });
+  }
+
+  const replay = replaySlipstreamExactInput({
+    state,
+    zeroForOne: direct,
+    amountIn: BigInt(request.amountIn),
+  });
+  if (typeof replay === "string") {
+    return unavailable(request, replay, {
+      poolId: latest.poolId,
+      chainId: latest.chainId,
+      poolAddress: latest.poolAddress,
+      observedThroughBlock: latest.observedThroughBlock,
+      sourceRegistryId: latest.sourceRegistryId,
+      maxFreshnessBlocks: options.maxFreshnessBlocks,
+    });
+  }
+
+  return {
+    status: "quoted",
+    quoteKind: "cl-quote-v1",
+    poolId: latest.poolId,
+    chainId: latest.chainId,
+    poolAddress: latest.poolAddress,
+    token0: latest.token0,
+    token1: latest.token1,
+    tokenIn: request.tokenIn,
+    tokenOut: request.tokenOut,
+    venueFamily: latest.venueFamily,
+    tickSpacing: latest.tickSpacing,
+    amountIn: request.amountIn,
+    amountOut: replay.amountOut.toString(),
+    sqrtPriceX96: latest.sqrtPriceX96,
+    sqrtPriceX96After: replay.sqrtPriceX96After.toString(),
+    tick: latest.tick,
+    liquidity: latest.liquidity,
+    fee: latest.fee,
+    feeSource: latest.feeSource,
+    observedThroughBlock: latest.observedThroughBlock,
+    blockHash: latest.blockHash,
+    parentHash: latest.parentHash,
+    snapshotId: latest.snapshotId,
+    stateHash: latest.stateHash,
+    source: latest.source,
+    sourceRegistryId: latest.sourceRegistryId,
+    maxFreshnessBlocks: options.maxFreshnessBlocks,
+  };
+}
+
+export async function handleFamePoolQuoteBatchRequest({
+  request,
+  tableName,
+  db,
+  registry = famePoolStateRegistry,
+  producerMaxFreshnessBlocks = 120,
+  maxBatchSize = 64,
+}: {
+  request: unknown;
+  tableName: string;
+  db?: PoolStateDocumentClient;
+  registry?: FamePoolStateRegistryFile;
+  producerMaxFreshnessBlocks?: number;
+  maxBatchSize?: number;
+}): Promise<FamePoolQuoteBatchResponse> {
+  const parsed = parseFamePoolQuoteBatchRequest(request, maxBatchSize);
+
+  const effectiveMaxFreshnessBlocks = Math.min(
+    parsed.maxFreshnessBlocks ?? producerMaxFreshnessBlocks,
+    producerMaxFreshnessBlocks,
+  );
+  const sourceRegistryId = sourceRegistryIdFor(registry.source);
+  const registryById = registryMaps(registry);
+  const entries = parsed.quotes.map((quote) => ({
+    request: quote,
+    entry: registryById.get(quote.poolId),
+  }));
+  const clReplayPoolsById = new Map(
+    entries
+      .map(({ entry }) => entry)
+      .filter(
+        (entry): entry is ClReplayPool =>
+          entry !== undefined && isClReplayPool(entry),
+      )
+      .map((entry) => [entry.id, entry]),
+  );
+  const latestStates = await batchGetLatestClReplayPointers({
+    db,
+    tableName,
+    pools: [...clReplayPoolsById.values()],
+  });
+  const freshLatestStates = latestStates.filter((latest) => {
+    const entry = clReplayPoolsById.get(latest.poolId);
+    return (
+      entry !== undefined &&
+      clReplayLatestStateMatchesRegistry({ latest, entry, sourceRegistryId }) &&
+      freshnessStatus({
+        state: latest,
+        currentBlock: parsed.currentBlock,
+        maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+      }) === "fresh"
+    );
+  });
+  const clReplayStates = await batchGetClReplayStateCapsules({
+    db,
+    tableName,
+    latestStates: freshLatestStates,
+  });
+  const latestStatesByPoolId = new Map(
+    latestStates.map((state) => [state.poolId, state]),
+  );
+  const clReplayStatesByPoolId = new Map(
+    clReplayStates.map((state) => [state.latest.poolId, state]),
+  );
+
+  return {
+    sourceRegistryId,
+    currentBlock: parsed.currentBlock,
+    producerMaxFreshnessBlocks,
+    effectiveMaxFreshnessBlocks,
+    quotes: entries.map(({ request: requested, entry }) => {
+      if (!entry) {
+        return unavailable(requested, "missing-registry-entry");
+      }
+      if (!isClReplayPool(entry)) {
+        return unavailable(requested, "unsupported-pool", {
+          poolId: entry.id,
+          chainId: entry.chainId,
+          poolAddress: entry.poolAddress,
+        });
+      }
+
+      const latest = latestStatesByPoolId.get(entry.id);
+      if (!latest) {
+        return unavailable(requested, "missing-indexed-state", {
+          poolId: entry.id,
+          chainId: entry.chainId,
+          poolAddress: entry.poolAddress,
+        });
+      }
+      if (latest.sourceRegistryId !== sourceRegistryId) {
+        return unavailable(requested, "source-registry-mismatch", {
+          poolId: entry.id,
+          chainId: entry.chainId,
+          poolAddress: entry.poolAddress,
+          observedThroughBlock: latest.observedThroughBlock,
+          sourceRegistryId: latest.sourceRegistryId,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+        });
+      }
+      if (!clReplayLatestStateMatchesRegistry({ latest, entry, sourceRegistryId })) {
+        return unavailable(requested, "missing-indexed-state", {
+          poolId: entry.id,
+          chainId: entry.chainId,
+          poolAddress: entry.poolAddress,
+          observedThroughBlock: latest.observedThroughBlock,
+          sourceRegistryId: latest.sourceRegistryId,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+        });
+      }
+      if (
+        freshnessStatus({
+          state: latest,
+          currentBlock: parsed.currentBlock,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+        }) === "stale"
+      ) {
+        return unavailable(requested, "stale-indexed-state", {
+          poolId: entry.id,
+          chainId: entry.chainId,
+          poolAddress: entry.poolAddress,
+          observedThroughBlock: latest.observedThroughBlock,
+          sourceRegistryId: latest.sourceRegistryId,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+        });
+      }
+
+      const state = clReplayStatesByPoolId.get(entry.id);
+      if (
+        !state ||
+        !clReplayStateMatchesRegistry({ state, entry, sourceRegistryId })
+      ) {
+        return unavailable(requested, "missing-indexed-state", {
+          poolId: entry.id,
+          chainId: entry.chainId,
+          poolAddress: entry.poolAddress,
+          observedThroughBlock: latest.observedThroughBlock,
+          sourceRegistryId: latest.sourceRegistryId,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+        });
+      }
+
+      return quoteFromReplayState({
+        request: requested,
+        state,
+        maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+      });
+    }),
+  };
+}

--- a/src/fame-swap-pool-state/fixtures/pool-quotes-v1.json
+++ b/src/fame-swap-pool-state/fixtures/pool-quotes-v1.json
@@ -1,0 +1,810 @@
+{
+  "schemaVersion": 1,
+  "description": "Golden compact FAME pool quote response for reserve constant-product pools.",
+  "response": {
+    "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+    "currentBlock": 125,
+    "producerMaxFreshnessBlocks": 120,
+    "effectiveMaxFreshnessBlocks": 120,
+    "quotes": [
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "aerodrome-v2-usdc-weth",
+        "chainId": 8453,
+        "poolAddress": "0xcdac0d6c6c59727a65f871236188350531885c43",
+        "token0": "0x4200000000000000000000000000000000000006",
+        "token1": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenIn": "0x4200000000000000000000000000000000000006",
+        "tokenOut": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "venueFamily": "AerodromeV2",
+        "feeBps": 30,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "831",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "2500000000000000000",
+          "postSwapPriceX18": "1112666666666666666",
+          "executionPriceX18": "1662000000000000000",
+          "marketImpactBps": 3352,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "value": "831"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "value": "2500000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "value": "1112666666666666666"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "value": "3352"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "aerodrome-v2-usdc-weth",
+        "chainId": 8453,
+        "poolAddress": "0xcdac0d6c6c59727a65f871236188350531885c43",
+        "token0": "0x4200000000000000000000000000000000000006",
+        "token1": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenIn": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenOut": "0x4200000000000000000000000000000000000006",
+        "venueFamily": "AerodromeV2",
+        "feeBps": 30,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "166",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "400000000000000000",
+          "postSwapPriceX18": "278000000000000000",
+          "executionPriceX18": "332000000000000000",
+          "marketImpactBps": 1700,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "value": "166"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "value": "400000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "value": "278000000000000000"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "value": "1700"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for aerodrome-v2-usdc-weth",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "scale-equalizer-frxusd-fame",
+        "chainId": 8453,
+        "poolAddress": "0xeded4e8790e01199da13dfec93bf5432f1980489",
+        "token0": "0xe5020a6d073a794b6e7f05678707de47986fb0b6",
+        "token1": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenIn": "0xe5020a6d073a794b6e7f05678707de47986fb0b6",
+        "tokenOut": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "venueFamily": "Solidly",
+        "feeBps": 100,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "827",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "2500000000000000000",
+          "postSwapPriceX18": "1115333333333333333",
+          "executionPriceX18": "1654000000000000000",
+          "marketImpactBps": 3384,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "value": "827"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "value": "2500000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "value": "1115333333333333333"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "value": "3384"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "scale-equalizer-frxusd-fame",
+        "chainId": 8453,
+        "poolAddress": "0xeded4e8790e01199da13dfec93bf5432f1980489",
+        "token0": "0xe5020a6d073a794b6e7f05678707de47986fb0b6",
+        "token1": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenIn": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenOut": "0xe5020a6d073a794b6e7f05678707de47986fb0b6",
+        "venueFamily": "Solidly",
+        "feeBps": 100,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "165",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "400000000000000000",
+          "postSwapPriceX18": "278333333333333333",
+          "executionPriceX18": "330000000000000000",
+          "marketImpactBps": 1750,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "value": "165"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "value": "400000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "value": "278333333333333333"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "value": "1750"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for scale-equalizer-frxusd-fame",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "scale-equalizer-scale-fame",
+        "chainId": 8453,
+        "poolAddress": "0xbbf6e67f14ed21884d9e12505a9b979fc42808be",
+        "token0": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+        "token1": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenIn": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+        "tokenOut": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "venueFamily": "Solidly",
+        "feeBps": 100,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "827",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "2500000000000000000",
+          "postSwapPriceX18": "1115333333333333333",
+          "executionPriceX18": "1654000000000000000",
+          "marketImpactBps": 3384,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "value": "827"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "value": "2500000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "value": "1115333333333333333"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "value": "3384"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "scale-equalizer-scale-fame",
+        "chainId": 8453,
+        "poolAddress": "0xbbf6e67f14ed21884d9e12505a9b979fc42808be",
+        "token0": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+        "token1": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenIn": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenOut": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+        "venueFamily": "Solidly",
+        "feeBps": 100,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "165",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "400000000000000000",
+          "postSwapPriceX18": "278333333333333333",
+          "executionPriceX18": "330000000000000000",
+          "marketImpactBps": 1750,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "value": "165"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "value": "400000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "value": "278333333333333333"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "value": "1750"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for scale-equalizer-scale-fame",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "scale-equalizer-usdc-scale",
+        "chainId": 8453,
+        "poolAddress": "0xd467b1bb20e9c5569ad8bc91d2236a8ceb574075",
+        "token0": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+        "token1": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenIn": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+        "tokenOut": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "venueFamily": "Solidly",
+        "feeBps": 100,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "827",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "2500000000000000000",
+          "postSwapPriceX18": "1115333333333333333",
+          "executionPriceX18": "1654000000000000000",
+          "marketImpactBps": 3384,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "value": "827"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "value": "2500000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "value": "1115333333333333333"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "value": "3384"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "scale-equalizer-usdc-scale",
+        "chainId": 8453,
+        "poolAddress": "0xd467b1bb20e9c5569ad8bc91d2236a8ceb574075",
+        "token0": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+        "token1": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenIn": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenOut": "0x54016a4848a38f257b6e96331f7404073fd9c32c",
+        "venueFamily": "Solidly",
+        "feeBps": 100,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "165",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "400000000000000000",
+          "postSwapPriceX18": "278333333333333333",
+          "executionPriceX18": "330000000000000000",
+          "marketImpactBps": 1750,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "value": "165"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "value": "400000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "value": "278333333333333333"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "value": "1750"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for scale-equalizer-usdc-scale",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "scale-equalizer-weth-fame",
+        "chainId": 8453,
+        "poolAddress": "0x0db3a3228520fc31162c24f1b47177255cc1b82e",
+        "token0": "0x4200000000000000000000000000000000000006",
+        "token1": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenIn": "0x4200000000000000000000000000000000000006",
+        "tokenOut": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "venueFamily": "Solidly",
+        "feeBps": 100,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "827",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "2500000000000000000",
+          "postSwapPriceX18": "1115333333333333333",
+          "executionPriceX18": "1654000000000000000",
+          "marketImpactBps": 3384,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "value": "827"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "value": "2500000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "value": "1115333333333333333"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "value": "3384"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "scale-equalizer-weth-fame",
+        "chainId": 8453,
+        "poolAddress": "0x0db3a3228520fc31162c24f1b47177255cc1b82e",
+        "token0": "0x4200000000000000000000000000000000000006",
+        "token1": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenIn": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenOut": "0x4200000000000000000000000000000000000006",
+        "venueFamily": "Solidly",
+        "feeBps": 100,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "165",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "400000000000000000",
+          "postSwapPriceX18": "278333333333333333",
+          "executionPriceX18": "330000000000000000",
+          "marketImpactBps": 1750,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "value": "165"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "value": "400000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "value": "278333333333333333"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "value": "1750"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for scale-equalizer-weth-fame",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "uniswap-v2-fame-direct",
+        "chainId": 8453,
+        "poolAddress": "0x3e2cab55bebf41719148b4e6b63f6644b18ae49c",
+        "token0": "0x4200000000000000000000000000000000000006",
+        "token1": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenIn": "0x4200000000000000000000000000000000000006",
+        "tokenOut": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "venueFamily": "UniswapV2",
+        "feeBps": 30,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "831",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "2500000000000000000",
+          "postSwapPriceX18": "1112666666666666666",
+          "executionPriceX18": "1662000000000000000",
+          "marketImpactBps": 3352,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "value": "831"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "value": "2500000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "value": "1112666666666666666"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "value": "3352"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "uniswap-v2-fame-direct",
+        "chainId": 8453,
+        "poolAddress": "0x3e2cab55bebf41719148b4e6b63f6644b18ae49c",
+        "token0": "0x4200000000000000000000000000000000000006",
+        "token1": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenIn": "0xf307e242bfe1ec1ff01a4cef2fdaa81b10a52418",
+        "tokenOut": "0x4200000000000000000000000000000000000006",
+        "venueFamily": "UniswapV2",
+        "feeBps": 30,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "166",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "400000000000000000",
+          "postSwapPriceX18": "278000000000000000",
+          "executionPriceX18": "332000000000000000",
+          "marketImpactBps": 1700,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "value": "166"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "value": "400000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "value": "278000000000000000"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "value": "1700"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for uniswap-v2-fame-direct",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "uniswap-v2-usdc-weth",
+        "chainId": 8453,
+        "poolAddress": "0x88a43bbdf9d098eec7bceda4e2494615dfd9bb9c",
+        "token0": "0x4200000000000000000000000000000000000006",
+        "token1": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenIn": "0x4200000000000000000000000000000000000006",
+        "tokenOut": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "venueFamily": "UniswapV2",
+        "feeBps": 30,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "831",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "2500000000000000000",
+          "postSwapPriceX18": "1112666666666666666",
+          "executionPriceX18": "1662000000000000000",
+          "marketImpactBps": 3352,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "value": "831"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "value": "2500000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "value": "1112666666666666666"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "value": "3352"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      },
+      {
+        "status": "quoted",
+        "quoteKind": "constant-product-quote-v1",
+        "quoteModel": "constant-product-reserves",
+        "quoteModelVersion": 1,
+        "poolId": "uniswap-v2-usdc-weth",
+        "chainId": 8453,
+        "poolAddress": "0x88a43bbdf9d098eec7bceda4e2494615dfd9bb9c",
+        "token0": "0x4200000000000000000000000000000000000006",
+        "token1": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenIn": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+        "tokenOut": "0x4200000000000000000000000000000000000006",
+        "venueFamily": "UniswapV2",
+        "feeBps": 30,
+        "feeSource": "registry-fee",
+        "source": "reserve-pool-state",
+        "stateSource": "getReserves",
+        "amountIn": "500",
+        "amountOut": "166",
+        "observedThroughBlock": 120,
+        "sourceRegistryId": "pool-state-registry-v3:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
+        "maxFreshnessBlocks": 120,
+        "priceImpact": {
+          "preSwapPriceX18": "400000000000000000",
+          "postSwapPriceX18": "278000000000000000",
+          "executionPriceX18": "332000000000000000",
+          "marketImpactBps": 1700,
+          "method": "constant-product-reserves"
+        },
+        "protocolEvidence": {
+          "quote": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "value": "166"
+          },
+          "prePrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "value": "400000000000000000"
+          },
+          "postPrice": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "value": "278000000000000000"
+          },
+          "marketImpact": {
+            "status": "available",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "value": "1700"
+          },
+          "activeLiquidity": {
+            "status": "not_applicable",
+            "source": "reserve-pool-state quote for uniswap-v2-usdc-weth",
+            "reason": "Constant-product reserve quote uses reserves, not active liquidity."
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/fame-swap-pool-state/lambdas/api.test.ts
+++ b/src/fame-swap-pool-state/lambdas/api.test.ts
@@ -23,7 +23,7 @@ function eventFixture({
 }: {
   body?: string;
   headers?: Record<string, string | undefined>;
-  path?: "/fame/pool-state" | "/fame/pool-quotes";
+  path?: string;
 }): APIGatewayProxyEventV2 {
   const routeKey = `POST ${path}`;
   return {
@@ -344,6 +344,51 @@ describe("FAME pool-state API Lambda transport", () => {
       );
     } finally {
       successLog.mockRestore();
+    }
+  });
+
+  test("rejects unknown routes without dispatching to pool-state handling", async () => {
+    const warnLog = jest.spyOn(console, "warn").mockImplementation(() => {
+      return undefined;
+    });
+    let stateCalled = false;
+    let quoteCalled = false;
+
+    try {
+      const response = await requestHandler(
+        async () => {
+          stateCalled = true;
+          throw new Error("should not call state handler");
+        },
+        eventFixture({
+          path: "/fame/not-a-route",
+          body: JSON.stringify({
+            currentBlock: 125,
+            pools: [],
+          }),
+        }),
+        async () => {
+          quoteCalled = true;
+          throw new Error("should not call quote handler");
+        },
+      );
+
+      expect(structuredResponse(response).statusCode).toBe(400);
+      expect(jsonBody(response)).toMatchObject({
+        error: "invalid-request",
+        message: expect.stringContaining("/fame/not-a-route"),
+      });
+      expect(stateCalled).toBe(false);
+      expect(quoteCalled).toBe(false);
+      expect(warnLog).toHaveBeenCalledTimes(1);
+      expect(parseLogLine(warnLog.mock.calls[0]?.[0])).toMatchObject({
+        level: "warn",
+        event: "fame-pool-state-api-error",
+        errorType: "invalid-request",
+        message: expect.stringContaining("routeKind"),
+      });
+    } finally {
+      warnLog.mockRestore();
     }
   });
 

--- a/src/fame-swap-pool-state/lambdas/api.test.ts
+++ b/src/fame-swap-pool-state/lambdas/api.test.ts
@@ -4,19 +4,25 @@ import type {
   APIGatewayProxyResultV2,
   APIGatewayProxyStructuredResultV2,
 } from "aws-lambda";
-import type { FamePoolStateBatchHandler } from "./api.ts";
+import type {
+  FamePoolQuoteBatchHandler,
+  FamePoolStateBatchHandler,
+} from "./api.ts";
 
 function eventFixture({
   body,
   headers = { authorization: "Bearer unit-token" },
+  path = "/fame/pool-state",
 }: {
   body?: string;
   headers?: Record<string, string | undefined>;
+  path?: "/fame/pool-state" | "/fame/pool-quotes";
 }): APIGatewayProxyEventV2 {
+  const routeKey = `POST ${path}`;
   return {
     version: "2.0",
-    routeKey: "POST /fame/pool-state",
-    rawPath: "/fame/pool-state",
+    routeKey,
+    rawPath: path,
     rawQueryString: "",
     headers,
     requestContext: {
@@ -26,13 +32,13 @@ function eventFixture({
       domainPrefix: "api",
       http: {
         method: "POST",
-        path: "/fame/pool-state",
+        path,
         protocol: "HTTP/1.1",
         sourceIp: "127.0.0.1",
         userAgent: "jest",
       },
       requestId: "unit",
-      routeKey: "POST /fame/pool-state",
+      routeKey,
       stage: "$default",
       time: "18/May/2026:00:00:00 +0000",
       timeEpoch: 1_779_062_400_000,
@@ -77,6 +83,7 @@ async function loadApiModule(): Promise<typeof import("./api.ts")> {
 async function requestHandler(
   handler: FamePoolStateBatchHandler,
   event: APIGatewayProxyEventV2,
+  quoteHandler?: FamePoolQuoteBatchHandler,
 ): Promise<APIGatewayProxyResultV2> {
   const { handleFamePoolStateApiEvent } = await loadApiModule();
   return handleFamePoolStateApiEvent({
@@ -86,6 +93,9 @@ async function requestHandler(
     producerMaxFreshnessBlocks: 120,
     maxBatchSize: 64,
     handleBatchRequest: handler,
+    ...(quoteHandler === undefined
+      ? {}
+      : { handleQuoteBatchRequest: quoteHandler }),
   });
 }
 
@@ -149,6 +159,108 @@ describe("FAME pool-state API Lambda transport", () => {
     expect(structuredResponse(response).statusCode).toBe(401);
     expect(jsonBody(response)).toEqual({ error: "unauthorized" });
     expect(called).toBe(false);
+  });
+
+  test("dispatches pool quote requests to the compact quote handler", async () => {
+    const successLog = jest.spyOn(console, "log").mockImplementation(() => {
+      return undefined;
+    });
+    let stateCalled = false;
+    let capturedQuoteRequest: unknown;
+    try {
+      const response = await requestHandler(
+        async () => {
+          stateCalled = true;
+          throw new Error("should not call state handler");
+        },
+        eventFixture({
+          path: "/fame/pool-quotes",
+          body: JSON.stringify({
+            currentBlock: 125,
+            quotes: [],
+          }),
+        }),
+        async (options) => {
+          capturedQuoteRequest = options.request;
+          return {
+            sourceRegistryId: "unit",
+            currentBlock: 125,
+            producerMaxFreshnessBlocks: 120,
+            effectiveMaxFreshnessBlocks: 120,
+            quotes: [
+              {
+                status: "unavailable",
+                requested: {
+                  poolId: "missing",
+                  tokenIn: "0x0000000000000000000000000000000000000001",
+                  tokenOut: "0x0000000000000000000000000000000000000002",
+                  amountIn: "1",
+                },
+                reason: "missing-registry-entry",
+              },
+            ],
+          };
+        },
+      );
+
+      expect(structuredResponse(response).statusCode).toBe(200);
+      expect(jsonBody(response)).toMatchObject({
+        sourceRegistryId: "unit",
+        quotes: [expect.objectContaining({ status: "unavailable" })],
+      });
+      expect(stateCalled).toBe(false);
+      expect(capturedQuoteRequest).toEqual({
+        currentBlock: 125,
+        quotes: [],
+      });
+      expect(successLog).toHaveBeenCalledWith(
+        expect.stringContaining('"routeKind":"pool-quotes"'),
+      );
+      expect(successLog).toHaveBeenCalledWith(
+        expect.stringContaining('"missing-registry-entry":1'),
+      );
+    } finally {
+      successLog.mockRestore();
+    }
+  });
+
+  test("logs successful pool-state batches", async () => {
+    const successLog = jest.spyOn(console, "log").mockImplementation(() => {
+      return undefined;
+    });
+    try {
+      const response = await requestHandler(
+        async () => ({
+          sourceRegistryId: "unit",
+          currentBlock: 125,
+          producerMaxFreshnessBlocks: 120,
+          effectiveMaxFreshnessBlocks: 120,
+          pools: [
+            {
+              status: "unknown",
+              requested: { poolId: "missing" },
+              reason: "missing-registry-entry",
+            },
+          ],
+        }),
+        eventFixture({
+          body: JSON.stringify({
+            currentBlock: 125,
+            pools: [],
+          }),
+        }),
+      );
+
+      expect(structuredResponse(response).statusCode).toBe(200);
+      expect(successLog).toHaveBeenCalledWith(
+        expect.stringContaining('"routeKind":"pool-state"'),
+      );
+      expect(successLog).toHaveBeenCalledWith(
+        expect.stringContaining('"unknown":1'),
+      );
+    } finally {
+      successLog.mockRestore();
+    }
   });
 
   test("returns server failure for dependency errors", async () => {

--- a/src/fame-swap-pool-state/lambdas/api.ts
+++ b/src/fame-swap-pool-state/lambdas/api.ts
@@ -14,10 +14,17 @@ import {
 } from "../api.ts";
 import type { FamePoolStateBatchResponse } from "../api.ts";
 import { poolStateRequestAuthorized } from "../auth.ts";
+import {
+  handleFamePoolQuoteBatchRequest,
+  type FamePoolQuoteBatchResponse,
+} from "../cl-quote.ts";
 
 export type FamePoolStateBatchHandler = (
   options: Parameters<typeof handleFamePoolStateBatchRequest>[0],
 ) => Promise<FamePoolStateBatchResponse>;
+export type FamePoolQuoteBatchHandler = (
+  options: Parameters<typeof handleFamePoolQuoteBatchRequest>[0],
+) => Promise<FamePoolQuoteBatchResponse>;
 
 function serviceToken(): string {
   const token = process.env.FAME_POOL_STATE_SERVICE_TOKEN;
@@ -40,12 +47,56 @@ function jsonResponse(
   };
 }
 
-function statusCounts(response: { pools: Array<{ status: string }> }) {
+function poolStateStatusCounts(response: { pools: Array<{ status: string }> }) {
   const counts: Record<string, number> = {};
   for (const pool of response.pools) {
     counts[pool.status] = (counts[pool.status] ?? 0) + 1;
   }
   return counts;
+}
+
+function poolQuoteStatusCounts(response: {
+  quotes: Array<{ status: string; reason?: string }>;
+}) {
+  const statusCounts: Record<string, number> = {};
+  const reasonCounts: Record<string, number> = {};
+  for (const quote of response.quotes) {
+    statusCounts[quote.status] = (statusCounts[quote.status] ?? 0) + 1;
+    if (quote.status === "unavailable" && quote.reason) {
+      reasonCounts[quote.reason] = (reasonCounts[quote.reason] ?? 0) + 1;
+    }
+  }
+  return { statusCounts, reasonCounts };
+}
+
+function logPoolStateSuccess(response: FamePoolStateBatchResponse): void {
+  console.log(
+    JSON.stringify({
+      event: "fame-pool-state-api-batch",
+      routeKind: "pool-state",
+      sourceRegistryId: response.sourceRegistryId,
+      currentBlock: response.currentBlock,
+      effectiveMaxFreshnessBlocks: response.effectiveMaxFreshnessBlocks,
+      batchSize: response.pools.length,
+      statusCounts: poolStateStatusCounts(response),
+    }),
+  );
+}
+
+function logPoolQuoteSuccess(response: FamePoolQuoteBatchResponse): void {
+  const counts = poolQuoteStatusCounts(response);
+  console.log(
+    JSON.stringify({
+      event: "fame-pool-state-api-batch",
+      routeKind: "pool-quotes",
+      sourceRegistryId: response.sourceRegistryId,
+      currentBlock: response.currentBlock,
+      effectiveMaxFreshnessBlocks: response.effectiveMaxFreshnessBlocks,
+      batchSize: response.quotes.length,
+      statusCounts: counts.statusCounts,
+      reasonCounts: counts.reasonCounts,
+    }),
+  );
 }
 
 function parseJsonBody(body: string | undefined): unknown {
@@ -62,6 +113,11 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "unknown error";
 }
 
+function routeKind(event: APIGatewayProxyEventV2): "pool-quotes" | "pool-state" {
+  const path = event.rawPath || event.requestContext.http.path;
+  return path === "/fame/pool-quotes" ? "pool-quotes" : "pool-state";
+}
+
 export async function handleFamePoolStateApiEvent({
   event,
   serviceToken,
@@ -69,6 +125,7 @@ export async function handleFamePoolStateApiEvent({
   producerMaxFreshnessBlocks,
   maxBatchSize,
   handleBatchRequest = handleFamePoolStateBatchRequest,
+  handleQuoteBatchRequest = handleFamePoolQuoteBatchRequest,
 }: {
   event: APIGatewayProxyEventV2;
   serviceToken: string;
@@ -76,6 +133,7 @@ export async function handleFamePoolStateApiEvent({
   producerMaxFreshnessBlocks: number;
   maxBatchSize: number;
   handleBatchRequest?: FamePoolStateBatchHandler;
+  handleQuoteBatchRequest?: FamePoolQuoteBatchHandler;
 }): Promise<APIGatewayProxyResultV2> {
   if (!poolStateRequestAuthorized(event.headers, serviceToken)) {
     return jsonResponse(401, {
@@ -84,22 +142,25 @@ export async function handleFamePoolStateApiEvent({
   }
 
   try {
+    const parsedBody = parseJsonBody(event.body);
+    const kind = routeKind(event);
+    if (kind === "pool-quotes") {
+      const response = await handleQuoteBatchRequest({
+        request: parsedBody,
+        tableName,
+        producerMaxFreshnessBlocks,
+        maxBatchSize,
+      });
+      logPoolQuoteSuccess(response);
+      return jsonResponse(200, response);
+    }
     const response = await handleBatchRequest({
-      request: parseJsonBody(event.body),
+      request: parsedBody,
       tableName,
       producerMaxFreshnessBlocks,
       maxBatchSize,
     });
-    console.log(
-      JSON.stringify({
-        event: "fame-pool-state-api-batch",
-        sourceRegistryId: response.sourceRegistryId,
-        currentBlock: response.currentBlock,
-        effectiveMaxFreshnessBlocks: response.effectiveMaxFreshnessBlocks,
-        batchSize: response.pools.length,
-        statusCounts: statusCounts(response),
-      }),
-    );
+    logPoolStateSuccess(response);
     return jsonResponse(200, response);
   } catch (error) {
     if (isFamePoolStateRequestError(error)) {

--- a/src/fame-swap-pool-state/lambdas/api.ts
+++ b/src/fame-swap-pool-state/lambdas/api.ts
@@ -66,9 +66,15 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "unknown error";
 }
 
-function routeKind(event: APIGatewayProxyEventV2): "pool-quotes" | "pool-state" {
+function routeKind(
+  event: APIGatewayProxyEventV2,
+): "pool-quotes" | "pool-state" {
   const path = event.rawPath || event.requestContext.http.path;
-  return path === "/fame/pool-quotes" ? "pool-quotes" : "pool-state";
+  if (path === "/fame/pool-quotes") return "pool-quotes";
+  if (path === "/fame/pool-state") return "pool-state";
+  throw new FamePoolStateRequestError(
+    `FAME pool-state request invalid at routeKind: expected /fame/pool-state or /fame/pool-quotes, received ${path}.`,
+  );
 }
 
 export async function handleFamePoolStateApiEvent({
@@ -95,8 +101,8 @@ export async function handleFamePoolStateApiEvent({
   }
 
   try {
-    const parsedBody = parseJsonBody(event.body);
     const kind = routeKind(event);
+    const parsedBody = parseJsonBody(event.body);
     if (kind === "pool-quotes") {
       const response = await handleQuoteBatchRequest({
         request: parsedBody,


### PR DESCRIPTION
## Summary

`society-bots` can now return exact-input CL quotes for the indexed `slipstream-usdc-weth-100` pool without sending raw bitmap/tick replay state to downstream quote consumers. Raw `cl-replay-v1` state remains available through the existing pool-state surface for parity and debug work, while `/fame/pool-quotes` gives `www` a compact `cl-quote-v1` response for the normal quote path once its companion branch is configured.

## What Changed

- Adds an authenticated `/fame/pool-quotes` route to the shared prod and dev HTTP APIs, including a `FamePoolQuotesDevEndpointUrl` output for dev wiring.
- Adds a compact quote handler that loads fresh indexed replay state for `slipstream-usdc-weth-100` and returns either a quoted `cl-quote-v1` entry or typed `unavailable` metadata.
- Keeps stale, incomplete, unsupported, and missing-state responses metadata-only; compact quote responses do not include raw `bitmapWords` or `initializedTicks`.
- Restores aggregate success logging for both pool-state and pool-quotes route kinds without logging request bodies, tokens, or raw replay payloads.

## Dev Deploy Notes

Use the new `FamePoolQuotesDevEndpointUrl` output as `FAME_POOL_QUOTE_API_URL` in the companion `www` branch. Before letting compact CL quotes carry user-facing execution, run a same-block smoke comparing `/fame/pool-quotes` output against the live Slipstream quoter.

Durable follow-ups are intentionally left for the next hardening slice: bounded replay work, per-quote replay exception containment, and richer compact quote observability in `www`.

## Tests

- `TMPDIR=/tmp node --experimental-vm-modules ./node_modules/.bin/jest src/fame-swap-pool-state/api.test.ts`
- `TMPDIR=/tmp node --experimental-vm-modules ./node_modules/.bin/jest src/fame-swap-pool-state/api.test.ts src/fame-swap-pool-state/lambdas/api.test.ts`
- `cd deploy && TMPDIR=/tmp node --experimental-vm-modules ./node_modules/.bin/jest test/fame-pool-state.test.ts`
- `TMPDIR=/tmp ./node_modules/.bin/tsc --noEmit --tsBuildInfoFile /tmp/society-bots.tsbuildinfo -p tsconfig.json`
- `git diff --check`
- Confirmed the staged diff has no CloudWatch/log-retention changes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
