### PR TITLE
fix(fame): reduce pool-state tick snapshot retention

### DIFF
--- a/deploy/lib/fame-pool-state.ts
+++ b/deploy/lib/fame-pool-state.ts
@@ -270,7 +270,9 @@ export class FamePoolState extends Construct {
     table.grantReadData(apiLambda);
 
     const scheduleRule = new events.Rule(this, "FamePoolStateScheduleRule", {
-      schedule: events.Schedule.rate(props.schedule ?? cdk.Duration.minutes(1)),
+      schedule: events.Schedule.rate(
+        props.schedule ?? cdk.Duration.minutes(30),
+      ),
     });
     scheduleRule.addTarget(
       new eventTargets.LambdaFunction(indexerLambda, {

--- a/deploy/test/fame-pool-state.test.ts
+++ b/deploy/test/fame-pool-state.test.ts
@@ -77,7 +77,7 @@ describe("FamePoolState infrastructure", () => {
       RetentionInDays: 7,
     });
     template.hasResourceProperties("AWS::Events::Rule", {
-      ScheduleExpression: "rate(1 minute)",
+      ScheduleExpression: "rate(30 minutes)",
       State: "ENABLED",
     });
   });

--- a/src/fame-swap-pool-state/dynamodb/pool-state.test.ts
+++ b/src/fame-swap-pool-state/dynamodb/pool-state.test.ts
@@ -134,6 +134,12 @@ function numberField(item: Record<string, unknown>, key: string): number {
   return value;
 }
 
+function firstItem<T>(items: readonly T[], label: string): T {
+  const item = items[0];
+  if (!item) throw new Error(`Missing ${label}.`);
+  return item;
+}
+
 class ReplayStateDb implements PoolStateDocumentClient {
   public readonly commands: SentCommand[] = [];
   public readonly items = new Map<string, Record<string, unknown>>();
@@ -673,11 +679,27 @@ describe("FAME pool-state DynamoDB mapping", () => {
           rows.latest,
           ...rows.bitmapChunks,
           {
-            ...rows.tickChunks[0],
+            ...firstItem(rows.tickChunks, "CL replay tick chunk"),
             initializedTicks: [
               { tick: 199_900, liquidityGross: "25", liquidityNet: 15 },
             ],
           },
+        ]),
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).rejects.toThrow(/Invalid CL replay tick chunk DynamoDB item/);
+
+    const {
+      expiresAt: _expiresAt,
+      ...tickChunkWithoutExpiresAt
+    } = firstItem(rows.tickChunks, "CL replay tick chunk");
+    await expect(
+      batchGetLatestClReplayStates({
+        db: new ReplayStateDb([
+          rows.latest,
+          ...rows.bitmapChunks,
+          tickChunkWithoutExpiresAt,
         ]),
         tableName: "PoolState",
         pools: [pool],

--- a/src/fame-swap-pool-state/dynamodb/pool-state.ts
+++ b/src/fame-swap-pool-state/dynamodb/pool-state.ts
@@ -167,7 +167,7 @@ export interface FameClReplayBitmapChunkState extends Record<string, unknown> {
   source: FameClReplaySource;
   sourceRegistryId: string;
   updatedAt: string;
-  expiresAt?: number;
+  expiresAt: number;
   chunkIndex: number;
   bitmapWords: FameClReplayBitmapWord[];
 }
@@ -187,7 +187,7 @@ export interface FameClReplayTickChunkState extends Record<string, unknown> {
   source: FameClReplaySource;
   sourceRegistryId: string;
   updatedAt: string;
-  expiresAt?: number;
+  expiresAt: number;
   chunkIndex: number;
   initializedTicks: FameClReplayInitializedTick[];
 }
@@ -837,6 +837,7 @@ function parseClReplayBitmapChunkItem(
     source: clReplaySourceField(item, recordType, "source"),
     sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
     updatedAt: stringField(item, recordType, "updatedAt"),
+    expiresAt: numberField(item, recordType, "expiresAt"),
     chunkIndex: numberField(item, recordType, "chunkIndex"),
     bitmapWords: arrayField(item, recordType, "bitmapWords").map(
       (entry, index) =>
@@ -873,6 +874,7 @@ function parseClReplayTickChunkItem(
     source: clReplaySourceField(item, recordType, "source"),
     sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
     updatedAt: stringField(item, recordType, "updatedAt"),
+    expiresAt: numberField(item, recordType, "expiresAt"),
     chunkIndex: numberField(item, recordType, "chunkIndex"),
     initializedTicks: arrayField(item, recordType, "initializedTicks").map(
       (entry, index) =>
@@ -1134,7 +1136,7 @@ export function latestClHeadStateFromSnapshot(options: {
 
 export const CL_REPLAY_DEFAULT_BITMAP_WORDS_PER_CHUNK = 128;
 export const CL_REPLAY_DEFAULT_TICKS_PER_CHUNK = 128;
-export const CL_REPLAY_CHUNK_TTL_SECONDS = 7 * 24 * 60 * 60;
+export const CL_REPLAY_CHUNK_TTL_SECONDS = 2 * 60 * 60;
 
 function assertNonNegativeBigInt(value: bigint, field: string): void {
   if (value < 0n) {
@@ -1156,6 +1158,17 @@ function epochSecondsFromIsoTimestamp(value: string, field: string): number {
     throw new Error(`CL replay snapshot ${field} must be an ISO timestamp.`);
   }
   return Math.floor(milliseconds / 1_000);
+}
+
+function expiresAtFromIsoTimestamp(value: string, field: string): number {
+  const expiresAt =
+    epochSecondsFromIsoTimestamp(value, field) + CL_REPLAY_CHUNK_TTL_SECONDS;
+  if (!Number.isSafeInteger(expiresAt) || expiresAt <= 0) {
+    throw new Error(
+      `CL replay snapshot ${field} must produce a valid DynamoDB TTL timestamp.`,
+    );
+  }
+  return expiresAt;
 }
 
 function canonicalUint256Hex(value: bigint): Hex {
@@ -1244,9 +1257,10 @@ export function clReplayStateRowsFromSnapshot(options: {
       };
     });
 
-  const chunkExpiresAt =
-    epochSecondsFromIsoTimestamp(options.updatedAt, "updatedAt") +
-    CL_REPLAY_CHUNK_TTL_SECONDS;
+  const chunkExpiresAt = expiresAtFromIsoTimestamp(
+    options.updatedAt,
+    "updatedAt",
+  );
 
   assertStrictlyIncreasing(
     bitmapWords.map((word) => word.wordPosition),


### PR DESCRIPTION
## Summary

FAME pool-state replay snapshots no longer run every minute or leave full tick snapshot chunks around for days. The indexer now defaults to 30-minute scheduled captures, and CL replay bitmap/tick chunks expire after 2 hours with read-time validation that `expiresAt` is present and numeric.

This keeps a few recent fallback/debug snapshots available while reducing unnecessary DynamoDB storage churn from old liquidity tick rows.

## Validation

- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn test src/fame-swap-pool-state/dynamodb/pool-state.test.ts`
- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn test fame-pool-state.test.ts` in `deploy`
- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn types`
- `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn build` in `deploy`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)