### PR TITLE
feat(fame): add delta CL replay maintenance

### DIFF
--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -43,6 +43,8 @@ jobs:
         env:
           BASE_RPCS_JSON: ${{ secrets.BASE_RPCS_JSON }}
           FAME_POOL_STATE_SERVICE_TOKEN: ${{ secrets.FAME_POOL_STATE_DEV_SERVICE_TOKEN }}
+          FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE: ${{ vars.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE }}
+          FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION: ${{ vars.FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION }}
         run: bash scripts/validate-fame-pool-state-deploy-config.sh
 
       - name: Deploy CDK Dev Stack
@@ -52,6 +54,8 @@ jobs:
           ENABLE_EVENT_SCHEDULES: "false"
           BASE_RPCS_JSON: ${{ secrets.BASE_RPCS_JSON }}
           FAME_POOL_STATE_SERVICE_TOKEN: ${{ secrets.FAME_POOL_STATE_DEV_SERVICE_TOKEN }}
+          FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE: ${{ vars.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE }}
+          FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION: ${{ vars.FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION }}
           MAINNET_RPCS_JSON: ${{ secrets.MAINNET_RPCS_JSON }}
           SEPOLIA_RPCS_JSON: ${{ secrets.SEPOLIA_RPCS_JSON }}
           DISCORD_APP_ID: ${{ secrets.DISCORD_APP_ID }}
@@ -102,6 +106,8 @@ jobs:
         env:
           BASE_RPCS_JSON: ${{ secrets.BASE_RPCS_JSON }}
           FAME_POOL_STATE_SERVICE_TOKEN: ${{ secrets.FAME_POOL_STATE_DEV_SERVICE_TOKEN }}
+          FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE: ${{ vars.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE }}
+          FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION: ${{ vars.FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION }}
         run: bash scripts/validate-fame-pool-state-deploy-config.sh
 
       - name: Bootstrap CDK
@@ -110,6 +116,8 @@ jobs:
           POOL_STATE_ONLY: "true"
           BASE_RPCS_JSON: ${{ secrets.BASE_RPCS_JSON }}
           FAME_POOL_STATE_DEV_SERVICE_TOKEN: ${{ secrets.FAME_POOL_STATE_DEV_SERVICE_TOKEN }}
+          FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE: ${{ vars.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE }}
+          FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION: ${{ vars.FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION }}
         run: cdk bootstrap
         working-directory: deploy/
 
@@ -119,6 +127,8 @@ jobs:
           POOL_STATE_ONLY: "true"
           BASE_RPCS_JSON: ${{ secrets.BASE_RPCS_JSON }}
           FAME_POOL_STATE_DEV_SERVICE_TOKEN: ${{ secrets.FAME_POOL_STATE_DEV_SERVICE_TOKEN }}
+          FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE: ${{ vars.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE }}
+          FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION: ${{ vars.FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION }}
         run: cdk deploy --require-approval never --all
         working-directory: deploy/
 
@@ -178,6 +188,8 @@ jobs:
         env:
           BASE_RPCS_JSON: ${{ secrets.BASE_RPCS_JSON }}
           FAME_POOL_STATE_SERVICE_TOKEN: ${{ secrets.FAME_POOL_STATE_PR_SERVICE_TOKEN }}
+          FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE: ${{ vars.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE }}
+          FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION: ${{ vars.FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION }}
         run: bash scripts/validate-fame-pool-state-deploy-config.sh
 
       - name: Bootstrap CDK
@@ -192,6 +204,8 @@ jobs:
           ALCHEMY_WEBHOOK_SIGNING_KEY: ${{ secrets.ALCHEMY_WEBHOOK_SIGNING_KEY }}
           BASE_RPCS_JSON: ${{ secrets.BASE_RPCS_JSON }}
           FAME_POOL_STATE_SERVICE_TOKEN: ${{ secrets.FAME_POOL_STATE_PR_SERVICE_TOKEN }}
+          FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE: ${{ vars.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE }}
+          FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION: ${{ vars.FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION }}
           MAINNET_RPCS_JSON: ${{ secrets.MAINNET_RPCS_JSON }}
           SEPOLIA_RPCS_JSON: ${{ secrets.SEPOLIA_RPCS_JSON }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}

--- a/deploy/lib/deploy-stack.ts
+++ b/deploy/lib/deploy-stack.ts
@@ -44,6 +44,16 @@ export class DeployInfraStack extends cdk.Stack {
     } = new FamePoolState(this, "FamePoolState", {
       baseRpcsJson: process.env.BASE_RPCS_JSON,
       serviceToken: process.env.FAME_POOL_STATE_SERVICE_TOKEN ?? "",
+      clReplayMaintenanceMode:
+        process.env.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE === "steady-state" ||
+        process.env.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE === "repair"
+          ? process.env.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE
+          : "checkpoint",
+      clReplayTrustPromotion:
+        process.env.FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION === "true",
+      clReplayMaxRangeBlocks: Number(
+        process.env.FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS ?? "1000",
+      ),
     });
 
     const { httpApi } = new HttpApi(this, "SocietyBotREST", {

--- a/deploy/lib/fame-pool-state-dev-stack.ts
+++ b/deploy/lib/fame-pool-state-dev-stack.ts
@@ -14,6 +14,16 @@ export class FamePoolStateDevStack extends cdk.Stack {
     const poolState = new FamePoolState(this, "FamePoolState", {
       baseRpcsJson: process.env.BASE_RPCS_JSON,
       serviceToken: process.env.FAME_POOL_STATE_DEV_SERVICE_TOKEN ?? "",
+      clReplayMaintenanceMode:
+        process.env.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE === "steady-state" ||
+        process.env.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE === "repair"
+          ? process.env.FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE
+          : "checkpoint",
+      clReplayTrustPromotion:
+        process.env.FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION === "true",
+      clReplayMaxRangeBlocks: Number(
+        process.env.FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS ?? "1000",
+      ),
     });
 
     const httpApi = new apigw2.HttpApi(this, "FamePoolStateDevApi", {

--- a/deploy/lib/fame-pool-state.ts
+++ b/deploy/lib/fame-pool-state.ts
@@ -285,7 +285,7 @@ export class FamePoolState extends Construct {
 
     const scheduleRule = new events.Rule(this, "FamePoolStateScheduleRule", {
       schedule: events.Schedule.rate(
-        props.schedule ?? cdk.Duration.minutes(30),
+        props.schedule ?? cdk.Duration.minutes(1),
       ),
     });
     scheduleRule.addTarget(

--- a/deploy/lib/fame-pool-state.ts
+++ b/deploy/lib/fame-pool-state.ts
@@ -21,6 +21,9 @@ export interface FamePoolStateProps {
   readonly apiReservedConcurrency?: number;
   readonly defaultMaxFreshnessBlocks?: number;
   readonly maxBatchSize?: number;
+  readonly clReplayMaintenanceMode?: "checkpoint" | "steady-state" | "repair";
+  readonly clReplayTrustPromotion?: boolean;
+  readonly clReplayMaxRangeBlocks?: number;
   readonly schedule?: cdk.Duration;
 }
 
@@ -104,6 +107,13 @@ export class FamePoolState extends Construct {
     const defaultMaxFreshnessBlocks =
       props.defaultMaxFreshnessBlocks?.toString() ?? "120";
     const maxBatchSize = props.maxBatchSize?.toString() ?? "64";
+    const clReplayMaintenanceMode =
+      props.clReplayMaintenanceMode ?? "checkpoint";
+    const clReplayTrustPromotion = props.clReplayTrustPromotion
+      ? "true"
+      : "false";
+    const clReplayMaxRangeBlocks =
+      props.clReplayMaxRangeBlocks?.toString() ?? "1000";
 
     const table = new dynamodb.Table(this, "FamePoolState", {
       partitionKey: { name: "pk", type: dynamodb.AttributeType.STRING },
@@ -140,6 +150,10 @@ export class FamePoolState extends Construct {
       environment: {
         ...commonEnvironment,
         BASE_RPCS_JSON: baseRpcsJson,
+        FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE:
+          clReplayMaintenanceMode,
+        FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION: clReplayTrustPromotion,
+        FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS: clReplayMaxRangeBlocks,
       },
     });
     table.grantReadWriteData(indexerLambda);

--- a/deploy/test/fame-pool-state.test.ts
+++ b/deploy/test/fame-pool-state.test.ts
@@ -133,6 +133,9 @@ describe("FamePoolState infrastructure", () => {
           BASE_RPCS_JSON: JSON.stringify(["https://base.example"]),
           FAME_POOL_STATE_DEFAULT_MAX_FRESHNESS_BLOCKS: "120",
           FAME_POOL_STATE_MAX_BATCH_SIZE: "64",
+          FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE: "checkpoint",
+          FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION: "false",
+          FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS: "1000",
         }),
       },
       Timeout: 60,
@@ -429,6 +432,8 @@ describe("FamePoolState infrastructure", () => {
     expect(bootstrapStep).toBeGreaterThan(-1);
     expect(preflightStep).toBeLessThan(bootstrapStep);
     expect(workflow).toContain("FAME_POOL_STATE_PR_SERVICE_TOKEN");
+    expect(workflow).toContain("FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE");
+    expect(workflow).toContain("FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION");
     expect(workflow).not.toContain(
       "FAME_POOL_STATE_SERVICE_TOKEN: ${{ secrets.FAME_POOL_STATE_SERVICE_TOKEN }}",
     );
@@ -450,6 +455,8 @@ describe("FamePoolState infrastructure", () => {
     expect(workflow).toContain("DEPLOY_DEV");
     expect(workflow).toContain("STAGE: dev");
     expect(workflow).toContain("FAME_POOL_STATE_DEV_SERVICE_TOKEN");
+    expect(workflow).toContain("FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE");
+    expect(workflow).toContain("FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION");
     expect(workflow).toContain('ENABLE_EVENT_SCHEDULES: "false"');
     expect(workflow).toContain(
       'IMAGE_BASE_HOST_JSON: \'["dev","fame.support"]\'',
@@ -472,6 +479,8 @@ describe("FamePoolState infrastructure", () => {
     expect(job).toContain('POOL_STATE_ONLY: "true"');
     expect(job).toContain("BASE_RPCS_JSON");
     expect(job).toContain("FAME_POOL_STATE_DEV_SERVICE_TOKEN");
+    expect(job).toContain("FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE");
+    expect(job).toContain("FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION");
     expect(job).toContain("run: cdk bootstrap");
     expect(job).not.toContain("CDK bootstrap already done or failed");
     expect(job).not.toContain("IMAGE_BASE_HOST_JSON");

--- a/deploy/test/fame-pool-state.test.ts
+++ b/deploy/test/fame-pool-state.test.ts
@@ -77,7 +77,7 @@ describe("FamePoolState infrastructure", () => {
       RetentionInDays: 7,
     });
     template.hasResourceProperties("AWS::Events::Rule", {
-      ScheduleExpression: "rate(30 minutes)",
+      ScheduleExpression: "rate(1 minute)",
       State: "ENABLED",
     });
   });

--- a/docs/brainstorms/2026-05-29-fame-delta-cl-replay-index-requirements.md
+++ b/docs/brainstorms/2026-05-29-fame-delta-cl-replay-index-requirements.md
@@ -1,0 +1,177 @@
+---
+date: 2026-05-29
+topic: fame-delta-cl-replay-index
+---
+
+# FAME Delta CL Replay Index Requirements
+
+## Summary
+
+Build a delta-maintained CL replay index for the existing reviewed replay pools. Full snapshots remain the seed, checkpoint, and repair mechanism; normal trusted maintenance is earned through bounded event replay, drift checks, and explicit fallback-safe producer state.
+
+---
+
+## Problem Frame
+
+The FAME indexed quote path has already proven that complete `cl-replay-v1` snapshots can support compact CL quote rows while preserving `www` live fallback. The next pain is operational: a full replay snapshot is expensive because it reads block identity, head state, dynamic fee, bitmap words, and initialized ticks for every reviewed replay pool.
+
+The current replay pool set is intentionally small, but the steady-state maintenance model still rereads full replay state on each indexer wake. That makes provider pressure scale with snapshot size instead of actual pool activity. The prior snapshot-first proof remains valuable as an audit tool, but it should not be the only model for keeping replay state fresh.
+
+```mermaid
+flowchart TB
+  Snapshot["Complete full snapshot"]
+  Delta["Bounded pool events"]
+  Reducer["Delta-maintained replay state"]
+  Checkpoint["Full-snapshot drift check"]
+  Producer["Compact quote producer state"]
+  Consumer["www quote validation and live fallback"]
+
+  Snapshot --> Reducer
+  Delta --> Reducer
+  Reducer --> Checkpoint
+  Checkpoint --> Producer
+  Producer --> Consumer
+  Consumer -->|fallback when untrusted| Consumer
+```
+
+---
+
+## Actors
+
+- A1. `society-bots` pool-state indexer: Maintains reviewed indexed state and publishes producer evidence.
+- A2. `society-bots` pool-state API: Serves compact quote rows and replay-state diagnostics to server-side callers.
+- A3. `www` quote system: Validates producer output, keeps route and quote authority, and falls back live when indexed output is untrusted.
+- A4. Operator/reviewer: Uses logs, smoke output, parity, and cost evidence to decide whether the delta lane is healthy.
+- A5. Base RPC provider: Supplies block, log, and checkpoint reads whose volume and reliability shape the rollout.
+
+---
+
+## Key Flows
+
+- F1. Delta state advances
+  - **Trigger:** The pool-state indexer reaches a new safe Base block.
+  - **Actors:** A1, A5
+  - **Steps:** The indexer starts from a complete replay state, scans a bounded event range for the reviewed replay pools, applies supported CL events in chain order, records the resulting maintenance state, and advances the cursor only after the range is complete.
+  - **Outcome:** Each reviewed replay pool has either fresh delta-maintained replay state or an explicit untrusted maintenance status.
+  - **Covered by:** R1, R2, R3, R4, R5, R6
+
+- F2. Drift is checked and repaired
+  - **Trigger:** A scheduled checkpoint, an operator action, or a maintenance anomaly requires a full-state comparison.
+  - **Actors:** A1, A4, A5
+  - **Steps:** The system captures a complete full snapshot, compares it with the delta-maintained state at a comparable block, marks drift-clean state trusted, and marks mismatched state untrusted until repair reseeds it from a complete checkpoint.
+  - **Outcome:** Full snapshots remain the source of audit confidence without being the ordinary maintenance algorithm.
+  - **Covered by:** R7, R8, R9, R10
+
+- F3. Compact CL quotes are consumed safely
+  - **Trigger:** `www` requests compact quote rows for a route that can use a reviewed replay pool.
+  - **Actors:** A2, A3
+  - **Steps:** The API returns quoted rows only when replay state is fresh, complete, and drift-clean. Otherwise it returns typed unavailable evidence, and `www` keeps using live quote paths.
+  - **Outcome:** User-facing quote correctness stays boring while reducer health becomes visible to operators.
+  - **Covered by:** R11, R12, R13, R14
+
+- F4. Rollout evidence is reviewed
+  - **Trigger:** The delta lane is ready for promotion from shadow or operator review.
+  - **Actors:** A1, A3, A4
+  - **Steps:** The reviewer checks provider-read counts, event ranges, changed event counts, drift results, compact quote usage, fallback counts, parity evidence, and cost trajectory before trusting the lane.
+  - **Outcome:** The feature is accepted only when it proves both correctness and reduced steady-state provider pressure.
+  - **Covered by:** R15, R16, R17
+
+---
+
+## Requirements
+
+**Scope and authority**
+
+- R1. The delta lane must cover the existing reviewed `cl-replay-v1` replay pool set only; adding more CL pools is out of scope for this feature.
+- R2. `society-bots` must remain the producer of replay state, maintenance provenance, and compact quote rows; `www` must remain responsible for route validation, quote safety, and live fallback.
+- R3. Full replay snapshots must remain valid seed, checkpoint, and repair artifacts, but the feature must not depend on full snapshots as the normal trusted maintenance algorithm.
+
+**Delta maintenance**
+
+- R4. Delta maintenance must start only from complete replay state for the pool being maintained.
+- R5. A normal maintenance pass must scan bounded pool-event ranges from the last trusted cursor to the safe block and apply supported CL deltas in deterministic chain order.
+- R6. The maintenance cursor must advance only after the whole scanned range has been applied and the resulting replay state is complete enough for quote validation.
+- R7. Event gaps, ambiguous block identity, unsupported replay-affecting events, range-limit failures, or inconsistent reducer output must make the replay state untrusted rather than fresh.
+
+**Drift and repair**
+
+- R8. Full snapshots must be usable as low-cadence drift checkpoints for delta-maintained state.
+- R9. Drift checks must fail closed: mismatched state is not eligible for compact CL quote rows until a complete repair reseeds trusted state.
+- R10. Maintenance state must distinguish at least trusted, warming, drift-failed, repairing, and event-gap conditions in a way operators and `www` diagnostics can understand.
+
+**Quote consumption and fallback**
+
+- R11. `/fame/pool-quotes` may return compact CL quoted rows only when the underlying replay state is fresh, complete, cursor-current, and drift-clean.
+- R12. When replay state is warming, stale, drift-failed, repairing, event-gapped, malformed, outside range, or otherwise untrusted, the API must return unavailable quote evidence rather than a best-effort CL quote.
+- R13. `www` must continue to fall back live whenever compact CL quote rows are unavailable, mismatched, stale, invalid, slow, or producer-untrusted.
+- R14. Raw replay payloads must stay off the normal hot quote path; they remain useful for proof, parity, and diagnostics rather than ordinary quote traffic.
+
+**Evidence and rollout**
+
+- R15. Promotion evidence must show correctness signals: drift-check result, replay parity or equivalent quote-validation proof, compact quote used count, fallback count, and unavailable reasons.
+- R16. Promotion evidence must show provider-pressure signals: full snapshot count, provider read count, scanned block ranges, event counts, applied delta counts, and an estimated steady-state cost trajectory.
+- R17. Documentation and release evidence must make the claim precise: the feature proves cheaper trusted steady-state replay maintenance, not emergency spend stoppage, broad CL expansion, or a new quote authority boundary.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R4, R5, R6.** Given a reviewed replay pool with complete seed state and a bounded event range, when the indexer applies every supported event in order, it publishes fresh trusted maintenance state and advances the cursor.
+- AE2. **Covers R7, R12, R13.** Given the indexer detects an event gap or unsupported replay-affecting event, when compact quotes are requested, the producer returns unavailable evidence and `www` falls back live.
+- AE3. **Covers R8, R9, R10.** Given a full checkpoint state does not match the delta-maintained state, when drift is evaluated, the pool becomes drift-failed and stays ineligible for compact CL quoted rows until repaired from a complete checkpoint.
+- AE4. **Covers R11, R14.** Given delta-maintained state is fresh and drift-clean, when `/fame/pool-quotes` serves a CL quote, the row is compact and does not include raw bitmap words or initialized tick arrays.
+- AE5. **Covers R15, R16, R17.** Given the feature is ready for review, when an operator reads the promotion evidence, they can see both quote correctness proof and reduced steady-state provider-read pressure.
+
+---
+
+## Success Criteria
+
+- The existing reviewed replay pools can be maintained from complete seed state by applying bounded event deltas instead of relying on full replay snapshots as the ordinary trusted maintenance algorithm.
+- Compact CL quote rows remain available only when replay maintenance is fresh, complete, and drift-clean; all untrusted states preserve live fallback.
+- Operators can distinguish reducer health states without reading raw replay payloads or CloudWatch-only details.
+- Promotion evidence demonstrates both quote correctness and materially lower steady-state provider pressure than repeated full snapshots.
+- Planning can proceed without re-deciding pool scope, quote authority, fallback behavior, drift-check policy, or whether an immediate cadence brake is part of this feature.
+
+---
+
+## Scope Boundaries
+
+- No emergency full-snapshot cadence brake, schedule change, or immediate spend-stop requirement.
+- No broad CL replay expansion beyond the current reviewed replay pool set.
+- No public historical liquidity API, analytics store, or indefinite delta journal.
+- No migration of quote authority from `www` into raw indexed replay state.
+- No raw replay payloads on the normal compact quote path.
+- No WebSocket or pending-log ingestion requirement for this slice.
+- No external dedicated indexer service unless planning proves the existing Lambda/table shape cannot safely support the reducer.
+
+---
+
+## Key Decisions
+
+- Reducer-only scope: The requirements focus on delta maintenance and exclude the immediate cadence brake the ideation considered.
+- Checkpoint plus reducer: Full snapshots are retained because they are the strongest existing audit and repair artifact.
+- Fail closed: Incorrect or uncertain reducer state is more dangerous than unavailable indexed quotes because `www` already has live fallback.
+- Current-pool scope: The feature should prove the maintenance model on the reviewed replay set before adding more CL pools.
+- Cost is an acceptance gate: Reduced provider pressure is part of success, not a nice-to-have observability metric.
+
+---
+
+## Dependencies / Assumptions
+
+- Existing full `cl-replay-v1` snapshots are complete enough to seed and repair the reducer.
+- The current reviewed replay pool set remains the intended first delta scope.
+- Base log reads can be bounded and retried by planning choices without weakening fail-closed behavior.
+- The relevant CL event streams expose enough ordered data to update replay state for the supported venues.
+- `www` compact quote diagnostics and live fallback behavior remain available during rollout.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R5, R7][Needs research] What bounded log-range size and safe-block policy should the reducer use for Base RPC reliability?
+- [Affects R5, R7][Needs research] Which exact venue-specific events affect replay state for Slipstream and Uniswap V3, including dynamic fee behavior?
+- [Affects R8, R9][Technical] How should planning orchestrate comparable-block drift checks without making the full snapshot path the normal hot maintenance loop again?
+- [Affects R10, R12][Technical] What is the smallest maintenance-state vocabulary that gives operators useful diagnosis without creating noisy reason-code sprawl?
+- [Affects R15, R16][Technical] What command or smoke artifact should collect before/after provider-read and quote-usage evidence for promotion?

--- a/docs/fame-pool-state-handoff.md
+++ b/docs/fame-pool-state-handoff.md
@@ -107,6 +107,7 @@ Final todos before enabling `www` production helper env:
 - Run an authenticated helper smoke call.
 - Run indexed route-lab from `www` with `BASE_RPC_URL` or `FAME_POOL_STATE_CURRENT_BLOCK`.
 - Run a `www` quote API smoke check.
+- Run `yarn fame-pool-state:delta-replay-smoke <input-json>` with redacted indexer/quote evidence and attach the report.
 - Watch at least five scheduled indexer intervals and confirm non-regressing `observedThroughBlock`, no Lambda errors/throttles, and failure queue depth `0`.
 
 ## Registry Refresh
@@ -131,6 +132,8 @@ Status meanings:
 - `unsupported`: the pool is reviewed but not eligible for the requested indexed state surface.
 
 The producer freshness default is configured by `FAME_POOL_STATE_DEFAULT_MAX_FRESHNESS_BLOCKS`. Callers may ask for stricter freshness, but cannot loosen the producer default.
+
+Delta CL replay maintenance is separate from the quoteable replay pointer. The indexer may write `cl-replay-candidate-v1` shadow capsules and `cl-replay-maintenance-v1` lifecycle rows, then publish a quoteable replay pointer only after a checkpoint-clean trusted promotion. `/fame/pool-quotes` only emits `cl-quote-v1` when maintenance is trusted and exactly compatible with the replay pointer. Warming, event-gap, drift-failed, repairing, or source-mismatched maintenance rows surface as unavailable compact quote evidence so `www` keeps live fallback. The supported Slipstream maintenance event surface is `Swap`, `Mint`, `Burn`, and no-op `Collect`; unknown topics still fail closed.
 
 ## AWS Surface
 

--- a/docs/fame-pool-state-index.md
+++ b/docs/fame-pool-state-index.md
@@ -9,13 +9,14 @@
 - Concentrated-liquidity head snapshots: Slipstream, Slipstream2, Uniswap V3, and Uniswap V4 pools with reviewed fee metadata.
 - Concentrated-liquidity replay snapshots: exactly `slipstream-usdc-weth-100` with complete safe-block `cl-replay-v1` state for the first proof.
 - Tracked-only pools: stable Solidly, native wrap, pools missing reviewed CL metadata, and unknown unsupported invariants.
-- No factory discovery, stable math, broad concentrated-liquidity replay, event-driven tick maintenance, notifier behavior, or public solver routing is owned here.
+- No factory discovery, stable math, broad concentrated-liquidity replay, notifier behavior, or public solver routing is owned here.
 
 ## Runtime
 
 - `FamePoolState` CDK creates one DynamoDB table keyed by `pk` and `sk`, a scheduled indexer Lambda, and an authenticated read API Lambda.
 - The indexer scans Base `Sync` logs for quote-model pools, reconciles every quote-model pool with `getReserves` at the safe block, writes monotonic latest rows when reserves drift or rows are missing, updates `observedThroughBlock`, records complete CL head snapshots at the same safe block, captures a full `cl-replay-v1` Slipstream snapshot for `slipstream-usdc-weth-100`, and advances a cursor only after reserve reconciliation succeeds.
 - The replay snapshot lane reads slot0, current liquidity, dynamic pool fee, the full initialized tick bitmap word range, and initialized tick liquidity records at one safe block. It writes bitmap/tick chunks first, then publishes the latest replay pointer so the API never returns a partial snapshot as fresh replay state.
+- The delta replay maintenance lane is checkpoint-seeded and promotion-gated. It stores a separate `cl-replay-maintenance-v1` lifecycle row and non-quoteable `cl-replay-candidate-v1` capsule for supported `Swap`, `Mint`, and `Burn` deltas; `Collect` is decoded as a supported no-op for quote-state maintenance. Full snapshots remain the seed/checkpoint/repair artifact; warming, event-gap, drift-failed, and repairing maintenance state cannot publish compact CL quotes. Trusted promotion can publish the reducer-maintained capsule only when the checkpoint is drift-clean and the maintenance row is cursor/state-hash compatible.
 - The API serves bounded batch reads to server-side `www` callers. API Gateway uses a Lambda authorizer for the same service token before invoking the API Lambda, and the API Lambda keeps its own token check as defense in depth. The token must be supplied through `Authorization: Bearer <token>`.
 - The API Lambda dispatches only `/fame/pool-state` and `/fame/pool-quotes`; unknown paths return an invalid-request error instead of falling through to pool-state handling.
 - The indexer has SQS-backed async failure destinations plus passive CloudWatch alarms for Lambda errors, Lambda throttles, missed invocations, and non-empty failure queue depth. These alarms have no notification action by default; they are an inspectable health surface for a free community service.
@@ -50,7 +51,7 @@ Freshness is based on `observedThroughBlock`, not `lastReserveChangeBlock`.
 
 Reserve quote-model pools return `constant-product-quote-v1` rows when fresh matching reserve state is available. Each row includes pool identity, token direction, `amountIn`, `amountOut`, `quoteModel: "constant-product-reserves"`, `quoteModelVersion: 1`, `feeBps`, `feeSource: "registry-fee"`, `stateSource`, `observedThroughBlock`, source registry id, price-impact fields, and safe protocol evidence. The quote math matches the existing `www` constant-product reserve adapter: input fee in basis points is applied before the invariant quote, while price-impact evidence uses full input amount against pre/post reserves.
 
-`slipstream-usdc-weth-100` keeps its existing `cl-quote-v1` compact row shape and still omits raw replay arrays. Other reviewed-but-unquoted pools return `unavailable` with an enum reason such as `unsupported-pool`, `missing-indexed-state`, `stale-indexed-state`, `source-registry-mismatch`, `token-direction-mismatch`, `malformed-reserve-state`, `reserve-quote-failed`, `malformed-replay-state`, `outside-indexed-tick-range`, or `replay-failed`.
+`slipstream-usdc-weth-100` keeps its existing `cl-quote-v1` compact row shape and still omits raw replay arrays. A CL compact quote is emitted only when the replay pointer is fresh and the matching maintenance row is trusted, source-registry-compatible, cursor-current, and state-hash-compatible. Shadow reducer candidates or unpromoted producer state return `unavailable` with `producer-untrusted` until reviewed promotion evidence exists. Other reviewed-but-unquoted pools return `unavailable` with an enum reason such as `unsupported-pool`, `missing-indexed-state`, `stale-indexed-state`, `source-registry-mismatch`, `token-direction-mismatch`, `malformed-reserve-state`, `reserve-quote-failed`, `malformed-replay-state`, `outside-indexed-tick-range`, or `replay-failed`.
 
 The versioned producer fixture at `src/fame-swap-pool-state/fixtures/pool-quotes-v1.json` locks the reserve quote row shape and exact amount/price-impact semantics for every reserve quote-model pool in both directions.
 
@@ -58,7 +59,9 @@ The versioned producer fixture at `src/fame-swap-pool-state/fixtures/pool-quotes
 
 Pool-state Lambda logs use compact JSON envelopes with `level`, `event`, `timestamp`, and event-specific metadata. Do not log service tokens, authorization headers, full RPC URLs, raw request bodies, raw tick arrays, or raw replay payloads.
 
-Indexer logs use `event: "fame-pool-state-indexed"` with chain id, block range, event counts, seeded pool count, reconciled pool count, observed pool count, replay snapshot success/failure counts, replay sizing metrics, duration, and registry id. Replay snapshot failures use `level: "error"` and preserve fail-fast Lambda behavior.
+Indexer logs use `event: "fame-pool-state-indexed"` with chain id, block range, event counts, seeded pool count, reconciled pool count, observed pool count, replay snapshot success/failure counts, replay sizing metrics, replay maintenance metrics, duration, and registry id. Replay maintenance metrics include scanned ranges, scanned log count, applied event count, candidate write status, state hash, and bounded status/reason fields. Replay snapshot failures use `level: "error"` and preserve fail-fast Lambda behavior.
+
+Replay maintenance modes are operator-controlled with `FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE=checkpoint|steady-state|repair`, `FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION=true|false`, and `FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS`. The default remains checkpoint mode without trust promotion. Steady-state mode advances trusted reducer state from bounded log reads and avoids full replay snapshots; repair mode reseeds trusted state from a complete full checkpoint after drift has failed closed.
 
 API success logs use `event: "fame-pool-state-api-batch"` with registry id, current block, effective freshness, batch size, status counts, and compact replay counts when `cl-replay-v1` state is returned. Ordinary all-fresh non-replay batches are not logged at INFO. Replay responses, stale rows, unknown rows, unsupported rows, malformed requests, and dependency failures remain operator-visible.
 
@@ -133,11 +136,12 @@ Do not add email, pager, or chat notification actions for the first release unle
 - failure queue depth;
 - any RPC timeout, throttle, or cursor-lag notes.
 
-14. Run `www` route lab with `--indexed`, `BASE_RPC_URL` or `FAME_POOL_STATE_CURRENT_BLOCK`, and production-like helper env. The tool derives proof-only raw-state reads from `FAME_POOL_API_URL` plus `/fame/pool-state`; confirm the indexed summary reports `cl replay slipstream-usdc-weth-100 ...` while selected CL quotes remain live or recorded in shadow mode.
+14. Run `www` route lab with `--indexed`, `BASE_RPC_URL` or `FAME_POOL_STATE_CURRENT_BLOCK`, and production-like helper env. The tool derives proof-only raw-state reads from `FAME_POOL_API_URL` plus `/fame/pool-state`; confirm the indexed summary reports `cl replay slipstream-usdc-weth-100 fresh block ... ticks ... hash ...` after a trusted steady-state delta pass with `clReplaySnapshots: 0`.
 15. Run `www` CL replay parity with `bun scripts/fame-swap-cl-replay-parity.ts` and production-like helper/RPC env. The tool also derives `/fame/pool-state` from the same `FAME_POOL_API_URL` base. Promotion requires exact same-block `amountOut` equality for both WETH -> USDC and USDC -> WETH amount bands.
 16. Run a `www` quote API smoke check against `/fame/pool-quotes`.
-17. Record route-lab and parity evidence locations in the PR or release checklist. Evidence must cover indexed success plus fallback-relevant stale, unknown, unsupported, malformed, incomplete replay, and unavailable-helper cases.
-18. Enable `www` server env `FAME_POOL_API_URL` and `FAME_POOL_STATE_SERVICE_TOKEN` only after route-lab and parity proof are attached. Do not create `NEXT_PUBLIC_` variants.
+17. Run `yarn fame-pool-state:delta-replay-smoke <input-json>` against an allowlisted JSON bundle containing an indexer result and optional quote response. Attach the redacted report with maintenance status, scanned range, applied delta count, candidate write status, full snapshot count, provider read count, compact quote count, and unavailable reasons.
+18. Record route-lab, parity, and delta replay smoke evidence locations in the PR or release checklist. Evidence must cover indexed success plus fallback-relevant stale, unknown, unsupported, malformed, incomplete replay, producer-untrusted, and unavailable-helper cases.
+19. Enable `www` server env `FAME_POOL_API_URL` and `FAME_POOL_STATE_SERVICE_TOKEN` only after route-lab and parity proof are attached. Do not create `NEXT_PUBLIC_` variants.
 
 ## Durable Follow-Ups
 

--- a/docs/ideation/2026-05-29-fame-delta-cl-replay-index-ideation.md
+++ b/docs/ideation/2026-05-29-fame-delta-cl-replay-index-ideation.md
@@ -1,0 +1,182 @@
+---
+date: 2026-05-29
+topic: fame-delta-cl-replay-index
+focus: delta-maintained CL replay index for the current www and society-bots FAME quote branches
+mode: repo-grounded
+---
+
+# Ideation: FAME Delta CL Replay Index
+
+## Grounding Context
+
+The active `www` and `society-bots` branches are both `codex/fame-cl-quote-surface`. The current branch pair has moved the hot quote boundary to compact `/fame/pool-quotes` rows: `society-bots` produces compact reserve and CL quote rows, while `www` validates row identity/provenance, converts accepted rows into quote results, and falls back live whenever helper output is unavailable, stale, mismatched, invalid, or slow.
+
+The serious cost change is concentrated in the replay maintenance model, not the consumer. `society-bots` currently runs the pool-state indexer on a one-minute EventBridge schedule by default. The registry has exactly two `cl-replay-v1` pools: `slipstream-usdc-weth-100` and `uniswap-v3-usdc-weth-5bps`. On every indexer run, `indexFamePoolStates` calls `getClReplaySnapshot` for every replay pool. That snapshot path reads block identity, slot0, active liquidity, fee, every tick bitmap word across the supported tick range, and every initialized tick for each replay pool. The code already records `providerReadCount`, `durationMs`, bitmap counts, tick counts, and state hashes in replay metrics, which gives this effort a concrete proof surface.
+
+The existing storage/publication shape is useful. `putLatestClReplayState` writes bitmap/tick chunks first, then publishes the latest replay pointer, so the API should not expose partial snapshots as fresh. `/fame/pool-quotes` reads fresh replay pointers and chunks, computes compact `cl-quote-v1` rows, and returns precise unavailable reasons for missing, stale, mismatched, malformed, outside-range, or failed replay state. `www` already has compact quote diagnostics and live fallback, so the consumer side is ready for stricter maintenance-state signals rather than a new quote architecture.
+
+Prior ideation intentionally chose full snapshots to prove parity before event-driven maintenance. That was correct for the proof rung, but the deployed cost signal changes the next move: full snapshots should remain as checkpoint/audit machinery, not as the minute-by-minute maintenance algorithm.
+
+External grounding supports the same shape. Uniswap's V3 pool-data guide says offchain modeling needs liquidity, slot0, and full tick data, and it explicitly notes that fetching all initialized ticks can be expensive or slow through normal RPC. The Uniswap V3 pool event interface exposes reducer-friendly data: `Mint`/`Burn` identify tick ranges and liquidity amounts, while `Swap` includes post-swap sqrt price, liquidity, and tick. Base's `eth_getLogs` docs describe log filtering as useful for indexing and recommend bounded block ranges for reliability.
+
+Relevant sources:
+
+- Uniswap V3 pool data guide: https://developers.uniswap.org/docs/sdks/v3/guides/pool-data
+- Uniswap V3 pool events: https://github.com/Uniswap/v3-core/blob/main/contracts/interfaces/pool/IUniswapV3PoolEvents.sol
+- Base `eth_getLogs`: https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs
+
+## Topic Axes
+
+- Event ingestion and reducer semantics
+- Snapshot and drift reconciliation
+- Storage and cursor contract
+- Quote/API consumption and safety
+- Observability and rollout economics
+
+## Ranked Ideas
+
+### 1. Snapshot-Seeded Delta CL Replay Reducer
+
+**Description:** Keep the existing full `cl-replay-v1` capsule as the seed, then maintain it by scanning pool logs from the last replay cursor and applying CL deltas. A normal scheduled wake should scan bounded `Mint`, `Burn`, and `Swap` logs for the two replay pools, apply changes to the latest capsule, and advance the replay cursor without rereading every bitmap word and initialized tick. Full bitmap/tick reads become seed or repair operations, not the steady-state algorithm.
+
+**Axis:** Event ingestion and reducer semantics
+
+**Basis:** `direct:` `indexFamePoolStates` currently calls `getClReplaySnapshot` for every replay pool on every scheduled run, and `getConcentratedLiquidityClReplaySnapshot` reads block identity, slot0, liquidity, fee, every bitmap word, and every initialized tick. `external:` Base documents `eth_getLogs` as an indexing primitive, and Uniswap V3 events expose the fields needed to update head state and tick liquidity deltas.
+
+**Rationale:** This directly attacks the burn source. Quiet or low-activity minutes should not spend full snapshot RPCs; they should spend a bounded log scan and small Dynamo updates, then serve the same compact quote contract when fresh.
+
+**Downsides:** Reducers are easier to get subtly wrong than snapshots. The first pass must be shadowed against snapshot hashes before compact rows are trusted.
+
+**Confidence:** 92%
+
+**Complexity:** High
+
+**Status:** Unexplored
+
+### 2. Immediate Full-Snapshot Cadence Brake
+
+**Description:** Add a short-term safety valve that stops minute-by-minute full CL replay capture while delta maintenance is being built. Keep reserve indexing and CL head snapshots on the fast schedule, but run full replay snapshots only on a slower cadence such as daily, manually, or behind an explicit maintenance mode. Compact CL rows can become unavailable during this interim if freshness cannot be maintained cheaply.
+
+**Axis:** Snapshot and drift reconciliation
+
+**Basis:** `direct:` CDK defaults the pool-state schedule to once per minute, docs say the indexer captures full replay snapshots for exactly two pools, and the user observed the daily RPC bill jump from cents to dollars after CL replay and quoting were added.
+
+**Rationale:** This is the quickest way to stop the unhealthy burn without pretending the delta reducer is already done. It preserves correctness by leaning on existing `www` live fallback rather than serving stale indexed quotes.
+
+**Downsides:** Indexed CL quote usage may drop until the reducer exists. Product latency regresses to live fallback for those edges during the brake.
+
+**Confidence:** 89%
+
+**Complexity:** Low-Medium
+
+**Status:** Unexplored
+
+### 3. Daily Drift Oracle And Fail-Closed Repair
+
+**Description:** Keep full snapshots as a low-cadence integrity oracle. Once per day, or on explicit operator demand, capture a full safe-block snapshot and compare its deterministic state hash against the delta-maintained state at the same block. If the hashes differ, publish a drift status, mark compact CL quotes unavailable, write a bounded debug bundle, and repair the latest capsule from the full snapshot.
+
+**Axis:** Snapshot and drift reconciliation
+
+**Basis:** `direct:` replay rows already carry `snapshotId`, `stateHash`, block hash, parent hash, bitmap counts, tick counts, and registry provenance. `reasoned:` the full snapshot path is expensive but valuable as an audit checkpoint; demoting it to a drift oracle keeps the proof value while removing the per-wake cost.
+
+**Rationale:** This keeps the previous parity work instead of throwing it away. The architecture becomes checkpoint plus log replay, like a database maintaining pages from a write-ahead log with periodic checkpoints.
+
+**Downsides:** Same-block comparison needs careful orchestration. If the daily check frequently repairs drift, the reducer is not production-ready.
+
+**Confidence:** 90%
+
+**Complexity:** Medium-High
+
+**Status:** Unexplored
+
+### 4. `cl-replay-maintenance-v1` Cursor And Journal
+
+**Description:** Add a compact maintenance row per replay pool that records the delta cursor, last applied block/hash/log position, latest state hash, last full checkpoint block/hash, drift status, repair status, and source registry id. Optionally retain short-TTL `cl-replay-delta-v1` journal rows for recently applied log cohorts so drift investigations can replay the last window without scraping CloudWatch.
+
+**Axis:** Storage and cursor contract
+
+**Basis:** `direct:` reserve indexing already uses sorted logs, monotonic writes, and a cursor; CL replay currently publishes latest snapshot rows but has no independent event cursor. `reasoned:` a reducer without cursor and recent-delta evidence is hard to repair or audit when snapshot comparison fails.
+
+**Rationale:** This gives the delta lane its own lifecycle instead of piggybacking on reserve cursor semantics. It also gives `/fame/pool-quotes`, route-lab, and operators one place to decide whether replay state is fresh, drift-clean, warming, or repairing.
+
+**Downsides:** Adds a new internal state contract and more Dynamo writes. The journal must be short-lived and bounded so it does not become an accidental analytics store.
+
+**Confidence:** 87%
+
+**Complexity:** Medium
+
+**Status:** Unexplored
+
+### 5. Normalized Slipstream/V3 Event Reducer Contract
+
+**Description:** Define a small normalized internal event stream for replay maintenance: `swap`, `mint`, `burn`, and any supported fee-change signal. Map Slipstream and Uniswap V3 logs into that stream, then test the reducer with deterministic fixtures before touching live RPC. `Swap` updates post-swap sqrt price, current tick, and active liquidity. `Mint`/`Burn` update lower/upper tick liquidity and active liquidity when the current tick lies inside the changed range.
+
+**Axis:** Event ingestion and reducer semantics
+
+**Basis:** `direct:` the registry explicitly limits replay to one Slipstream pool and one Uniswap V3 pool. `external:` the V3 event interface emits tickLower/tickUpper/amount on Mint and Burn, and sqrtPrice/liquidity/tick on Swap. `reasoned:` a venue-normalized reducer contract avoids duplicating two near-identical maintenance loops while still preserving venue-specific fee/source validation.
+
+**Rationale:** The hard part is not scanning logs; it is applying them exactly and proving the state transition model. A normalized contract makes the reducer reviewable and testable in isolation.
+
+**Downsides:** Slipstream-specific fee behavior may need a small side lane. The normalized event type must not erase venue differences that affect quote parity.
+
+**Confidence:** 84%
+
+**Complexity:** Medium-High
+
+**Status:** Unexplored
+
+### 6. Quote API Maintenance Mode For Safe Fallback
+
+**Description:** Extend compact CL quote unavailable metadata with maintenance-state reasons such as `delta-warming`, `drift-check-failed`, `repairing`, `event-gap`, or `snapshot-cadence-paused`. `www` should keep accepting only quoted rows whose maintenance state is fresh and drift-clean, while debug output reports the producer maintenance state when it falls back live.
+
+**Axis:** Quote/API consumption and safety
+
+**Basis:** `direct:` `www` already records `debug.quoteApi` attempts/used/fallback counts and falls back live for unavailable rows; `society-bots` already returns quote-specific unavailable rows with pool/freshness metadata. `reasoned:` delta maintenance introduces failure modes that are neither ordinary staleness nor malformed replay math, so they need explicit names.
+
+**Rationale:** This keeps user-facing quote correctness boring while making operator diagnosis sharp. A reducer should earn compact quote usage; it should not silently feed the hot path while warming, lagging, or drift-failed.
+
+**Downsides:** Requires a small wire-contract expansion in both repos. Too many reason codes can become noisy unless they are grouped carefully in diagnostics.
+
+**Confidence:** 86%
+
+**Complexity:** Low-Medium
+
+**Status:** Unexplored
+
+### 7. Cost-Aware Rollout Proof
+
+**Description:** Make the delta rollout proof include provider-read economics, not only parity. The promotion evidence should show before/after `providerReadCount`, full snapshot count, log ranges scanned, changed log count, delta-applied pool count, drift-check result, compact quote used count, fallback count, and an estimated daily RPC-cost trajectory.
+
+**Axis:** Observability and rollout economics
+
+**Basis:** `direct:` replay metrics already include provider read count, duration, bitmap/tick counts, and state hash. `direct:` the user supplied a concrete daily RPC-cost regression after CL replay and compact quoting. `reasoned:` the feature is not healthy unless it proves both quote correctness and reduced provider pressure.
+
+**Rationale:** This turns the central concern into an acceptance gate. It also prevents a future “technically indexed but still too expensive” outcome.
+
+**Downsides:** Daily cost estimates may be provider-specific and approximate. The proof needs a short soak window before it is persuasive.
+
+**Confidence:** 91%
+
+**Complexity:** Low
+
+**Status:** Unexplored
+
+## Recommendation
+
+The strongest next exploration is a **snapshot-seeded delta reducer with a full-snapshot cadence brake**. In practical sequence, first stop the minute-by-minute full replay capture from driving cost, then build the reducer for one replay pool in shadow mode, then compare its state hash against low-cadence full snapshots, then expose compact quotes only when the maintenance row says the delta state is fresh and drift-clean. After that works for `slipstream-usdc-weth-100`, add `uniswap-v3-usdc-weth-5bps`.
+
+This should not become a giant indexer rewrite. The existing table, latest-pointer publication shape, compact quote API, `www` validation, live fallback, and parity tooling are the base. The change is the CL replay maintenance algorithm: full snapshots become checkpoints; bounded log scans become the normal wake.
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Keep full snapshots but use multicall | Could reduce latency but not the core provider-call/cost shape; weaker than delta maintenance. |
+| 2 | Birth-to-head event backfill as first step | Too much initial risk; current full snapshots should seed the reducer. |
+| 3 | Broad replay expansion to more CL pools | Scope overrun before the two-pool delta model is proven. |
+| 4 | Move quote authority back to `www` raw state | Conflicts with the current compact quote boundary and recent branch work. |
+| 5 | Remove full snapshots entirely | Throws away the strongest parity/audit tool; better as a low-cadence drift oracle. |
+| 6 | WebSocket pending-log ingestion | More operational complexity than scheduled safe-block log scans need right now. |
+| 7 | Dedicated external indexer service | Premature infrastructure for a two-pool reducer; the existing Lambda/table can prove the model first. |
+| 8 | Store every historical state indefinitely | Useful later for analytics, but current problem is hot-path maintenance cost. |
+| 9 | Delta-only compact quote promotion without shadow drift checks | Too risky; wrong replay state can produce plausible bad quotes. |

--- a/docs/plans/2026-05-29-001-feat-fame-delta-cl-replay-index-plan.md
+++ b/docs/plans/2026-05-29-001-feat-fame-delta-cl-replay-index-plan.md
@@ -1,0 +1,548 @@
+---
+title: "feat: Add FAME Delta CL Replay Index"
+type: feat
+status: active
+date: 2026-05-29
+origin: docs/brainstorms/2026-05-29-fame-delta-cl-replay-index-requirements.md
+deepened: 2026-05-29
+---
+
+# feat: Add FAME Delta CL Replay Index
+
+## Summary
+
+Implement a shadow-first delta maintenance lane for FAME CL replay state. The plan keeps full snapshots as the seed, checkpoint, and repair artifact, adds a distinct replay-maintenance lifecycle, and only lets compact CL quote rows trust reducer-maintained state after deterministic fixtures and drift evidence prove it is fresh and clean.
+
+---
+
+## Problem Frame
+
+The existing replay proof captures complete `cl-replay-v1` snapshots for the reviewed replay pool set on each indexer run. That is correct but expensive: the steady-state path rereads the full bitmap and initialized tick universe even when a pool has few or no relevant events.
+
+---
+
+## Requirements
+
+- R1. Cover only the existing reviewed `cl-replay-v1` replay pool set.
+- R2. Preserve the authority split: `society-bots` produces replay state and compact quote evidence; `www` validates quote safety and falls back live.
+- R3. Keep full replay snapshots as seed, checkpoint, and repair artifacts, not the normal trusted maintenance algorithm.
+- R4. Start delta maintenance only from complete replay state.
+- R5. Scan bounded pool-event ranges and apply supported CL deltas in deterministic chain order.
+- R6. Advance the replay maintenance cursor only after the scanned range has been fully applied.
+- R7. Treat event gaps, ambiguous block identity, unsupported replay-affecting events, range-limit failures, and inconsistent reducer output as untrusted state.
+- R8. Use full snapshots as low-cadence drift checkpoints.
+- R9. Fail closed on drift: compact CL quotes stay unavailable until complete repair reseeds trusted state.
+- R10. Expose a small maintenance-state vocabulary for trusted, warming, drift-failed, repairing, and event-gap conditions.
+- R11. Return compact CL quoted rows only when replay state is fresh, complete, cursor-current, and drift-clean.
+- R12. Return unavailable quote evidence instead of best-effort CL quotes for untrusted replay state.
+- R13. Preserve `www` live fallback for unavailable, mismatched, stale, invalid, slow, or producer-untrusted compact CL rows.
+- R14. Keep raw replay payloads off the normal hot quote path.
+- R15. Promotion evidence must include correctness signals: drift result, quote validation or parity proof, compact quote usage, fallback counts, and unavailable reasons.
+- R16. Promotion evidence must include provider-pressure signals: full snapshot count, provider read count, scanned ranges, event counts, applied delta counts, and steady-state cost trajectory.
+- R17. Documentation and release evidence must distinguish steady-state reducer proof from emergency spend stoppage, broad CL expansion, or quote-authority changes.
+
+**Origin actors:** A1 (`society-bots` pool-state indexer), A2 (`society-bots` pool-state API), A3 (`www` quote system), A4 (operator/reviewer), A5 (Base RPC provider)
+
+**Origin flows:** F1 (delta state advances), F2 (drift is checked and repaired), F3 (compact CL quotes are consumed safely), F4 (rollout evidence is reviewed)
+
+**Origin acceptance examples:** AE1 (ordered delta application), AE2 (event gap fallback), AE3 (drift fail-closed repair), AE4 (compact quote path stays compact), AE5 (correctness plus provider-pressure evidence)
+
+---
+
+## Scope Boundaries
+
+- No emergency full-snapshot cadence brake, schedule change, or immediate spend-stop requirement.
+- No broad CL replay expansion beyond the current reviewed replay pool set.
+- No public historical liquidity API, analytics store, or indefinite delta journal.
+- No migration of quote authority from `www` into raw indexed replay state.
+- No raw replay payloads on the normal compact quote path.
+- No WebSocket or pending-log ingestion requirement for this slice.
+- No external dedicated indexer service in this plan. If the existing Lambda/table shape proves insufficient, reopen planning before changing service topology.
+
+### Deferred to Follow-Up Work
+
+- Emergency schedule/cadence brake: out of scope. The implementation still needs a planned replay-maintenance mode where the scheduled steady-state path stops calling full replay snapshots every wake after seed/trust conditions are satisfied.
+- Active reducer-backed quote activation: trusted producer state can be surfaced only after same-block drift-clean evidence and promotion evidence are reviewed; until then, reducer state stays shadow/unavailable.
+- Additional CL venues: keep V4, Slipstream2, and other CL pools outside this delta reducer until the current reviewed replay set proves the model.
+- `www` parity harness changes beyond consuming producer trust evidence: keep deeper frontend/router changes in the companion repo plan when needed.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/fame-swap-pool-state/indexer.ts` already computes safe blocks, scans reserve `Sync` logs through viem, reconciles reserve state, captures CL head snapshots, captures full CL replay snapshots, and returns replay metrics.
+- `src/fame-swap-pool-state/dynamodb/pool-state.ts` already models latest rows, chunk-before-pointer publication for replay capsules, cursor rows, strict item parsing, conditional writes, and batch read completeness.
+- `src/fame-swap-pool-state/cl-quote.ts` already gates compact CL quotes on fresh replay pointers, matching chunk capsules, registry identity, token direction, and replay math.
+- `src/fame-swap-pool-state/lambdas/logging.ts` already has compact structured indexer and quote API summaries with replay sizing and provider-read metrics.
+- `src/fame-swap-pool-state/indexer.test.ts`, `src/fame-swap-pool-state/dynamodb/pool-state.test.ts`, `src/fame-swap-pool-state/api.test.ts`, and `src/fame-swap-pool-state/lambdas/logging.test.ts` provide the closest unit-test patterns to extend.
+- `docs/fame-pool-state-index.md` and `docs/fame-pool-state-handoff.md` are the operational docs that must stay aligned with replay-state guarantees.
+
+### Institutional Learnings
+
+- No `docs/solutions/` directory exists in this checkout, so planning relies on the origin brainstorm, current repo docs, and current code patterns.
+- The repo instructions supplied in the prompt require clean typed TypeScript, no `any`, no unsafe casts or compatibility shims, simple control flow, and fail-fast handling for violated assumptions.
+- Existing FAME memory reinforces that `www` is quote-safety authority while `society-bots` produces indexed state/provenance; this plan preserves that boundary.
+
+### External References
+
+- Base `eth_getLogs` docs describe log filtering as an indexing primitive and recommend keeping large ranges bounded for reliability.
+- Uniswap V3 pool-data docs confirm that accurate offchain CL modeling needs pool head state and initialized tick data, and that fetching all initialized ticks can be expensive or slow through ordinary RPC.
+- Uniswap V3 pool event definitions expose reducer-relevant `Mint`, `Burn`, and `Swap` events; those same semantics are the baseline to validate against Slipstream before trusting venue-normalized deltas.
+
+---
+
+## Key Technical Decisions
+
+- Shadow-first reducer: Build and persist delta-maintained state as a candidate before it becomes quoteable latest replay state.
+- Separate maintenance lifecycle: Add replay-maintenance state rather than overloading the reserve cursor or latest replay pointer with warming, gap, repair, and drift status.
+- Candidate versus quoteable publication: Candidate reducer state may be persisted for comparison and drift checks; only drift-clean trusted state may update the quoteable `cl-replay-v1` latest pointer.
+- Candidate capsule storage: Persist candidate reducer capsules with their own chunk/pointer identity, not only a maintenance metadata row, so the next reducer pass and drift check can read the complete candidate without blessing it as quoteable.
+- Snapshot rows remain publication artifact: Continue using the existing chunk-before-pointer replay capsule shape for quoteable state so the API never exposes partial arrays as fresh.
+- Explicit activation boundary: Reducer-backed compact quote emission requires a reviewed promotion control; shadow maintenance and drift repair alone must not silently switch hot-path behavior.
+- Venue-normalized event reducer: Decode venue-specific logs into a small internal event model, then apply deterministic reducer logic shared by Slipstream and Uniswap V3 where semantics match.
+- Slipstream-first proof, Uniswap V3 follow-through: Prove the reducer on the existing Slipstream replay pool first because it already has the heaviest current route-lab history, then apply the same storage and trust contract to the Uniswap V3 replay pool.
+- Fail closed on uncertainty: Missing logs, unsupported events, drift mismatch, malformed maintenance rows, and incomplete repair should make compact CL quotes unavailable, not best-effort.
+- Test-first for reducer semantics: Reducer and maintenance-state behavior should start from deterministic fixtures before wiring live RPC reads.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Bounded log range policy: Use a configurable maximum range with a fail-closed event-gap state when the cursor falls too far behind; exact default belongs to implementation after measuring typical Base lag and provider behavior.
+- Maintenance-state vocabulary: Use a small status family aligned to the origin requirements: trusted, warming, drift-failed, repairing, and event-gap, with quote API reasons grouped from those states instead of one reason per internal detail.
+- Drift orchestration: Compare reducer state to a full checkpoint in an explicit drift-check path rather than making every scheduled wake perform a full snapshot.
+- Promotion evidence shape: Reuse existing structured logs and add a focused smoke/report script rather than requiring a dashboard.
+
+### Deferred to Implementation
+
+- Exact log-range default: final value should be selected after local tests and live dev soak show practical Base RPC behavior.
+- Exact Slipstream event surface after fixture work: if U2 cannot prove that `Swap`, `Mint`, and `Burn` plus existing fee reads cover replay-affecting state for the supported Slipstream pool, U3 must keep Slipstream in untrusted shadow mode until the missing event lane is planned.
+- Exact DynamoDB row shape: implementer should choose field names that fit existing parser and key conventions while preserving the lifecycle contract.
+- Candidate capsule keying: implementation should choose the exact key names, but the model must support reading a complete non-quoteable candidate capsule by maintenance state identity.
+- Exact `www` debug display shape: companion repo work may need to map producer-trust reasons into existing `debug.quoteApi` output.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  Seed["Complete cl-replay-v1 seed"]
+  Cursor["Replay maintenance cursor"]
+  Logs["Bounded Mint/Burn/Swap logs"]
+  Reducer["Deterministic CL reducer"]
+  Status{"Maintenance trusted and drift-clean?"}
+  Candidate["Persist candidate state"]
+  Publish["Update quoteable replay pointer"]
+  Unavailable["Expose unavailable quote evidence"]
+  Drift["Checkpoint drift check"]
+  Repair["Repair from full snapshot"]
+
+  Seed --> Cursor
+  Cursor --> Logs
+  Logs --> Reducer
+  Reducer --> Candidate
+  Candidate --> Status
+  Status -->|trusted| Publish
+  Status -->|warming/gap/drift/repair| Unavailable
+  Publish --> Drift
+  Drift -->|clean| Cursor
+  Drift -->|mismatch| Repair
+  Repair --> Seed
+```
+
+---
+
+## Implementation Units
+
+### U1. Model Replay Maintenance State
+
+**Goal:** Add a typed internal state model for replay maintenance lifecycle, cursor position, trust status, and metrics without changing hot-path quote payloads yet.
+
+**Requirements:** R1, R2, R4, R6, R7, R10, R14; supports F1, F2, AE2, AE3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/fame-swap-pool-state/dynamodb/pool-state.ts`
+- Test: `src/fame-swap-pool-state/dynamodb/pool-state.test.ts`
+- Modify: `src/fame-swap-pool-state/indexer.ts`
+- Test: `src/fame-swap-pool-state/indexer.test.ts`
+
+**Approach:**
+- Add a replay-pool-scoped maintenance row separate from `cursor:${chainId}:quote-model-v1` and separate from the `cl-replay-v1` latest pointer.
+- Store enough cursor identity to prove deterministic replay order: observed block, block hash, transaction index, log index, source registry id, current state hash, last checkpoint block/hash, status, and bounded reason metadata.
+- Store enough target safe-block identity to let the next run verify the previous cursor block is still canonical before applying more deltas.
+- Add a non-quoteable candidate capsule read/write path with chunk-before-candidate-pointer semantics mirroring the latest replay pointer safety model.
+- Keep status values intentionally small and typed. Do not add one status per internal error detail.
+- Parse maintenance rows strictly and fail fast on malformed status, missing cursor identity, invalid block/hash fields, or source registry mismatch.
+
+**Execution note:** Implement parser and conditional-write behavior test-first; persistent state bugs are more dangerous than missing optimization.
+
+**Patterns to follow:**
+- Strict field parsers and item-specific errors in `src/fame-swap-pool-state/dynamodb/pool-state.ts`
+- `latestClReplayStateKey`, `cursorKey`, and conditional write style in `src/fame-swap-pool-state/dynamodb/pool-state.ts`
+- In-memory database testing patterns in `src/fame-swap-pool-state/indexer.test.ts`
+
+**Test scenarios:**
+- Happy path: a trusted maintenance row with complete cursor identity parses to the typed state and can be fetched by replay pool.
+- Happy path: a warming maintenance row can be written without a published replay pointer change.
+- Edge case: a same-block conditional write from the same source registry is accepted only when it does not rewind cursor order.
+- Edge case: maintenance state can represent a cursor block hash mismatch as untrusted without publishing quoteable state.
+- Error path: malformed status, bad block hash, missing source registry id, or negative cursor fields throw `PoolStateInvalidItemError`.
+- Error path: a stale source registry id does not make a current replay pool trusted.
+- Integration: writing maintenance state must not write replay chunks or update the existing `cl-replay-v1` latest pointer.
+- Integration: writing a candidate capsule writes complete chunks before the candidate pointer and remains invisible to normal quote reads.
+
+**Verification:**
+- Maintenance rows are independently readable, strictly parsed, and cannot accidentally publish quoteable replay state.
+
+---
+
+### U2. Decode and Normalize CL Replay Events
+
+**Goal:** Add a bounded log ingestion surface for supported replay pools, verify the supported replay-affecting event surface, and normalize venue-specific logs into reducer events.
+
+**Requirements:** R1, R5, R7, R16; supports F1, AE1, AE2
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `src/fame-swap-pool-state/indexer.ts`
+- Test: `src/fame-swap-pool-state/indexer.test.ts`
+
+**Approach:**
+- Extend the indexer client boundary with a replay-log read method for reviewed replay pools.
+- Fetch bounded safe-block ranges by replay-pool address and decode through an allowlisted topic set so unsupported logs from reviewed replay pools can be detected.
+- Before scanning a new range from persisted maintenance state, verify the stored cursor block hash is still canonical; a mismatch must fail closed to event-gap or repair-needed state.
+- Store and verify the target safe-block hash for the applied range so a later run can detect canonicality drift even when no removed log appears in the forward range.
+- Normalize `Swap`, `Mint`, and `Burn` into a venue-independent reducer input while retaining venue, pool id, source address, and block/log identity.
+- Confirm the supported event surface per venue before U3 treats reducer output as trustable. Fee must be maintained by a supported event, a same-block `fee()` read, or fail-closed unavailable status.
+- Treat unknown logs from reviewed replay-pool addresses, removed logs, unsupported replay-affecting events, or an overlarge scan window as a maintenance event gap.
+
+**Execution note:** Characterize exact event decoding with fixtures before wiring reducer state changes.
+
+**Patterns to follow:**
+- `getSyncLogs` viem log-reading pattern in `src/fame-swap-pool-state/indexer.ts`
+- Address-scoped viem log reads with explicit topic decoding rather than event-filter-only reads for replay maintenance.
+- `sortedLogs` and unknown-log fatal behavior in `src/fame-swap-pool-state/indexer.ts`
+- Registry replay-scope assertions in `src/fame-swap-pool-state/registry/index.ts`
+
+**Test scenarios:**
+- Happy path: Slipstream `Swap`, `Mint`, and `Burn` logs decode into normalized events with stable block/log ordering.
+- Happy path: Uniswap V3 `Swap`, `Mint`, and `Burn` logs decode into the same normalized event model where semantics match.
+- Edge case: an empty bounded range produces no deltas and can still advance maintenance if the prior state is trusted.
+- Error path: a log from an unregistered replay pool address creates an event-gap result before cursor advancement.
+- Error path: a venue event outside the supported replay-affecting surface creates an unsupported/event-gap status rather than trusted reducer output.
+- Error path: stored cursor block hash mismatch creates event-gap or repair-needed status even when the new forward log range itself is clean.
+- Error path: a same-block fee/state change without a supported maintenance path prevents trusted state.
+- Error path: removed logs, missing block identity, or a range larger than the configured cap create event-gap status.
+- Integration: replay log reads do not alter reserve `Sync` log reads or quote-model cursor behavior.
+
+**Verification:**
+- The indexer can produce sorted, typed reducer events for the reviewed replay pools without affecting reserve indexing.
+
+---
+
+### U3. Implement Deterministic CL Delta Reducer
+
+**Goal:** Apply normalized CL events to complete seed state and produce a new replay state candidate with deterministic state hash and trust metadata.
+
+**Requirements:** R3, R4, R5, R6, R7, R8, R9; supports F1, F2, AE1, AE3
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `src/fame-swap-pool-state/indexer.ts`
+- Test: `src/fame-swap-pool-state/indexer.test.ts`
+- Modify: `src/fame-swap-pool-state/dynamodb/pool-state.ts`
+- Test: `src/fame-swap-pool-state/dynamodb/pool-state.test.ts`
+
+**Approach:**
+- Build the reducer around existing replay capsule primitives: head price, current tick, active liquidity, fee, bitmap words, initialized ticks, block identity, and state hash.
+- For swaps, update the post-swap head state from event data and retain initialized tick liquidity data from the existing capsule.
+- For mints and burns, update lower and upper initialized tick liquidity and bitmap membership; update active liquidity when the current tick lies inside the changed range.
+- Remove initialized ticks only when liquidity gross becomes zero and update bitmap membership accordingly.
+- Produce a candidate replay capsule only when all events in the range are supported and the resulting state is internally consistent.
+
+**Technical design:** *(directional guidance, not implementation specification)*
+
+```text
+complete seed + ordered normalized events
+  -> apply event deltas to tick map and head state
+  -> recompute bitmap words from initialized ticks
+  -> recompute state hash from the canonical replay capsule
+  -> return trusted candidate or typed untrusted maintenance state
+```
+
+**Patterns to follow:**
+- `clReplayStateHash` and `clReplayRowsFromSnapshot` canonicalization in `src/fame-swap-pool-state/indexer.ts`
+- `initializedTicksForBitmapWord` bitmap/tick conversion behavior in `src/fame-swap-pool-state/indexer.ts`
+- Replay math malformed-state handling in `src/fame-swap-pool-state/cl-quote.ts`
+
+**Test scenarios:**
+- Covers AE1. Happy path: a swap event updates sqrt price, tick, active liquidity, cursor identity, and state hash.
+- Happy path: mint below the current tick updates initialized tick state without changing active liquidity.
+- Happy path: mint spanning the current tick updates initialized tick state and active liquidity.
+- Happy path: burn that removes all liquidity at a boundary removes the initialized tick and clears its bitmap bit.
+- Edge case: multiple events in the same transaction apply by log index and produce deterministic output.
+- Error path: applying deltas without complete seed state returns warming or untrusted state instead of a candidate capsule.
+- Error path: liquidity underflow, invalid tick spacing, missing event block hash, or inconsistent bitmap/tick state fails closed.
+- Integration: candidate rows preserve the existing chunk-before-pointer publication invariant when promoted to latest state.
+
+**Verification:**
+- Deterministic fixtures prove reducer output and state hash are stable across Slipstream and Uniswap V3 cases before live RPC is involved.
+
+---
+
+### U4. Wire Shadow Delta Maintenance into the Indexer
+
+**Goal:** Run delta maintenance during scheduled indexing while preserving existing reserve indexing, CL head snapshots, and full replay snapshot behavior as seed/checkpoint machinery.
+
+**Requirements:** R3, R4, R5, R6, R7, R8, R9, R10, R16; supports F1, F2, F4, AE1, AE2, AE3, AE5
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Modify: `src/fame-swap-pool-state/indexer.ts`
+- Test: `src/fame-swap-pool-state/indexer.test.ts`
+- Modify: `src/fame-swap-pool-state/lambdas/indexer.ts`
+- Test: `src/fame-swap-pool-state/lambdas/indexer.test.ts`
+- Modify: `src/fame-swap-pool-state/lambdas/logging.ts`
+- Test: `src/fame-swap-pool-state/lambdas/logging.test.ts`
+
+**Approach:**
+- Seed maintenance from the latest complete replay capsule when no trusted maintenance cursor exists.
+- On each indexer run, attempt bounded replay-log maintenance for the reviewed replay pools after reserve and CL head safety work.
+- Introduce an explicit replay-maintenance mode: seed/checkpoint mode may call full snapshots, but trusted steady-state delta mode must avoid calling the full replay snapshot reader on every scheduled wake.
+- Persist candidate reducer state first; update the quoteable replay pointer only when reducer output is trusted, canonicality-verified, and drift-clean.
+- Add explicit drift-check entry points and metrics, but keep the default scheduled wake from doing full checkpoint work every time.
+- Include metrics for scanned range, changed event count, applied event count, status counts, full snapshot count, provider reads, and drift result.
+
+**Patterns to follow:**
+- Existing reserve cursor advancement discipline in `indexFamePoolStates`
+- Existing replay failure aggregation and sanitized Lambda logging
+- Existing `FamePoolStateIndexerResult` metrics and `indexerResultLogFields`
+
+**Test scenarios:**
+- Covers AE1. Happy path: trusted seed plus supported event range advances maintenance cursor and writes trusted candidate state.
+- Covers AE2. Error path: event-gap status is persisted and the replay latest pointer is not overwritten.
+- Covers AE3. Error path: drift mismatch marks the pool drift-failed and keeps quoted rows unavailable until repair.
+- Error path: stored cursor block hash mismatch prevents cursor advancement and quoteable pointer updates.
+- Edge case: no new replay events advances cursor without changing state hash when block identity is valid.
+- Edge case: trusted steady-state delta mode with no checkpoint due does not call the full replay snapshot reader.
+- Edge case: reserve reconciliation failure still prevents cursor advancement as it does today.
+- Integration: CL head snapshot failures do not corrupt replay maintenance state.
+- Integration: older overlapping runs cannot rewind replay maintenance cursor or latest replay state.
+- Logging: indexer logs summarize maintenance status and provider-pressure metrics without raw tick arrays, raw logs, RPC URLs, or request bodies.
+
+**Verification:**
+- Scheduled indexer behavior can maintain replay trust state in shadow mode while existing reserve and CL head guarantees remain unchanged.
+
+---
+
+### U5. Gate Compact CL Quotes on Maintenance Trust
+
+**Goal:** Make `/fame/pool-quotes` aware of replay-maintenance trust state so compact CL quoted rows are emitted only when state is fresh, complete, cursor-current, and drift-clean.
+
+**Requirements:** R2, R10, R11, R12, R13, R14, R15; supports F3, AE2, AE4, AE5
+
+**Dependencies:** U1, U4, U6
+
+**Files:**
+- Modify: `src/fame-swap-pool-state/cl-quote.ts`
+- Test: `src/fame-swap-pool-state/api.test.ts`
+- Modify: `src/fame-swap-pool-state/lambdas/logging.ts`
+- Test: `src/fame-swap-pool-state/lambdas/logging.test.ts`
+
+**Approach:**
+- Fetch maintenance trust state for CL replay pools alongside replay pointers.
+- Return existing compact CL quote rows only when maintenance state is trusted, drift-clean, and compatible with the replay pointer being quoted.
+- Define pointer compatibility as exact agreement on state hash, snapshot id, observed block, block hash, cursor identity, and source registry id.
+- Before U6 lands, producer-trust-aware quote gating must treat reducer-maintained state as unavailable rather than assuming drift-clean status.
+- Before reviewed promotion evidence exists, producer-trust-aware quote gating must surface reducer state as shadow/unavailable even if the internal maintenance row is trusted.
+- Map warming, event-gap, drift-failed, and repairing states into bounded unavailable quote evidence with enough metadata for `www` debug output and operator diagnosis.
+- Keep API metadata allowlisted to enum-like reasons and bounded block/provenance fields; do not include provider error messages, RPC request details, raw logs, or environment-derived strings.
+- Preserve compact quoted-row shape: do not add raw bitmap words, initialized ticks, helper URLs, tokens, or raw event logs.
+- Keep reserve compact quote behavior unchanged.
+
+**Patterns to follow:**
+- `freshLatestStates` filtering and `clReplayStateMatchesRegistry` in `src/fame-swap-pool-state/cl-quote.ts`
+- Existing `FamePoolQuoteUnavailableReason` handling
+- Existing compact CL quote tests in `src/fame-swap-pool-state/api.test.ts`
+
+**Test scenarios:**
+- Covers AE4. Happy path: trusted maintenance state plus complete replay capsule returns the same compact CL quoted row shape without raw replay arrays.
+- Covers AE2. Error path: warming maintenance state returns unavailable evidence and does not load tick chunks unnecessarily.
+- Error path: drift-failed maintenance state returns unavailable evidence even when a fresh replay pointer exists.
+- Error path: event-gap maintenance state returns unavailable evidence with pool identity and observed block metadata.
+- Edge case: maintenance state from an older source registry id is treated as untrusted.
+- Edge case: trusted maintenance state whose state hash or block identity differs from the replay pointer is treated as untrusted.
+- Edge case: trusted internal maintenance state without reviewed promotion evidence returns unavailable/shadow evidence rather than a quoted row.
+- Security: unavailable metadata never contains provider error text, RPC URLs, raw log data, bearer tokens, or env-derived strings.
+- Integration: a mixed batch can still return reserve quoted rows while CL replay rows are unavailable due to maintenance trust.
+- Logging: quote API reason counts include producer-trust failures without logging raw replay state.
+
+**Verification:**
+- Compact CL quote responses remain small and fallback-safe while producer maintenance status becomes diagnosable.
+
+---
+
+### U6. Add Drift Check and Repair Operations
+
+**Goal:** Provide explicit full-snapshot checkpoint comparison and repair behavior without making full snapshots the default scheduled maintenance algorithm.
+
+**Requirements:** R3, R8, R9, R10, R15, R16; supports F2, F4, AE3, AE5
+
+**Dependencies:** U1, U3, U4
+
+**Files:**
+- Modify: `src/fame-swap-pool-state/indexer.ts`
+- Test: `src/fame-swap-pool-state/indexer.test.ts`
+- Modify: `src/fame-swap-pool-state/lambdas/indexer.ts`
+- Test: `src/fame-swap-pool-state/lambdas/indexer.test.ts`
+- Modify: `src/fame-swap-pool-state/lambdas/logging.ts`
+- Test: `src/fame-swap-pool-state/lambdas/logging.test.ts`
+
+**Approach:**
+- Add an explicit drift-check mode that compares a full checkpoint snapshot with reducer-maintained state at the same block and block hash.
+- If same-block comparison is not available, fail closed rather than approximating drift across neighboring blocks.
+- Mark mismatch as drift-failed before repair so compact quotes fail closed.
+- Repair by reseeding from a complete full snapshot and resetting maintenance cursor/trust only after the repaired state is complete and source-registry-compatible.
+- Keep drift-check and repair entry points Lambda-internal or IAM/operator-only. The authenticated read-helper API token must never authorize checkpoint capture, repair, or trust-state mutation.
+- Keep drift and repair metrics separate from normal delta metrics so rollout evidence can distinguish snapshot pressure from steady-state event maintenance.
+
+**Patterns to follow:**
+- `assertNoClReplaySnapshotFailures` for operational fail-fast behavior
+- Full replay snapshot row construction and state hashing in `src/fame-swap-pool-state/indexer.ts`
+- Sanitized structured logging in `src/fame-swap-pool-state/lambdas/logging.ts`
+
+**Test scenarios:**
+- Covers AE3. Happy path: checkpoint hash matches reducer state and maintenance remains trusted.
+- Covers AE3. Error path: checkpoint hash mismatch marks drift-failed and prevents compact CL quoting.
+- Error path: checkpoint block/hash cannot be aligned with reducer state, so the pool becomes untrusted pending repair.
+- Happy path: repair from a complete checkpoint publishes a repaired trusted state and resets cursor identity.
+- Error path: incomplete checkpoint or source-registry mismatch refuses repair and leaves state untrusted.
+- Security: a read-helper bearer token cannot trigger drift check, checkpoint capture, repair, or trust-state mutation.
+- Edge case: drift check for a pool without seed state records warming or repair-needed status, not trusted.
+- Logging: drift-check metrics show checkpoint count, provider reads, compared block, status, and repaired pool count without raw payloads.
+
+**Verification:**
+- Operators can run a checkpoint/repair path that proves or restores trust without making every scheduled wake pay full snapshot cost.
+
+---
+
+### U7. Produce Promotion Evidence and Documentation
+
+**Goal:** Add the docs and smoke/report surface needed to prove both correctness and provider-pressure improvement.
+
+**Requirements:** R15, R16, R17; supports F4, AE5
+
+**Dependencies:** U4, U5, U6
+
+**Files:**
+- Create: `scripts/fame-pool-state-delta-replay-smoke.ts`
+- Create: `scripts/fame-pool-state-delta-replay-smoke.test.ts`
+- Modify: `package.json`
+- Test: `src/fame-swap-pool-state/lambdas/logging.test.ts`
+- Modify: `docs/fame-pool-state-index.md`
+- Modify: `docs/fame-pool-state-handoff.md`
+
+**Approach:**
+- Add a focused operator smoke/report script that summarizes maintenance status, scanned ranges, event counts, applied delta counts, full snapshot count, provider read count, drift result, compact quote usage, fallback count, and unavailable reasons.
+- Make the report schema allowlisted and redacted by construction: no bearer tokens, RPC URLs, raw request/response bodies, raw CloudWatch lines, raw event logs, helper secrets, or environment variable values.
+- Structure the script around a testable report-building module and add a package script for operator use, rather than burying all logic in an untested CLI entrypoint.
+- Update docs to describe the distinction between full replay snapshots, delta-maintained trusted state, maintenance status, compact quote eligibility, and live fallback.
+- Preserve existing deployment guidance that `FAME_POOL_API_URL` is a base URL, not an endpoint-specific path.
+- Document that the feature proves cheaper trusted steady-state maintenance rather than emergency spend stoppage.
+
+**Patterns to follow:**
+- Existing FAME operational docs in `docs/fame-pool-state-index.md`
+- Existing handoff terminology in `docs/fame-pool-state-handoff.md`
+- Existing structured log field style in `src/fame-swap-pool-state/lambdas/logging.ts`
+- Existing `nodets` TypeScript execution hook in `package.json`
+
+**Test scenarios:**
+- Happy path: report output can represent a trusted reducer-maintained pool with drift-clean evidence and lower provider-read count than full snapshot metrics.
+- Error path: report output can represent event-gap, drift-failed, and repairing pools without implying compact quote trust.
+- Security: report output cannot include token-looking strings, configured RPC URL substrings, raw request/response bodies, or raw CloudWatch log lines.
+- Integration: package script invokes the smoke/report entrypoint without changing existing `test` or `types` scripts.
+- Documentation: docs describe live fallback, compact quote trust, and snapshot checkpoint semantics consistently.
+- Integration: logs and report evidence contain the metrics required by the origin rollout acceptance example.
+
+**Verification:**
+- A reviewer can use docs plus smoke/report output to decide whether the delta lane is correct, fallback-safe, and cheaper in steady state.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The indexer gains a replay-log maintenance lane, DynamoDB gains maintenance rows, `/fame/pool-quotes` reads producer trust state, and `www` continues to consume compact quoted/unavailable rows with live fallback.
+- **Error propagation:** Reducer uncertainty becomes maintenance status and unavailable quote evidence; malformed persistent state remains fail-fast at parser boundaries.
+- **Authorization boundary:** Helper bearer-token reads remain read-only. Drift check, checkpoint capture, repair, and trust-state mutation are Lambda-internal or IAM/operator-only surfaces.
+- **State lifecycle risks:** Partial writes must not publish quoteable replay pointers. Maintenance cursor advancement must be monotonic and coupled to complete event application.
+- **API surface parity:** `/fame/pool-quotes` gains producer-trust unavailable reasons; `/fame/pool-state` replay payloads remain opt-in and raw replay arrays stay off the hot path.
+- **Integration coverage:** Unit tests prove reducer semantics; API tests prove fallback; live dev soak proves provider-read economics and Base log reliability.
+- **Unchanged invariants:** Reserve quote rows, CL head snapshots, service-token auth, base URL env shape, route dispatch fail-fast behavior, and `www` quote authority remain unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Reducer subtly diverges from actual pool state | Shadow-first rollout, deterministic fixtures, low-cadence drift checks, and fail-closed compact quote gating |
+| Base log ranges become too large or provider-limited | Configurable bounded ranges, explicit event-gap status, and smoke evidence for scanned ranges |
+| Slipstream event semantics differ from plain Uniswap V3 | Venue-normalized events retain venue metadata; Slipstream-specific fee or event behavior is confirmed before trusting deltas |
+| Maintenance status leaks into confusing public API behavior | Keep the status vocabulary small and map it into bounded unavailable quote evidence |
+| Operator report or debug evidence leaks secrets or provider internals | Use allowlisted report/API fields and add redaction-focused tests for tokens, RPC URLs, raw logs, and env-derived strings |
+| Read-helper credentials mutate trust state or trigger expensive checkpoints | Keep drift/repair behind Lambda-internal or IAM/operator-only entry points; bearer-token API remains read-only |
+| Persistent state shape corrupts latest replay publication | Separate maintenance rows from replay pointer rows and preserve chunk-before-pointer writes |
+| Plan expands into broad CL indexing | Registry scope remains the current reviewed replay set, with additional pools deferred |
+
+---
+
+## Phased Delivery
+
+### Phase 1: Shadow Maintenance Foundation
+
+- Land maintenance state, event decoding, deterministic reducer fixtures, and shadow indexer metrics.
+
+### Phase 2: Drift, Repair, and Promotion-Gated Compact Quotes
+
+- Add same-block checkpoint comparison and repair flow, then gate compact CL quote rows on trusted drift-clean maintenance state with fallback-safe unavailable reasons. Until same-block drift-clean evidence and reviewed promotion evidence exist, CL rows remain unavailable/live-fallback.
+
+### Phase 3: Promotion Evidence
+
+- Add smoke/report output and documentation for promotion review.
+
+---
+
+## Documentation / Operational Notes
+
+- Update FAME pool-state docs before enabling any producer-trust-dependent quote behavior in a deployed environment.
+- Rollout evidence should compare steady-state delta provider reads against existing full snapshot metrics; it should not claim emergency cost reduction from this feature alone.
+- Deployment should keep existing helper auth and env shape unchanged.
+- A short dev soak should capture several scheduled intervals with advancing maintenance cursor, no drift failures, compact quote fallback counts, and provider-read metrics.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-29-fame-delta-cl-replay-index-requirements.md](docs/brainstorms/2026-05-29-fame-delta-cl-replay-index-requirements.md)
+- Related ideation: [docs/ideation/2026-05-29-fame-delta-cl-replay-index-ideation.md](docs/ideation/2026-05-29-fame-delta-cl-replay-index-ideation.md)
+- Related code: `src/fame-swap-pool-state/indexer.ts`
+- Related code: `src/fame-swap-pool-state/dynamodb/pool-state.ts`
+- Related code: `src/fame-swap-pool-state/cl-quote.ts`
+- Related code: `src/fame-swap-pool-state/lambdas/logging.ts`
+- Related docs: [docs/fame-pool-state-index.md](docs/fame-pool-state-index.md)
+- Related docs: [docs/fame-pool-state-handoff.md](docs/fame-pool-state-handoff.md)
+- External docs: [Base `eth_getLogs`](https://docs.base.org/base-chain/api-reference/ethereum-json-rpc-api/eth_getLogs)
+- External docs: [Uniswap V3 fetching pool data](https://developers.uniswap.org/docs/sdks/v3/guides/pool-data)
+- External docs: [Uniswap V3 pool events](https://github.com/Uniswap/v3-core/blob/main/contracts/interfaces/pool/IUniswapV3PoolEvents.sol)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
 export default {
   testEnvironment: "node",
-  roots: ["<rootDir>/src"],
+  roots: ["<rootDir>/src", "<rootDir>/scripts"],
   transform: {
     "^.+.tsx?$": [
       "ts-jest",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "yarn fame-ipfs:origin:build && yarn fame-thumb:build && yarn fame-mosaic:build && yarn discord:build && yarn discord:fls:wrapped:build && yarn discord:cli:build",
     "generate:types": "graphql-codegen --config codegen.yml",
     "nodets": "node --import 'data:text/javascript,import { register } from \"node:module\"; import { pathToFileURL } from \"node:url\"; register(\"ts-node/esm\", pathToFileURL(\"./\"));'",
+    "fame-pool-state:delta-replay-smoke": "yarn nodets scripts/fame-pool-state-delta-replay-smoke.ts",
     "types": "tsc --noEmit -p tsconfig.json"
   },
   "devDependencies": {

--- a/scripts/fame-pool-state-delta-replay-smoke.test.ts
+++ b/scripts/fame-pool-state-delta-replay-smoke.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "@jest/globals";
+import { buildFameDeltaReplaySmokeReport } from "./fame-pool-state-delta-replay-smoke.ts";
+
+describe("FAME delta replay smoke report", () => {
+  test("summarizes maintenance, provider pressure, and quote fallback evidence", () => {
+    const report = buildFameDeltaReplaySmokeReport({
+      indexer: {
+        sourceRegistryId: "pool-state-registry-v3:unit",
+        observedThroughBlock: 123,
+        clReplaySnapshots: 1,
+        clReplayMetrics: [
+          {
+            poolId: "slipstream-usdc-weth-100",
+            bitmapWordCount: 2,
+            initializedTickCount: 3,
+            bitmapChunkCount: 1,
+            tickChunkCount: 1,
+            providerReadCount: 75,
+            durationMs: 42,
+            stateHash:
+              "0x1111111111111111111111111111111111111111111111111111111111111111",
+          },
+        ],
+        clReplayMaintenanceMetrics: [
+          {
+            poolId: "slipstream-usdc-weth-100",
+            status: "warming",
+            reason: "shadow-not-promoted",
+            fromBlock: 120,
+            toBlock: 123,
+            scannedLogCount: 2,
+            appliedEventCount: 2,
+            candidateWritten: true,
+            stateHash:
+              "0x2222222222222222222222222222222222222222222222222222222222222222",
+          },
+        ],
+      },
+      quoteResponse: {
+        sourceRegistryId: "pool-state-registry-v3:unit",
+        currentBlock: 123,
+        producerMaxFreshnessBlocks: 120,
+        effectiveMaxFreshnessBlocks: 120,
+        quotes: [
+          {
+            status: "unavailable",
+            requested: {
+              poolId: "slipstream-usdc-weth-100",
+              tokenIn: "0x0000000000000000000000000000000000000001",
+              tokenOut: "0x0000000000000000000000000000000000000002",
+              amountIn: "1000",
+            },
+            reason: "producer-untrusted",
+            poolId: "slipstream-usdc-weth-100",
+          },
+        ],
+      },
+    });
+
+    expect(report).toEqual({
+      sourceRegistryId: "pool-state-registry-v3:unit",
+      observedThroughBlock: 123,
+      replaySnapshotCount: 1,
+      providerReadCount: 75,
+      maintenance: [
+        {
+          poolId: "slipstream-usdc-weth-100",
+          status: "warming",
+          reason: "shadow-not-promoted",
+          fromBlock: 120,
+          toBlock: 123,
+          scannedLogCount: 2,
+          appliedEventCount: 2,
+          candidateWritten: true,
+          stateHash:
+            "0x2222222222222222222222222222222222222222222222222222222222222222",
+        },
+      ],
+      quote: {
+        quoted: 0,
+        unavailable: 1,
+        unavailableReasons: {
+          "producer-untrusted": 1,
+        },
+      },
+    });
+    expect(JSON.stringify(report)).not.toContain("https://");
+    expect(JSON.stringify(report)).not.toContain("Bearer");
+    expect(JSON.stringify(report)).not.toContain("eth_getLogs");
+  });
+});

--- a/scripts/fame-pool-state-delta-replay-smoke.ts
+++ b/scripts/fame-pool-state-delta-replay-smoke.ts
@@ -1,0 +1,192 @@
+import { readFileSync } from "node:fs";
+import type {
+  FameClReplayMaintenanceMetric,
+  FameClReplaySnapshotMetric,
+  FamePoolStateIndexerResult,
+} from "../src/fame-swap-pool-state/indexer.ts";
+import type {
+  FamePoolQuoteBatchResponse,
+  FamePoolQuoteUnavailableReason,
+} from "../src/fame-swap-pool-state/cl-quote.ts";
+
+export interface FameDeltaReplaySmokeInput {
+  indexer: Pick<
+    FamePoolStateIndexerResult,
+    | "sourceRegistryId"
+    | "observedThroughBlock"
+    | "clReplaySnapshots"
+    | "clReplayMetrics"
+    | "clReplayMaintenanceMetrics"
+  >;
+  quoteResponse?: FamePoolQuoteBatchResponse;
+}
+
+export interface FameDeltaReplaySmokeReport {
+  sourceRegistryId: string;
+  observedThroughBlock: number;
+  replaySnapshotCount: number;
+  providerReadCount: number;
+  maintenance: {
+    poolId: string;
+    status: FameClReplayMaintenanceMetric["status"];
+    reason: string | null;
+    fromBlock: number;
+    toBlock: number;
+    scannedLogCount: number;
+    appliedEventCount: number;
+    candidateWritten: boolean;
+    stateHash: string | null;
+  }[];
+  quote: {
+    quoted: number;
+    unavailable: number;
+    unavailableReasons: Partial<Record<FamePoolQuoteUnavailableReason, number>>;
+  } | null;
+}
+
+function sumProviderReads(
+  metrics: readonly FameClReplaySnapshotMetric[],
+): number {
+  return metrics.reduce(
+    (total, metric) => total + metric.providerReadCount,
+    0,
+  );
+}
+
+function quoteSummary(response: FamePoolQuoteBatchResponse | undefined) {
+  if (!response) return null;
+  const unavailableReasons: Partial<
+    Record<FamePoolQuoteUnavailableReason, number>
+  > = {};
+  let quoted = 0;
+  let unavailable = 0;
+  for (const quote of response.quotes) {
+    if (quote.status === "quoted") {
+      quoted += 1;
+      continue;
+    }
+    unavailable += 1;
+    unavailableReasons[quote.reason] =
+      (unavailableReasons[quote.reason] ?? 0) + 1;
+  }
+  return {
+    quoted,
+    unavailable,
+    unavailableReasons,
+  };
+}
+
+function maintenanceReport(metric: FameClReplayMaintenanceMetric) {
+  return {
+    poolId: metric.poolId,
+    status: metric.status,
+    reason: metric.reason,
+    fromBlock: metric.fromBlock,
+    toBlock: metric.toBlock,
+    scannedLogCount: metric.scannedLogCount,
+    appliedEventCount: metric.appliedEventCount,
+    candidateWritten: metric.candidateWritten,
+    stateHash: metric.stateHash,
+  };
+}
+
+function objectValue(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${name} must be a JSON object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function numberValue(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${name} must be a finite number.`);
+  }
+  return value;
+}
+
+function stringValue(value: unknown, name: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${name} must be a string.`);
+  }
+  return value;
+}
+
+function arrayValue(value: unknown, name: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${name} must be an array.`);
+  }
+  return value;
+}
+
+function validateSmokeInput(value: unknown): FameDeltaReplaySmokeInput {
+  const input = objectValue(value, "Delta replay smoke input");
+  const indexer = objectValue(input.indexer, "indexer");
+  const sourceRegistryId = stringValue(
+    indexer.sourceRegistryId,
+    "indexer.sourceRegistryId",
+  );
+  const observedThroughBlock = numberValue(
+    indexer.observedThroughBlock,
+    "indexer.observedThroughBlock",
+  );
+  const clReplaySnapshots = numberValue(
+    indexer.clReplaySnapshots,
+    "indexer.clReplaySnapshots",
+  );
+  arrayValue(indexer.clReplayMetrics, "indexer.clReplayMetrics");
+  arrayValue(
+    indexer.clReplayMaintenanceMetrics,
+    "indexer.clReplayMaintenanceMetrics",
+  );
+  if (input.quoteResponse !== undefined) {
+    const quoteResponse = objectValue(input.quoteResponse, "quoteResponse");
+    arrayValue(quoteResponse.quotes, "quoteResponse.quotes");
+  }
+  return {
+    indexer: {
+      sourceRegistryId,
+      observedThroughBlock,
+      clReplaySnapshots,
+      clReplayMetrics:
+        indexer.clReplayMetrics as FameClReplaySnapshotMetric[],
+      clReplayMaintenanceMetrics:
+        indexer.clReplayMaintenanceMetrics as FameClReplayMaintenanceMetric[],
+    },
+    quoteResponse: input.quoteResponse as FamePoolQuoteBatchResponse | undefined,
+  };
+}
+
+export function buildFameDeltaReplaySmokeReport(
+  input: FameDeltaReplaySmokeInput,
+): FameDeltaReplaySmokeReport {
+  return {
+    sourceRegistryId: input.indexer.sourceRegistryId,
+    observedThroughBlock: input.indexer.observedThroughBlock,
+    replaySnapshotCount: input.indexer.clReplaySnapshots,
+    providerReadCount: sumProviderReads(input.indexer.clReplayMetrics),
+    maintenance: input.indexer.clReplayMaintenanceMetrics.map(
+      maintenanceReport,
+    ),
+    quote: quoteSummary(input.quoteResponse),
+  };
+}
+
+function parseInput(path: string): FameDeltaReplaySmokeInput {
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  return validateSmokeInput(parsed);
+}
+
+function main(): void {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    throw new Error(
+      "Usage: yarn fame-pool-state:delta-replay-smoke <input-json>",
+    );
+  }
+  const report = buildFameDeltaReplaySmokeReport(parseInput(inputPath));
+  console.log(JSON.stringify(report, null, 2));
+}
+
+if (process.argv[1]?.endsWith("fame-pool-state-delta-replay-smoke.ts")) {
+  main();
+}

--- a/scripts/fame-pool-state-local-route-lab-server.ts
+++ b/scripts/fame-pool-state-local-route-lab-server.ts
@@ -1,0 +1,305 @@
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import {
+  BatchGetCommand,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
+import { baseClient } from "../src/viem.ts";
+import {
+  handleFamePoolQuoteBatchRequest,
+} from "../src/fame-swap-pool-state/cl-quote.ts";
+import {
+  handleFamePoolStateBatchRequest,
+} from "../src/fame-swap-pool-state/api.ts";
+import {
+  createViemPoolStateIndexerClient,
+  indexFamePoolStates,
+} from "../src/fame-swap-pool-state/indexer.ts";
+import type {
+  PoolStateDocumentClient,
+  PoolStateDynamoResponse,
+} from "../src/fame-swap-pool-state/dynamodb/pool-state.ts";
+
+type SentCommand = Parameters<PoolStateDocumentClient["send"]>[0];
+
+class LocalPoolStateDb implements PoolStateDocumentClient {
+  private readonly items = new Map<string, Record<string, unknown>>();
+
+  async send(command: SentCommand): Promise<PoolStateDynamoResponse> {
+    if (command instanceof GetCommand) {
+      return { Item: this.items.get(keyFromValue(command.input.Key)) };
+    }
+    if (command instanceof BatchGetCommand) {
+      const responses: Record<string, Record<string, unknown>[]> = {};
+      const requestItems = objectValue(command.input.RequestItems);
+      for (const [tableName, request] of Object.entries(requestItems)) {
+        const keys = objectValue(request).Keys;
+        if (!Array.isArray(keys)) {
+          throw new Error("BatchGetCommand keys must be an array.");
+        }
+        responses[tableName] = keys
+          .map((key) => this.items.get(keyFromValue(key)))
+          .filter((item): item is Record<string, unknown> => item !== undefined);
+      }
+      return { Responses: responses };
+    }
+    if (command instanceof PutCommand) {
+      const item = objectValue(command.input.Item);
+      const existing = this.items.get(keyFromRecord(item));
+      enforcePutCondition(command, item, existing);
+      this.items.set(keyFromRecord(item), item);
+      return {};
+    }
+    if (command instanceof UpdateCommand) {
+      const key = keyFromValue(command.input.Key);
+      const existing = this.items.get(key);
+      if (!existing) throwConditionalFailure();
+      const values = objectValue(command.input.ExpressionAttributeValues);
+      const observedThroughBlock = numberField(values, ":observedThroughBlock");
+      if (
+        typeof existing.observedThroughBlock === "number" &&
+        existing.observedThroughBlock >= observedThroughBlock
+      ) {
+        throwConditionalFailure();
+      }
+      this.items.set(key, {
+        ...existing,
+        observedThroughBlock,
+        sourceRegistryId: stringField(values, ":sourceRegistryId"),
+        updatedAt: stringField(values, ":updatedAt"),
+      });
+      return {};
+    }
+    throw new Error("Unexpected DynamoDB command.");
+  }
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Expected object.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function keyFromRecord(record: Record<string, unknown>): string {
+  return `${stringField(record, "pk")}\u0000${stringField(record, "sk")}`;
+}
+
+function keyFromValue(value: unknown): string {
+  return keyFromRecord(objectValue(value));
+}
+
+function stringField(item: Record<string, unknown>, key: string): string {
+  const value = item[key];
+  if (typeof value !== "string") throw new Error(`${key} must be a string.`);
+  return value;
+}
+
+function numberField(item: Record<string, unknown>, key: string): number {
+  const value = item[key];
+  if (typeof value !== "number") throw new Error(`${key} must be a number.`);
+  return value;
+}
+
+function eventVersion(item: Record<string, unknown>) {
+  return {
+    blockNumber: numberField(item, "lastReserveChangeBlock"),
+    transactionIndex: numberField(item, "lastEventTransactionIndex"),
+    logIndex: numberField(item, "lastEventLogIndex"),
+  };
+}
+
+function compareEventVersions(
+  left: ReturnType<typeof eventVersion>,
+  right: ReturnType<typeof eventVersion>,
+): number {
+  if (left.blockNumber !== right.blockNumber) return left.blockNumber - right.blockNumber;
+  if (left.transactionIndex !== right.transactionIndex) {
+    return left.transactionIndex - right.transactionIndex;
+  }
+  return left.logIndex - right.logIndex;
+}
+
+function throwConditionalFailure(): never {
+  const error = new Error("conditional");
+  error.name = "ConditionalCheckFailedException";
+  throw error;
+}
+
+function enforcePutCondition(
+  command: PutCommand,
+  item: Record<string, unknown>,
+  existing: Record<string, unknown> | undefined,
+): void {
+  if (!existing) return;
+  const condition = String(command.input.ConditionExpression ?? "");
+  if (condition.length === 0) return;
+  if (condition === "attribute_not_exists(pk)") throwConditionalFailure();
+  const values = objectValue(command.input.ExpressionAttributeValues);
+  if (condition.includes("lastReserveChangeBlock")) {
+    if (numberField(existing, "observedThroughBlock") > numberField(values, ":observedThroughBlock")) {
+      throwConditionalFailure();
+    }
+    if (compareEventVersions(eventVersion(item), eventVersion(existing)) <= 0) {
+      throwConditionalFailure();
+    }
+    return;
+  }
+  if (condition.includes("cursorBlock")) {
+    const current = {
+      cursorBlock: numberField(existing, "cursorBlock"),
+      cursorTransactionIndex: numberField(existing, "cursorTransactionIndex"),
+      cursorLogIndex: numberField(existing, "cursorLogIndex"),
+      sourceRegistryId: stringField(existing, "sourceRegistryId"),
+    };
+    const incoming = {
+      cursorBlock: numberField(values, ":cursorBlock"),
+      cursorTransactionIndex: numberField(values, ":cursorTransactionIndex"),
+      cursorLogIndex: numberField(values, ":cursorLogIndex"),
+      sourceRegistryId: stringField(values, ":sourceRegistryId"),
+    };
+    const stale =
+      current.cursorBlock > incoming.cursorBlock ||
+      (current.cursorBlock === incoming.cursorBlock &&
+        current.cursorTransactionIndex > incoming.cursorTransactionIndex) ||
+      (current.cursorBlock === incoming.cursorBlock &&
+        current.cursorTransactionIndex === incoming.cursorTransactionIndex &&
+        current.cursorLogIndex > incoming.cursorLogIndex) ||
+      (current.cursorBlock === incoming.cursorBlock &&
+        current.cursorTransactionIndex === incoming.cursorTransactionIndex &&
+        current.cursorLogIndex === incoming.cursorLogIndex &&
+        current.sourceRegistryId !== incoming.sourceRegistryId);
+    if (stale) throwConditionalFailure();
+    return;
+  }
+  if (condition.includes("observedThroughBlock")) {
+    const currentBlock = numberField(existing, "observedThroughBlock");
+    const incomingBlock = numberField(values, ":observedThroughBlock");
+    const currentSourceRegistryId = stringField(existing, "sourceRegistryId");
+    const rawIncomingSourceRegistryId = values[":sourceRegistryId"];
+    const incomingSourceRegistryId =
+      typeof rawIncomingSourceRegistryId === "string"
+        ? rawIncomingSourceRegistryId
+        : currentSourceRegistryId;
+    if (
+      currentBlock > incomingBlock ||
+      (currentBlock === incomingBlock && currentSourceRegistryId !== incomingSourceRegistryId)
+    ) {
+      throwConditionalFailure();
+    }
+  }
+}
+
+async function readBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    if (Buffer.isBuffer(chunk)) chunks.push(chunk);
+    else chunks.push(Buffer.from(chunk));
+  }
+  const body = Buffer.concat(chunks).toString("utf8");
+  return JSON.parse(body || "{}") as unknown;
+}
+
+function json(response: ServerResponse, statusCode: number, body: unknown): void {
+  response.writeHead(statusCode, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+function safeErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message.split("\n", 1)[0] ?? "Unknown error";
+  }
+  return "Unknown error";
+}
+
+async function main(): Promise<void> {
+  const port = Number(process.env.FAME_POOL_STATE_LOCAL_PORT ?? "3977");
+  const token = process.env.FAME_POOL_STATE_SERVICE_TOKEN ?? "local-route-lab";
+  const seedConfirmationBlocks = Number(
+    process.env.FAME_POOL_STATE_LOCAL_SEED_CONFIRMATION_BLOCKS ?? "64",
+  );
+  const finalConfirmationBlocks = Number(
+    process.env.FAME_POOL_STATE_LOCAL_FINAL_CONFIRMATION_BLOCKS ?? "2",
+  );
+  const tableName = "LocalPoolState";
+  const db = new LocalPoolStateDb();
+  const client = createViemPoolStateIndexerClient(baseClient);
+  const seedResult = await indexFamePoolStates({
+    client,
+    db,
+    tableName,
+    confirmationBlocks: seedConfirmationBlocks,
+    clReplayMaintenanceMode: "checkpoint",
+    clReplayTrustPromotion: true,
+  });
+  console.log(
+    JSON.stringify({
+      event: "local-indexed",
+      phase: "checkpoint-seed",
+      result: seedResult,
+    }),
+  );
+  const result = await indexFamePoolStates({
+    client: createViemPoolStateIndexerClient(baseClient),
+    db,
+    tableName,
+    confirmationBlocks: finalConfirmationBlocks,
+    clReplayMaintenanceMode: "steady-state",
+    clReplayTrustPromotion: true,
+  });
+  console.log(
+    JSON.stringify({ event: "local-indexed", phase: "steady-state", result }),
+  );
+
+  const server = createServer((request, response) => {
+    void (async () => {
+      try {
+        if (request.method !== "POST") {
+          json(response, 405, { error: "method-not-allowed" });
+          return;
+        }
+        if (request.headers.authorization !== `Bearer ${token}`) {
+          json(response, 401, { error: "unauthorized" });
+          return;
+        }
+        const body = await readBody(request);
+        if (request.url === "/fame/pool-state") {
+          json(
+            response,
+            200,
+            await handleFamePoolStateBatchRequest({ request: body, db, tableName }),
+          );
+          return;
+        }
+        if (request.url === "/fame/pool-quotes") {
+          json(
+            response,
+            200,
+            await handleFamePoolQuoteBatchRequest({ request: body, db, tableName }),
+          );
+          return;
+        }
+        json(response, 404, { error: "not-found" });
+      } catch (error) {
+        json(response, 500, {
+          error: safeErrorMessage(error),
+        });
+      }
+    })();
+  });
+  server.listen(port, "127.0.0.1", () => {
+    console.log(JSON.stringify({ event: "local-server-ready", port }));
+  });
+}
+
+await main().catch((error: unknown) => {
+  console.error(
+    JSON.stringify({ event: "local-server-failed", error: safeErrorMessage(error) }),
+  );
+  process.exitCode = 1;
+});

--- a/src/fame-swap-pool-state/api.test.ts
+++ b/src/fame-swap-pool-state/api.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   clReplayStateRowsFromSnapshot,
   latestClHeadStateFromSnapshot,
+  latestClReplayMaintenanceStateKey,
   latestPoolStateKey,
   latestStateFromReserves,
   sourceRegistryIdFor,
@@ -19,6 +20,7 @@ import {
   type FameClHeadSnapshotRegistryEntry,
   type FameClReplayBitmapChunkState,
   type FameClReplayLatestState,
+  type FameClReplayMaintenanceState,
   type FameClReplayRegistryEntry,
   type FameClReplayTickChunkState,
   type FamePoolLatestState,
@@ -43,6 +45,7 @@ class BatchStateDb implements PoolStateDocumentClient {
       | FameClHeadLatestState
       | FameClReplayBitmapChunkState
       | FameClReplayLatestState
+      | FameClReplayMaintenanceState
       | FameClReplayTickChunkState
       | FamePoolLatestState
     )[],
@@ -103,6 +106,7 @@ function recordFromState(
     | FameClHeadLatestState
     | FameClReplayBitmapChunkState
     | FameClReplayLatestState
+    | FameClReplayMaintenanceState
     | FameClReplayTickChunkState
     | FamePoolLatestState,
 ): Record<string, unknown> {
@@ -290,6 +294,44 @@ function quoteClReplayRowsForPool(pool: FameClReplayRegistryEntry) {
     bitmapChunkSize: 1,
     tickChunkSize: 1,
   });
+}
+
+function trustedMaintenanceForReplayRows(
+  pool: FameClReplayRegistryEntry,
+  rows: ReturnType<typeof clReplayStateRowsFromSnapshot>,
+): FameClReplayMaintenanceState {
+  return {
+    ...latestClReplayMaintenanceStateKey(pool),
+    stateKind: "cl-replay-maintenance-v1",
+    poolId: pool.id,
+    chainId: pool.chainId,
+    poolAddress: pool.poolAddress,
+    status: "trusted",
+    cursorBlock: rows.latest.observedThroughBlock,
+    cursorBlockHash: rows.latest.blockHash,
+    cursorTransactionIndex: Number.MAX_SAFE_INTEGER,
+    cursorLogIndex: Number.MAX_SAFE_INTEGER,
+    targetBlock: rows.latest.observedThroughBlock,
+    targetBlockHash: rows.latest.blockHash,
+    stateHash: rows.latest.stateHash,
+    sourceRegistryId: rows.latest.sourceRegistryId,
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    lastCheckpointBlock: rows.latest.observedThroughBlock,
+    lastCheckpointBlockHash: rows.latest.blockHash,
+    reason: null,
+    candidateId: rows.latest.snapshotId,
+  };
+}
+
+function warmingMaintenanceForReplayRows(
+  pool: FameClReplayRegistryEntry,
+  rows: ReturnType<typeof clReplayStateRowsFromSnapshot>,
+): FameClReplayMaintenanceState {
+  return {
+    ...trustedMaintenanceForReplayRows(pool, rows),
+    status: "warming",
+    reason: "shadow-not-promoted",
+  };
 }
 
 function parseFixtureObject(
@@ -491,6 +533,7 @@ describe("FAME pool-state API contract", () => {
       },
       tableName: "PoolState",
       db: new BatchStateDb([
+        trustedMaintenanceForReplayRows(pool, rows),
         rows.latest,
         ...rows.bitmapChunks,
         ...rows.tickChunks,
@@ -567,6 +610,7 @@ describe("FAME pool-state API contract", () => {
       },
       tableName: "PoolState",
       db: new BatchStateDb([
+        trustedMaintenanceForReplayRows(pool, rows),
         rows.latest,
         ...rows.bitmapChunks,
         ...rows.tickChunks,
@@ -686,6 +730,7 @@ describe("FAME pool-state API contract", () => {
           reserve1: 2500n,
           sourceRegistryId: sourceRegistryIdFor(famePoolStateRegistry.source),
         }),
+        trustedMaintenanceForReplayRows(clPool, clRows),
         clRows.latest,
         ...clRows.bitmapChunks,
         ...clRows.tickChunks,
@@ -885,7 +930,7 @@ describe("FAME pool-state API contract", () => {
       observedThroughBlock: 120,
       maxFreshnessBlocks: 120,
     });
-    expect(db.readCount).toBe(1);
+    expect(db.readCount).toBe(2);
   });
 
   test("returns unavailable CL quotes for incomplete replay capsules", async () => {
@@ -904,7 +949,11 @@ describe("FAME pool-state API contract", () => {
         ],
       },
       tableName: "PoolState",
-      db: new BatchStateDb([rows.latest, ...rows.bitmapChunks]),
+      db: new BatchStateDb([
+        trustedMaintenanceForReplayRows(pool, rows),
+        rows.latest,
+        ...rows.bitmapChunks,
+      ]),
       producerMaxFreshnessBlocks: 120,
     });
 
@@ -914,6 +963,43 @@ describe("FAME pool-state API contract", () => {
       poolId: pool.id,
       observedThroughBlock: 120,
     });
+  });
+
+  test("returns unavailable CL quotes for untrusted producer maintenance without loading chunks", async () => {
+    const pool = clReplayPool();
+    const rows = quoteClReplayRowsForPool(pool);
+    const db = new BatchStateDb([
+      warmingMaintenanceForReplayRows(pool, rows),
+      rows.latest,
+      ...rows.bitmapChunks,
+      ...rows.tickChunks,
+    ]);
+    const response = await handleFamePoolQuoteBatchRequest({
+      request: {
+        currentBlock: 125,
+        quotes: [
+          {
+            poolId: pool.id,
+            tokenIn: pool.token0,
+            tokenOut: pool.token1,
+            amountIn: "1000000",
+          },
+        ],
+      },
+      tableName: "PoolState",
+      db,
+      producerMaxFreshnessBlocks: 120,
+    });
+
+    expect(response.quotes[0]).toMatchObject({
+      status: "unavailable",
+      reason: "producer-untrusted",
+      poolId: pool.id,
+      observedThroughBlock: 120,
+      producerStatus: "warming",
+      producerReason: "shadow-not-promoted",
+    });
+    expect(db.readCount).toBe(2);
   });
 
   test("returns unavailable compact quotes for unsupported or unknown pools", async () => {

--- a/src/fame-swap-pool-state/cl-quote.ts
+++ b/src/fame-swap-pool-state/cl-quote.ts
@@ -2,10 +2,13 @@ import { isAddress, type Address, type Hex } from "viem";
 import { FamePoolStateRequestError } from "./api.ts";
 import {
   batchGetClReplayStateCapsules,
+  batchGetLatestClReplayMaintenanceStates,
   batchGetLatestClReplayPointers,
   batchGetLatestPoolStates,
   sourceRegistryIdFor,
   type FameClReplayLatestState,
+  type FameClReplayMaintenanceState,
+  type FameClReplayMaintenanceStatus,
   type FameClReplayRegistryEntry,
   type FameClReplayStateCapsule,
   type FamePoolLatestState,
@@ -43,7 +46,8 @@ export type FamePoolQuoteUnavailableReason =
   | "reserve-quote-failed"
   | "malformed-replay-state"
   | "outside-indexed-tick-range"
-  | "replay-failed";
+  | "replay-failed"
+  | "producer-untrusted";
 
 interface FamePoolQuoteUnavailableEntry {
   status: "unavailable";
@@ -55,6 +59,8 @@ interface FamePoolQuoteUnavailableEntry {
   observedThroughBlock?: number;
   sourceRegistryId?: string;
   maxFreshnessBlocks?: number;
+  producerStatus?: FameClReplayMaintenanceStatus;
+  producerReason?: string | null;
 }
 
 interface FameSlipstreamClQuoteEntry {
@@ -393,6 +399,30 @@ function clReplayStateMatchesRegistry({
     clReplayLatestStateMatchesRegistry({ latest, entry, sourceRegistryId }) &&
     latest.bitmapWordCount === state.bitmapWords.length &&
     latest.initializedTickCount === state.initializedTicks.length
+  );
+}
+
+function clReplayMaintenanceCompatible({
+  maintenance,
+  latest,
+  sourceRegistryId,
+}: {
+  maintenance: FameClReplayMaintenanceState | undefined;
+  latest: FameClReplayLatestState;
+  sourceRegistryId: string;
+}): boolean {
+  return (
+    maintenance !== undefined &&
+    maintenance.status === "trusted" &&
+    maintenance.sourceRegistryId === sourceRegistryId &&
+    maintenance.poolId === latest.poolId &&
+    maintenance.chainId === latest.chainId &&
+    sameAddress(maintenance.poolAddress, latest.poolAddress) &&
+    maintenance.cursorBlock === latest.observedThroughBlock &&
+    maintenance.cursorBlockHash === latest.blockHash &&
+    maintenance.targetBlock === latest.observedThroughBlock &&
+    maintenance.targetBlockHash === latest.blockHash &&
+    maintenance.stateHash === latest.stateHash
   );
 }
 
@@ -1081,11 +1111,25 @@ export async function handleFamePoolQuoteBatchRequest({
     tableName,
     pools: [...clReplayPoolsById.values()],
   });
+  const maintenanceStates = await batchGetLatestClReplayMaintenanceStates({
+    db,
+    tableName,
+    pools: [...clReplayPoolsById.values()],
+  });
+  const maintenanceStatesByPoolId = new Map(
+    maintenanceStates.map((state) => [state.poolId, state]),
+  );
   const freshLatestStates = latestStates.filter((latest) => {
     const entry = clReplayPoolsById.get(latest.poolId);
+    const maintenance = maintenanceStatesByPoolId.get(latest.poolId);
     return (
       entry !== undefined &&
       clReplayLatestStateMatchesRegistry({ latest, entry, sourceRegistryId }) &&
+      clReplayMaintenanceCompatible({
+        maintenance,
+        latest,
+        sourceRegistryId,
+      }) &&
       freshnessStatus({
         state: latest,
         currentBlock: parsed.currentBlock,
@@ -1227,6 +1271,25 @@ export async function handleFamePoolQuoteBatchRequest({
           observedThroughBlock: latest.observedThroughBlock,
           sourceRegistryId: latest.sourceRegistryId,
           maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+        });
+      }
+      const maintenance = maintenanceStatesByPoolId.get(entry.id);
+      if (
+        !clReplayMaintenanceCompatible({
+          maintenance,
+          latest,
+          sourceRegistryId,
+        })
+      ) {
+        return unavailable(requested, "producer-untrusted", {
+          poolId: entry.id,
+          chainId: entry.chainId,
+          poolAddress: entry.poolAddress,
+          observedThroughBlock: latest.observedThroughBlock,
+          sourceRegistryId: latest.sourceRegistryId,
+          maxFreshnessBlocks: effectiveMaxFreshnessBlocks,
+          producerStatus: maintenance?.status,
+          producerReason: maintenance?.reason,
         });
       }
 

--- a/src/fame-swap-pool-state/config.ts
+++ b/src/fame-swap-pool-state/config.ts
@@ -17,6 +17,25 @@ function optionalIntegerEnv(name: string, fallback: number): number {
   return parsed;
 }
 
+function optionalBooleanEnv(name: string, fallback: boolean): boolean {
+  const value = process.env[name];
+  if (!value || value.trim().length === 0) return fallback;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`${name} must be true or false`);
+}
+
+function optionalStringEnumEnv<const T extends readonly string[]>(
+  name: string,
+  values: T,
+  fallback: T[number],
+): T[number] {
+  const value = process.env[name];
+  if (!value || value.trim().length === 0) return fallback;
+  if (values.includes(value)) return value;
+  throw new Error(`${name} must be one of ${values.join(", ")}`);
+}
+
 export const FAME_POOL_STATE_TABLE_NAME = requiredEnv(
   "FAME_POOL_STATE_TABLE_NAME",
 );
@@ -34,4 +53,21 @@ export const FAME_POOL_STATE_MAX_BATCH_SIZE = optionalIntegerEnv(
 export const FAME_POOL_STATE_CONFIRMATION_BLOCKS = optionalIntegerEnv(
   "FAME_POOL_STATE_CONFIRMATION_BLOCKS",
   2,
+);
+
+export const FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE =
+  optionalStringEnumEnv(
+    "FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE",
+    ["checkpoint", "steady-state", "repair"] as const,
+    "checkpoint",
+  );
+
+export const FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION = optionalBooleanEnv(
+  "FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION",
+  false,
+);
+
+export const FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS = optionalIntegerEnv(
+  "FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS",
+  1_000,
 );

--- a/src/fame-swap-pool-state/dynamodb/pool-state.test.ts
+++ b/src/fame-swap-pool-state/dynamodb/pool-state.test.ts
@@ -3,9 +3,12 @@ import { BatchGetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 import type { Address, Hex } from "viem";
 import {
   batchGetLatestClReplayStates,
+  batchGetLatestClReplayCandidateStates,
+  batchGetLatestClReplayMaintenanceStates,
   CL_REPLAY_CHUNK_TTL_SECONDS,
   batchGetLatestClHeadStates,
   batchGetLatestPoolStates,
+  clReplayCandidateStateRowsFromSnapshot,
   clReplayStateRowsFromSnapshot,
   comparePoolStateEventVersions,
   getLatestClHeadState,
@@ -15,11 +18,14 @@ import {
   latestClReplayStateKey,
   latestPoolStateKey,
   putLatestClReplayState,
+  putLatestClReplayCandidateState,
+  putLatestClReplayMaintenanceState,
   latestStateFromReserves,
   putLatestClHeadState,
   putLatestPoolState,
   sourceRegistryIdFor,
   type FameClReplayRegistryEntry,
+  type FameClReplayMaintenanceState,
   type FameClHeadSnapshotRegistryEntry,
   type PoolStateDocumentClient,
   type PoolStateDynamoResponse,
@@ -181,6 +187,55 @@ class ReplayStateDb implements PoolStateDocumentClient {
           (currentBlock === incomingBlock &&
             currentSourceRegistryId !== incomingSourceRegistryId)
         ) {
+          const error = new Error("conditional");
+          error.name = "ConditionalCheckFailedException";
+          throw error;
+        }
+      }
+      if (
+        condition ===
+          "attribute_not_exists(pk) OR cursorBlock < :cursorBlock OR (cursorBlock = :cursorBlock AND cursorTransactionIndex < :cursorTransactionIndex) OR (cursorBlock = :cursorBlock AND cursorTransactionIndex = :cursorTransactionIndex AND cursorLogIndex < :cursorLogIndex) OR (cursorBlock = :cursorBlock AND cursorTransactionIndex = :cursorTransactionIndex AND cursorLogIndex = :cursorLogIndex AND sourceRegistryId = :sourceRegistryId)" &&
+        existing
+      ) {
+        const values = command.input.ExpressionAttributeValues;
+        if (!values) {
+          throw new Error(
+            "PutCommand fixture is missing ExpressionAttributeValues.",
+          );
+        }
+        const incoming = {
+          cursorBlock: numberField(values, ":cursorBlock"),
+          cursorTransactionIndex: numberField(
+            values,
+            ":cursorTransactionIndex",
+          ),
+          cursorLogIndex: numberField(values, ":cursorLogIndex"),
+          sourceRegistryId: stringField(values, ":sourceRegistryId"),
+        };
+        const current = {
+          cursorBlock: numberField(existing, "cursorBlock"),
+          cursorTransactionIndex: numberField(
+            existing,
+            "cursorTransactionIndex",
+          ),
+          cursorLogIndex: numberField(existing, "cursorLogIndex"),
+          sourceRegistryId: stringField(existing, "sourceRegistryId"),
+        };
+        const incomingIsStale =
+          current.cursorBlock > incoming.cursorBlock ||
+          (current.cursorBlock === incoming.cursorBlock &&
+            current.cursorTransactionIndex >
+              incoming.cursorTransactionIndex) ||
+          (current.cursorBlock === incoming.cursorBlock &&
+            current.cursorTransactionIndex ===
+              incoming.cursorTransactionIndex &&
+            current.cursorLogIndex > incoming.cursorLogIndex) ||
+          (current.cursorBlock === incoming.cursorBlock &&
+            current.cursorTransactionIndex ===
+              incoming.cursorTransactionIndex &&
+            current.cursorLogIndex === incoming.cursorLogIndex &&
+            current.sourceRegistryId !== incoming.sourceRegistryId);
+        if (incomingIsStale) {
           const error = new Error("conditional");
           error.name = "ConditionalCheckFailedException";
           throw error;
@@ -459,6 +514,288 @@ describe("FAME pool-state DynamoDB mapping", () => {
         CL_REPLAY_CHUNK_TTL_SECONDS,
     );
     expect(rows.tickChunks[0]?.expiresAt).toBe(rows.bitmapChunks[0]?.expiresAt);
+  });
+
+  test("round-trips replay maintenance rows independently from published replay state", async () => {
+    const pool = clReplayPool();
+    const trustedState: FameClReplayMaintenanceState = {
+      pk: `pool:${pool.chainId.toString()}:address:${pool.poolAddress.toLowerCase()}`,
+      sk: "cl-replay-maintenance-v1",
+      stateKind: "cl-replay-maintenance-v1",
+      poolId: pool.id,
+      chainId: pool.chainId,
+      poolAddress: pool.poolAddress,
+      status: "trusted",
+      cursorBlock: 321,
+      cursorBlockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      cursorTransactionIndex: 4,
+      cursorLogIndex: 9,
+      targetBlock: 325,
+      targetBlockHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      lastCheckpointBlock: 300,
+      lastCheckpointBlockHash:
+        "0x4444444444444444444444444444444444444444444444444444444444444444",
+      reason: null,
+      candidateId: "candidate-321",
+    };
+    const db = new ReplayStateDb();
+
+    await expect(
+      putLatestClReplayMaintenanceState({
+        db,
+        tableName: "PoolState",
+        state: trustedState,
+      }),
+    ).resolves.toBe("written");
+    await expect(
+      batchGetLatestClReplayMaintenanceStates({
+        db,
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).resolves.toEqual([trustedState]);
+    await expect(
+      batchGetLatestClReplayStates({
+        db,
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  test("persists warming replay maintenance rows without a replay pointer", async () => {
+    const pool = clReplayPool();
+    const warmingState: FameClReplayMaintenanceState = {
+      pk: `pool:${pool.chainId.toString()}:address:${pool.poolAddress.toLowerCase()}`,
+      sk: "cl-replay-maintenance-v1",
+      stateKind: "cl-replay-maintenance-v1",
+      poolId: pool.id,
+      chainId: pool.chainId,
+      poolAddress: pool.poolAddress,
+      status: "warming",
+      cursorBlock: 0,
+      cursorBlockHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      cursorTransactionIndex: 0,
+      cursorLogIndex: 0,
+      targetBlock: 0,
+      targetBlockHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      stateHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      lastCheckpointBlock: null,
+      lastCheckpointBlockHash: null,
+      reason: "seed-required",
+      candidateId: null,
+    };
+    const db = new ReplayStateDb();
+
+    await expect(
+      putLatestClReplayMaintenanceState({
+        db,
+        tableName: "PoolState",
+        state: warmingState,
+      }),
+    ).resolves.toBe("written");
+    expect(db.items.get(`${warmingState.pk}\u0000cl-replay-v1`)).toBeUndefined();
+  });
+
+  test("rejects stale replay maintenance cursor writes", async () => {
+    const pool = clReplayPool();
+    const baseState: FameClReplayMaintenanceState = {
+      pk: `pool:${pool.chainId.toString()}:address:${pool.poolAddress.toLowerCase()}`,
+      sk: "cl-replay-maintenance-v1",
+      stateKind: "cl-replay-maintenance-v1",
+      poolId: pool.id,
+      chainId: pool.chainId,
+      poolAddress: pool.poolAddress,
+      status: "event-gap",
+      cursorBlock: 321,
+      cursorBlockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      cursorTransactionIndex: 4,
+      cursorLogIndex: 9,
+      targetBlock: 325,
+      targetBlockHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
+      sourceRegistryId: "registry-a",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      lastCheckpointBlock: null,
+      lastCheckpointBlockHash: null,
+      reason: "cursor-block-hash-mismatch",
+      candidateId: null,
+    };
+    const db = new ReplayStateDb();
+
+    await expect(
+      putLatestClReplayMaintenanceState({
+        db,
+        tableName: "PoolState",
+        state: baseState,
+      }),
+    ).resolves.toBe("written");
+    await expect(
+      putLatestClReplayMaintenanceState({
+        db,
+        tableName: "PoolState",
+        state: {
+          ...baseState,
+          cursorLogIndex: 8,
+          updatedAt: "2026-05-20T00:01:00.000Z",
+        },
+      }),
+    ).resolves.toBe("ignored");
+    await expect(
+      putLatestClReplayMaintenanceState({
+        db,
+        tableName: "PoolState",
+        state: {
+          ...baseState,
+          status: "trusted",
+          reason: null,
+          updatedAt: "2026-05-20T00:02:00.000Z",
+        },
+      }),
+    ).resolves.toBe("written");
+  });
+
+  test("rejects malformed replay maintenance rows", async () => {
+    const pool = clReplayPool();
+    const state: FameClReplayMaintenanceState = {
+      pk: `pool:${pool.chainId.toString()}:address:${pool.poolAddress.toLowerCase()}`,
+      sk: "cl-replay-maintenance-v1",
+      stateKind: "cl-replay-maintenance-v1",
+      poolId: pool.id,
+      chainId: pool.chainId,
+      poolAddress: pool.poolAddress,
+      status: "trusted",
+      cursorBlock: 321,
+      cursorBlockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      cursorTransactionIndex: 4,
+      cursorLogIndex: 9,
+      targetBlock: 325,
+      targetBlockHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      lastCheckpointBlock: 300,
+      lastCheckpointBlockHash:
+        "0x4444444444444444444444444444444444444444444444444444444444444444",
+      reason: null,
+      candidateId: "candidate-321",
+    };
+
+    await expect(
+      batchGetLatestClReplayMaintenanceStates({
+        db: new ReplayStateDb([{ ...state, status: "ready" }]),
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).rejects.toThrow(/Invalid CL replay maintenance DynamoDB item/);
+    await expect(
+      batchGetLatestClReplayMaintenanceStates({
+        db: new ReplayStateDb([{ ...state, cursorBlockHash: "0x1" }]),
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).rejects.toThrow(/Invalid CL replay maintenance DynamoDB item/);
+    await expect(
+      batchGetLatestClReplayMaintenanceStates({
+        db: new ReplayStateDb([{ ...state, sourceRegistryId: "" }]),
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).rejects.toThrow(/Invalid CL replay maintenance DynamoDB item/);
+  });
+
+  test("writes candidate replay chunks before candidate pointer and keeps candidates invisible to quote reads", async () => {
+    const pool = clReplayPool();
+    const rows = clReplayCandidateStateRowsFromSnapshot({
+      pool,
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 123_456_789n,
+      fee: 100n,
+      observedThroughBlock: 321,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      candidateId: "unit-candidate-321",
+      stateHash:
+        "0x3333333333333333333333333333333333333333333333333333333333333333",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      bitmapWords: [
+        { wordPosition: 7, bitmap: 1n },
+        { wordPosition: 8, bitmap: 2n ** 255n },
+      ],
+      initializedTicks: [
+        { tick: 199_800, liquidityGross: 10n, liquidityNet: -10n },
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
+      bitmapChunkSize: 1,
+      tickChunkSize: 1,
+    });
+    const db = new ReplayStateDb();
+
+    await expect(
+      putLatestClReplayCandidateState({
+        db,
+        tableName: "PoolState",
+        rows,
+      }),
+    ).resolves.toBe("written");
+    await expect(
+      batchGetLatestClReplayCandidateStates({
+        db,
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).resolves.toEqual([
+      {
+        latest: rows.latest,
+        bitmapWords: rows.bitmapChunks.flatMap((chunk) => chunk.bitmapWords),
+        initializedTicks: rows.tickChunks.flatMap(
+          (chunk) => chunk.initializedTicks,
+        ),
+      },
+    ]);
+    await expect(
+      batchGetLatestClReplayStates({
+        db,
+        tableName: "PoolState",
+        pools: [pool],
+      }),
+    ).resolves.toEqual([]);
+    expect(db.commands.map((command) => command.constructor.name)).toEqual([
+      "PutCommand",
+      "PutCommand",
+      "PutCommand",
+      "PutCommand",
+      "PutCommand",
+      "BatchGetCommand",
+      "BatchGetCommand",
+      "BatchGetCommand",
+    ]);
+    expect(rows.latest).toMatchObject({
+      sk: "cl-replay-candidate-v1",
+      stateKind: "cl-replay-candidate-v1",
+      candidateId: "unit-candidate-321",
+    });
   });
 
   test("keeps the published replay capsule when a same-block registry write is ignored", async () => {

--- a/src/fame-swap-pool-state/dynamodb/pool-state.ts
+++ b/src/fame-swap-pool-state/dynamodb/pool-state.ts
@@ -146,11 +146,83 @@ export interface FameClReplayLatestState extends Record<string, unknown> {
   maxTick: number | null;
 }
 
+export type FameClReplayMaintenanceStatus =
+  | "trusted"
+  | "warming"
+  | "drift-failed"
+  | "repairing"
+  | "event-gap";
+
+export interface FameClReplayMaintenanceState
+  extends Record<string, unknown> {
+  pk: string;
+  sk: "cl-replay-maintenance-v1";
+  stateKind: "cl-replay-maintenance-v1";
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  status: FameClReplayMaintenanceStatus;
+  cursorBlock: number;
+  cursorBlockHash: Hex;
+  cursorTransactionIndex: number;
+  cursorLogIndex: number;
+  targetBlock: number;
+  targetBlockHash: Hex;
+  stateHash: Hex;
+  sourceRegistryId: string;
+  updatedAt: string;
+  lastCheckpointBlock: number | null;
+  lastCheckpointBlockHash: Hex | null;
+  reason: string | null;
+  candidateId: string | null;
+}
+
+export interface FameClReplayCandidateLatestState
+  extends Record<string, unknown> {
+  pk: string;
+  sk: "cl-replay-candidate-v1";
+  stateKind: "cl-replay-candidate-v1";
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  token0: Address;
+  token1: Address;
+  venueFamily: FamePoolStateVenueFamily;
+  tickSpacing: number;
+  sqrtPriceX96: string;
+  tick: number;
+  liquidity: string;
+  fee: string;
+  feeSource: "pool-fee";
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  candidateId: string;
+  stateHash: Hex;
+  source: FameClReplaySource;
+  sourceRegistryId: string;
+  updatedAt: string;
+  bitmapWordCount: number;
+  initializedTickCount: number;
+  bitmapChunkCount: number;
+  tickChunkCount: number;
+  minWordPosition: number | null;
+  maxWordPosition: number | null;
+  minTick: number | null;
+  maxTick: number | null;
+}
+
 export type FameClReplayBitmapChunkSortKey =
   `cl-replay-v1:${string}:bitmap:${number}`;
 
 export type FameClReplayTickChunkSortKey =
   `cl-replay-v1:${string}:tick:${number}`;
+
+export type FameClReplayCandidateBitmapChunkSortKey =
+  `cl-replay-candidate-v1:${string}:bitmap:${number}`;
+
+export type FameClReplayCandidateTickChunkSortKey =
+  `cl-replay-candidate-v1:${string}:tick:${number}`;
 
 export interface FameClReplayBitmapChunkState extends Record<string, unknown> {
   pk: string;
@@ -192,6 +264,48 @@ export interface FameClReplayTickChunkState extends Record<string, unknown> {
   initializedTicks: FameClReplayInitializedTick[];
 }
 
+export interface FameClReplayCandidateBitmapChunkState
+  extends Record<string, unknown> {
+  pk: string;
+  sk: FameClReplayCandidateBitmapChunkSortKey;
+  stateKind: "cl-replay-candidate-bitmap-chunk-v1";
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  candidateId: string;
+  stateHash: Hex;
+  source: FameClReplaySource;
+  sourceRegistryId: string;
+  updatedAt: string;
+  expiresAt: number;
+  chunkIndex: number;
+  bitmapWords: FameClReplayBitmapWord[];
+}
+
+export interface FameClReplayCandidateTickChunkState
+  extends Record<string, unknown> {
+  pk: string;
+  sk: FameClReplayCandidateTickChunkSortKey;
+  stateKind: "cl-replay-candidate-tick-chunk-v1";
+  poolId: string;
+  chainId: number;
+  poolAddress: Address;
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  candidateId: string;
+  stateHash: Hex;
+  source: FameClReplaySource;
+  sourceRegistryId: string;
+  updatedAt: string;
+  expiresAt: number;
+  chunkIndex: number;
+  initializedTicks: FameClReplayInitializedTick[];
+}
+
 export interface FameClReplayStateRows {
   latest: FameClReplayLatestState;
   bitmapChunks: FameClReplayBitmapChunkState[];
@@ -200,6 +314,18 @@ export interface FameClReplayStateRows {
 
 export interface FameClReplayStateCapsule {
   latest: FameClReplayLatestState;
+  bitmapWords: FameClReplayBitmapWord[];
+  initializedTicks: FameClReplayInitializedTick[];
+}
+
+export interface FameClReplayCandidateStateRows {
+  latest: FameClReplayCandidateLatestState;
+  bitmapChunks: FameClReplayCandidateBitmapChunkState[];
+  tickChunks: FameClReplayCandidateTickChunkState[];
+}
+
+export interface FameClReplayCandidateStateCapsule {
+  latest: FameClReplayCandidateLatestState;
   bitmapWords: FameClReplayBitmapWord[];
   initializedTicks: FameClReplayInitializedTick[];
 }
@@ -284,6 +410,30 @@ export function latestClReplayStateKey(pool: FameClReplayRegistryEntry): {
   };
 }
 
+export function latestClReplayMaintenanceStateKey(
+  pool: FameClReplayRegistryEntry,
+): {
+  pk: string;
+  sk: "cl-replay-maintenance-v1";
+} {
+  return {
+    pk: `pool:${pool.chainId.toString()}:${clReplayPoolIdentity(pool)}`,
+    sk: "cl-replay-maintenance-v1",
+  };
+}
+
+export function latestClReplayCandidateStateKey(
+  pool: FameClReplayRegistryEntry,
+): {
+  pk: string;
+  sk: "cl-replay-candidate-v1";
+} {
+  return {
+    pk: `pool:${pool.chainId.toString()}:${clReplayPoolIdentity(pool)}`,
+    sk: "cl-replay-candidate-v1",
+  };
+}
+
 function clReplayAddressKey(chainId: number, poolAddress: Address): string {
   return `pool:${chainId.toString()}:address:${poolAddress.toLowerCase()}`;
 }
@@ -307,6 +457,28 @@ function clReplayTickChunkKey(
   return {
     pk: clReplayAddressKey(pool.chainId, pool.poolAddress),
     sk: `cl-replay-v1:${snapshotId}:tick:${chunkIndex}`,
+  };
+}
+
+function clReplayCandidateBitmapChunkKey(
+  pool: { chainId: number; poolAddress: Address },
+  candidateId: string,
+  chunkIndex: number,
+): { pk: string; sk: FameClReplayCandidateBitmapChunkSortKey } {
+  return {
+    pk: clReplayAddressKey(pool.chainId, pool.poolAddress),
+    sk: `cl-replay-candidate-v1:${candidateId}:bitmap:${chunkIndex}`,
+  };
+}
+
+function clReplayCandidateTickChunkKey(
+  pool: { chainId: number; poolAddress: Address },
+  candidateId: string,
+  chunkIndex: number,
+): { pk: string; sk: FameClReplayCandidateTickChunkSortKey } {
+  return {
+    pk: clReplayAddressKey(pool.chainId, pool.poolAddress),
+    sk: `cl-replay-candidate-v1:${candidateId}:tick:${chunkIndex}`,
   };
 }
 
@@ -367,6 +539,18 @@ function itemToLatestClReplayState(
   item?: Record<string, unknown> | null,
 ): FameClReplayLatestState | null {
   return item ? parseLatestClReplayStateItem(item) : null;
+}
+
+function itemToLatestClReplayMaintenanceState(
+  item?: Record<string, unknown> | null,
+): FameClReplayMaintenanceState | null {
+  return item ? parseLatestClReplayMaintenanceStateItem(item) : null;
+}
+
+function itemToLatestClReplayCandidateState(
+  item?: Record<string, unknown> | null,
+): FameClReplayCandidateLatestState | null {
+  return item ? parseLatestClReplayCandidateStateItem(item) : null;
 }
 
 function invalidItem(
@@ -433,6 +617,26 @@ function nullableIntegerField(
   const value = item[field];
   if (value === null) return null;
   return integerField(item, recordType, field);
+}
+
+function nullableStringField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): string | null {
+  const value = item[field];
+  if (value === null) return null;
+  return stringField(item, recordType, field);
+}
+
+function nullableBytes32HexField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): Hex | null {
+  const value = item[field];
+  if (value === null) return null;
+  return bytes32HexField(item, recordType, field);
 }
 
 function decimalStringField(
@@ -511,6 +715,38 @@ function clReplayTickChunkSortKeyField(
   return value as FameClReplayTickChunkSortKey;
 }
 
+function clReplayCandidateBitmapChunkSortKeyField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): FameClReplayCandidateBitmapChunkSortKey {
+  const value = stringField(item, recordType, field);
+  if (!/^cl-replay-candidate-v1:.+:bitmap:[0-9]+$/.test(value)) {
+    invalidItem(
+      recordType,
+      field,
+      "expected a CL replay candidate bitmap chunk key",
+    );
+  }
+  return value as FameClReplayCandidateBitmapChunkSortKey;
+}
+
+function clReplayCandidateTickChunkSortKeyField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): FameClReplayCandidateTickChunkSortKey {
+  const value = stringField(item, recordType, field);
+  if (!/^cl-replay-candidate-v1:.+:tick:[0-9]+$/.test(value)) {
+    invalidItem(
+      recordType,
+      field,
+      "expected a CL replay candidate tick chunk key",
+    );
+  }
+  return value as FameClReplayCandidateTickChunkSortKey;
+}
+
 function arrayField(
   item: Record<string, unknown>,
   recordType: string,
@@ -581,6 +817,28 @@ function clReplaySourceField(
   const value = item[field];
   if (value !== "slipstream-pool-state") {
     invalidItem(recordType, field, "expected slipstream-pool-state");
+  }
+  return value;
+}
+
+function clReplayMaintenanceStatusField(
+  item: Record<string, unknown>,
+  recordType: string,
+  field: string,
+): FameClReplayMaintenanceStatus {
+  const value = item[field];
+  if (
+    value !== "trusted" &&
+    value !== "warming" &&
+    value !== "drift-failed" &&
+    value !== "repairing" &&
+    value !== "event-gap"
+  ) {
+    invalidItem(
+      recordType,
+      field,
+      "expected trusted, warming, drift-failed, repairing, or event-gap",
+    );
   }
   return value;
 }
@@ -813,6 +1071,95 @@ function parseLatestClReplayStateItem(
   };
 }
 
+function parseLatestClReplayMaintenanceStateItem(
+  item: Record<string, unknown>,
+): FameClReplayMaintenanceState {
+  const recordType = "CL replay maintenance";
+  return {
+    pk: stringField(item, recordType, "pk"),
+    sk: literalField(item, recordType, "sk", "cl-replay-maintenance-v1"),
+    stateKind: literalField(
+      item,
+      recordType,
+      "stateKind",
+      "cl-replay-maintenance-v1",
+    ),
+    poolId: stringField(item, recordType, "poolId"),
+    chainId: numberField(item, recordType, "chainId"),
+    poolAddress: addressField(item, recordType, "poolAddress"),
+    status: clReplayMaintenanceStatusField(item, recordType, "status"),
+    cursorBlock: numberField(item, recordType, "cursorBlock"),
+    cursorBlockHash: bytes32HexField(item, recordType, "cursorBlockHash"),
+    cursorTransactionIndex: numberField(
+      item,
+      recordType,
+      "cursorTransactionIndex",
+    ),
+    cursorLogIndex: numberField(item, recordType, "cursorLogIndex"),
+    targetBlock: numberField(item, recordType, "targetBlock"),
+    targetBlockHash: bytes32HexField(item, recordType, "targetBlockHash"),
+    stateHash: bytes32HexField(item, recordType, "stateHash"),
+    sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
+    updatedAt: stringField(item, recordType, "updatedAt"),
+    lastCheckpointBlock: nullableIntegerField(
+      item,
+      recordType,
+      "lastCheckpointBlock",
+    ),
+    lastCheckpointBlockHash: nullableBytes32HexField(
+      item,
+      recordType,
+      "lastCheckpointBlockHash",
+    ),
+    reason: nullableStringField(item, recordType, "reason"),
+    candidateId: nullableStringField(item, recordType, "candidateId"),
+  };
+}
+
+function parseLatestClReplayCandidateStateItem(
+  item: Record<string, unknown>,
+): FameClReplayCandidateLatestState {
+  const recordType = "latest CL replay candidate";
+  return {
+    pk: stringField(item, recordType, "pk"),
+    sk: literalField(item, recordType, "sk", "cl-replay-candidate-v1"),
+    stateKind: literalField(
+      item,
+      recordType,
+      "stateKind",
+      "cl-replay-candidate-v1",
+    ),
+    poolId: stringField(item, recordType, "poolId"),
+    chainId: numberField(item, recordType, "chainId"),
+    poolAddress: addressField(item, recordType, "poolAddress"),
+    token0: addressField(item, recordType, "token0"),
+    token1: addressField(item, recordType, "token1"),
+    venueFamily: venueFamilyField(item, recordType, "venueFamily"),
+    tickSpacing: numberField(item, recordType, "tickSpacing"),
+    sqrtPriceX96: decimalStringField(item, recordType, "sqrtPriceX96"),
+    tick: integerField(item, recordType, "tick"),
+    liquidity: decimalStringField(item, recordType, "liquidity"),
+    fee: decimalStringField(item, recordType, "fee"),
+    feeSource: literalField(item, recordType, "feeSource", "pool-fee"),
+    observedThroughBlock: numberField(item, recordType, "observedThroughBlock"),
+    blockHash: bytes32HexField(item, recordType, "blockHash"),
+    parentHash: bytes32HexField(item, recordType, "parentHash"),
+    candidateId: stringField(item, recordType, "candidateId"),
+    stateHash: bytes32HexField(item, recordType, "stateHash"),
+    source: clReplaySourceField(item, recordType, "source"),
+    sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
+    updatedAt: stringField(item, recordType, "updatedAt"),
+    bitmapWordCount: numberField(item, recordType, "bitmapWordCount"),
+    initializedTickCount: numberField(item, recordType, "initializedTickCount"),
+    bitmapChunkCount: numberField(item, recordType, "bitmapChunkCount"),
+    tickChunkCount: numberField(item, recordType, "tickChunkCount"),
+    minWordPosition: nullableIntegerField(item, recordType, "minWordPosition"),
+    maxWordPosition: nullableIntegerField(item, recordType, "maxWordPosition"),
+    minTick: nullableIntegerField(item, recordType, "minTick"),
+    maxTick: nullableIntegerField(item, recordType, "maxTick"),
+  };
+}
+
 function parseClReplayBitmapChunkItem(
   item: Record<string, unknown>,
 ): FameClReplayBitmapChunkState {
@@ -870,6 +1217,80 @@ function parseClReplayTickChunkItem(
     blockHash: bytes32HexField(item, recordType, "blockHash"),
     parentHash: bytes32HexField(item, recordType, "parentHash"),
     snapshotId: stringField(item, recordType, "snapshotId"),
+    stateHash: bytes32HexField(item, recordType, "stateHash"),
+    source: clReplaySourceField(item, recordType, "source"),
+    sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
+    updatedAt: stringField(item, recordType, "updatedAt"),
+    expiresAt: numberField(item, recordType, "expiresAt"),
+    chunkIndex: numberField(item, recordType, "chunkIndex"),
+    initializedTicks: arrayField(item, recordType, "initializedTicks").map(
+      (entry, index) =>
+        parseReplayInitializedTick(
+          entry,
+          recordType,
+          `initializedTicks[${index.toString()}]`,
+        ),
+    ),
+  };
+}
+
+function parseClReplayCandidateBitmapChunkItem(
+  item: Record<string, unknown>,
+): FameClReplayCandidateBitmapChunkState {
+  const recordType = "CL replay candidate bitmap chunk";
+  return {
+    pk: stringField(item, recordType, "pk"),
+    sk: clReplayCandidateBitmapChunkSortKeyField(item, recordType, "sk"),
+    stateKind: literalField(
+      item,
+      recordType,
+      "stateKind",
+      "cl-replay-candidate-bitmap-chunk-v1",
+    ),
+    poolId: stringField(item, recordType, "poolId"),
+    chainId: numberField(item, recordType, "chainId"),
+    poolAddress: addressField(item, recordType, "poolAddress"),
+    observedThroughBlock: numberField(item, recordType, "observedThroughBlock"),
+    blockHash: bytes32HexField(item, recordType, "blockHash"),
+    parentHash: bytes32HexField(item, recordType, "parentHash"),
+    candidateId: stringField(item, recordType, "candidateId"),
+    stateHash: bytes32HexField(item, recordType, "stateHash"),
+    source: clReplaySourceField(item, recordType, "source"),
+    sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
+    updatedAt: stringField(item, recordType, "updatedAt"),
+    expiresAt: numberField(item, recordType, "expiresAt"),
+    chunkIndex: numberField(item, recordType, "chunkIndex"),
+    bitmapWords: arrayField(item, recordType, "bitmapWords").map(
+      (entry, index) =>
+        parseReplayBitmapWord(
+          entry,
+          recordType,
+          `bitmapWords[${index.toString()}]`,
+        ),
+    ),
+  };
+}
+
+function parseClReplayCandidateTickChunkItem(
+  item: Record<string, unknown>,
+): FameClReplayCandidateTickChunkState {
+  const recordType = "CL replay candidate tick chunk";
+  return {
+    pk: stringField(item, recordType, "pk"),
+    sk: clReplayCandidateTickChunkSortKeyField(item, recordType, "sk"),
+    stateKind: literalField(
+      item,
+      recordType,
+      "stateKind",
+      "cl-replay-candidate-tick-chunk-v1",
+    ),
+    poolId: stringField(item, recordType, "poolId"),
+    chainId: numberField(item, recordType, "chainId"),
+    poolAddress: addressField(item, recordType, "poolAddress"),
+    observedThroughBlock: numberField(item, recordType, "observedThroughBlock"),
+    blockHash: bytes32HexField(item, recordType, "blockHash"),
+    parentHash: bytes32HexField(item, recordType, "parentHash"),
+    candidateId: stringField(item, recordType, "candidateId"),
     stateHash: bytes32HexField(item, recordType, "stateHash"),
     source: clReplaySourceField(item, recordType, "source"),
     sourceRegistryId: stringField(item, recordType, "sourceRegistryId"),
@@ -998,6 +1419,46 @@ function replayCapsuleMatchesPointer(
   );
 }
 
+function replayCandidateChunkMatchesLatest(
+  latest: FameClReplayCandidateLatestState,
+  chunk:
+    | FameClReplayCandidateBitmapChunkState
+    | FameClReplayCandidateTickChunkState,
+): boolean {
+  return (
+    chunk.pk === latest.pk &&
+    chunk.poolId === latest.poolId &&
+    chunk.chainId === latest.chainId &&
+    chunk.poolAddress.toLowerCase() === latest.poolAddress.toLowerCase() &&
+    chunk.observedThroughBlock === latest.observedThroughBlock &&
+    chunk.blockHash === latest.blockHash &&
+    chunk.parentHash === latest.parentHash &&
+    chunk.candidateId === latest.candidateId &&
+    chunk.stateHash === latest.stateHash &&
+    chunk.source === latest.source &&
+    chunk.sourceRegistryId === latest.sourceRegistryId
+  );
+}
+
+function replayCandidateCapsuleMatchesPointer(
+  latest: FameClReplayCandidateLatestState,
+  bitmapWords: readonly FameClReplayBitmapWord[],
+  initializedTicks: readonly FameClReplayInitializedTick[],
+): boolean {
+  const wordPositions = bitmapWords.map((word) => word.wordPosition);
+  const tickIndexes = initializedTicks.map((tick) => tick.tick);
+  return (
+    bitmapWords.length === latest.bitmapWordCount &&
+    initializedTicks.length === latest.initializedTickCount &&
+    minOrNull(wordPositions) === latest.minWordPosition &&
+    maxOrNull(wordPositions) === latest.maxWordPosition &&
+    minOrNull(tickIndexes) === latest.minTick &&
+    maxOrNull(tickIndexes) === latest.maxTick &&
+    strictlyIncreasingNumbers(wordPositions) &&
+    strictlyIncreasingNumbers(tickIndexes)
+  );
+}
+
 function completeReplayCapsuleFromItems({
   latest,
   itemsByKey,
@@ -1050,6 +1511,82 @@ function completeReplayCapsuleFromItems({
     (chunk) => chunk.initializedTicks,
   );
   if (!replayCapsuleMatchesPointer(latest, bitmapWords, initializedTicks)) {
+    return null;
+  }
+
+  return {
+    latest,
+    bitmapWords,
+    initializedTicks,
+  };
+}
+
+function completeReplayCandidateCapsuleFromItems({
+  latest,
+  itemsByKey,
+}: {
+  latest: FameClReplayCandidateLatestState;
+  itemsByKey: ReadonlyMap<string, Record<string, unknown>>;
+}): FameClReplayCandidateStateCapsule | null {
+  const bitmapChunks: FameClReplayCandidateBitmapChunkState[] = [];
+  for (
+    let chunkIndex = 0;
+    chunkIndex < latest.bitmapChunkCount;
+    chunkIndex += 1
+  ) {
+    const key = clReplayCandidateBitmapChunkKey(
+      latest,
+      latest.candidateId,
+      chunkIndex,
+    );
+    const item = itemsByKey.get(dynamoKeyString(key));
+    if (!item) return null;
+    const chunk = parseClReplayCandidateBitmapChunkItem(item);
+    if (
+      chunk.chunkIndex !== chunkIndex ||
+      chunk.sk !== key.sk ||
+      !replayCandidateChunkMatchesLatest(latest, chunk)
+    ) {
+      return null;
+    }
+    bitmapChunks.push(chunk);
+  }
+
+  const tickChunks: FameClReplayCandidateTickChunkState[] = [];
+  for (
+    let chunkIndex = 0;
+    chunkIndex < latest.tickChunkCount;
+    chunkIndex += 1
+  ) {
+    const key = clReplayCandidateTickChunkKey(
+      latest,
+      latest.candidateId,
+      chunkIndex,
+    );
+    const item = itemsByKey.get(dynamoKeyString(key));
+    if (!item) return null;
+    const chunk = parseClReplayCandidateTickChunkItem(item);
+    if (
+      chunk.chunkIndex !== chunkIndex ||
+      chunk.sk !== key.sk ||
+      !replayCandidateChunkMatchesLatest(latest, chunk)
+    ) {
+      return null;
+    }
+    tickChunks.push(chunk);
+  }
+
+  const bitmapWords = bitmapChunks.flatMap((chunk) => chunk.bitmapWords);
+  const initializedTicks = tickChunks.flatMap(
+    (chunk) => chunk.initializedTicks,
+  );
+  if (
+    !replayCandidateCapsuleMatchesPointer(
+      latest,
+      bitmapWords,
+      initializedTicks,
+    )
+  ) {
     return null;
   }
 
@@ -1355,6 +1892,165 @@ export function clReplayStateRowsFromSnapshot(options: {
   };
 }
 
+export function clReplayCandidateStateRowsFromSnapshot(options: {
+  pool: FameClReplayRegistryEntry;
+  sqrtPriceX96: bigint;
+  tick: number;
+  liquidity: bigint;
+  fee: bigint;
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  candidateId: string;
+  stateHash: Hex;
+  sourceRegistryId: string;
+  updatedAt: string;
+  bitmapWords: readonly { wordPosition: number; bitmap: bigint }[];
+  initializedTicks: readonly {
+    tick: number;
+    liquidityGross: bigint;
+    liquidityNet: bigint;
+  }[];
+  bitmapChunkSize?: number;
+  tickChunkSize?: number;
+}): FameClReplayCandidateStateRows {
+  if (options.candidateId.length === 0) {
+    throw new Error("CL replay candidateId must be non-empty.");
+  }
+  assertNonNegativeBigInt(options.sqrtPriceX96, "sqrtPriceX96");
+  assertNonNegativeBigInt(options.liquidity, "liquidity");
+  assertNonNegativeBigInt(options.fee, "fee");
+
+  const bitmapChunkSize =
+    options.bitmapChunkSize ?? CL_REPLAY_DEFAULT_BITMAP_WORDS_PER_CHUNK;
+  const tickChunkSize =
+    options.tickChunkSize ?? CL_REPLAY_DEFAULT_TICKS_PER_CHUNK;
+  assertPositiveChunkSize(bitmapChunkSize, "bitmapChunkSize");
+  assertPositiveChunkSize(tickChunkSize, "tickChunkSize");
+
+  const bitmapWords = [...options.bitmapWords]
+    .sort((left, right) => left.wordPosition - right.wordPosition)
+    .map((word) => ({
+      wordPosition: word.wordPosition,
+      bitmap: canonicalUint256Hex(word.bitmap),
+    }));
+  const initializedTicks = [...options.initializedTicks]
+    .sort((left, right) => left.tick - right.tick)
+    .map((tick) => {
+      assertNonNegativeBigInt(tick.liquidityGross, "liquidityGross");
+      return {
+        tick: tick.tick,
+        liquidityGross: tick.liquidityGross.toString(),
+        liquidityNet: tick.liquidityNet.toString(),
+      };
+    });
+
+  const chunkExpiresAt = expiresAtFromIsoTimestamp(
+    options.updatedAt,
+    "updatedAt",
+  );
+
+  assertStrictlyIncreasing(
+    bitmapWords.map((word) => word.wordPosition),
+    "bitmap word",
+  );
+  assertStrictlyIncreasing(
+    initializedTicks.map((tick) => tick.tick),
+    "initialized tick",
+  );
+
+  const latest = {
+    ...latestClReplayCandidateStateKey(options.pool),
+    stateKind: "cl-replay-candidate-v1",
+    poolId: options.pool.id,
+    chainId: options.pool.chainId,
+    poolAddress: options.pool.poolAddress,
+    token0: options.pool.token0,
+    token1: options.pool.token1,
+    venueFamily: options.pool.venueFamily,
+    tickSpacing: options.pool.tickSpacing,
+    sqrtPriceX96: options.sqrtPriceX96.toString(),
+    tick: options.tick,
+    liquidity: options.liquidity.toString(),
+    fee: options.fee.toString(),
+    feeSource: "pool-fee",
+    observedThroughBlock: options.observedThroughBlock,
+    blockHash: options.blockHash,
+    parentHash: options.parentHash,
+    candidateId: options.candidateId,
+    stateHash: options.stateHash,
+    source: "slipstream-pool-state",
+    sourceRegistryId: options.sourceRegistryId,
+    updatedAt: options.updatedAt,
+    bitmapWordCount: bitmapWords.length,
+    initializedTickCount: initializedTicks.length,
+    bitmapChunkCount: Math.ceil(bitmapWords.length / bitmapChunkSize),
+    tickChunkCount: Math.ceil(initializedTicks.length / tickChunkSize),
+    minWordPosition: minOrNull(bitmapWords.map((word) => word.wordPosition)),
+    maxWordPosition: maxOrNull(bitmapWords.map((word) => word.wordPosition)),
+    minTick: minOrNull(initializedTicks.map((tick) => tick.tick)),
+    maxTick: maxOrNull(initializedTicks.map((tick) => tick.tick)),
+  } satisfies FameClReplayCandidateLatestState;
+
+  const bitmapChunks = chunkArray(bitmapWords, bitmapChunkSize).map(
+    (chunk, chunkIndex) =>
+      ({
+        ...clReplayCandidateBitmapChunkKey(
+          options.pool,
+          options.candidateId,
+          chunkIndex,
+        ),
+        stateKind: "cl-replay-candidate-bitmap-chunk-v1",
+        poolId: options.pool.id,
+        chainId: options.pool.chainId,
+        poolAddress: options.pool.poolAddress,
+        observedThroughBlock: options.observedThroughBlock,
+        blockHash: options.blockHash,
+        parentHash: options.parentHash,
+        candidateId: options.candidateId,
+        stateHash: options.stateHash,
+        source: "slipstream-pool-state",
+        sourceRegistryId: options.sourceRegistryId,
+        updatedAt: options.updatedAt,
+        expiresAt: chunkExpiresAt,
+        chunkIndex,
+        bitmapWords: chunk,
+      }) satisfies FameClReplayCandidateBitmapChunkState,
+  );
+
+  const tickChunks = chunkArray(initializedTicks, tickChunkSize).map(
+    (chunk, chunkIndex) =>
+      ({
+        ...clReplayCandidateTickChunkKey(
+          options.pool,
+          options.candidateId,
+          chunkIndex,
+        ),
+        stateKind: "cl-replay-candidate-tick-chunk-v1",
+        poolId: options.pool.id,
+        chainId: options.pool.chainId,
+        poolAddress: options.pool.poolAddress,
+        observedThroughBlock: options.observedThroughBlock,
+        blockHash: options.blockHash,
+        parentHash: options.parentHash,
+        candidateId: options.candidateId,
+        stateHash: options.stateHash,
+        source: "slipstream-pool-state",
+        sourceRegistryId: options.sourceRegistryId,
+        updatedAt: options.updatedAt,
+        expiresAt: chunkExpiresAt,
+        chunkIndex,
+        initializedTicks: chunk,
+      }) satisfies FameClReplayCandidateTickChunkState,
+  );
+
+  return {
+    latest,
+    bitmapChunks,
+    tickChunks,
+  };
+}
+
 export async function getLatestPoolState({
   db = defaultDb,
   tableName,
@@ -1493,6 +2189,69 @@ function assertClReplayLatestChunkBounds(
   }
 }
 
+function assertClReplayCandidateChunkBounds(
+  latest: FameClReplayCandidateLatestState,
+): void {
+  if (latest.bitmapWordCount === 0) {
+    if (latest.bitmapChunkCount !== 0) {
+      throw new PoolStateInvalidItemError(
+        "latest CL replay candidate",
+        "bitmapChunkCount",
+        "must be 0 when bitmapWordCount is 0",
+      );
+    }
+  } else if (
+    latest.bitmapChunkCount < 1 ||
+    latest.bitmapChunkCount > latest.bitmapWordCount
+  ) {
+    throw new PoolStateInvalidItemError(
+      "latest CL replay candidate",
+      "bitmapChunkCount",
+      "must be between 1 and bitmapWordCount",
+    );
+  }
+
+  if (latest.initializedTickCount === 0) {
+    if (latest.tickChunkCount !== 0) {
+      throw new PoolStateInvalidItemError(
+        "latest CL replay candidate",
+        "tickChunkCount",
+        "must be 0 when initializedTickCount is 0",
+      );
+    }
+  } else if (
+    latest.tickChunkCount < 1 ||
+    latest.tickChunkCount > latest.initializedTickCount
+  ) {
+    throw new PoolStateInvalidItemError(
+      "latest CL replay candidate",
+      "tickChunkCount",
+      "must be between 1 and initializedTickCount",
+    );
+  }
+}
+
+export async function batchGetLatestClReplayMaintenanceStates({
+  db = defaultDb,
+  tableName,
+  pools,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  pools: readonly FameClReplayRegistryEntry[];
+}): Promise<FameClReplayMaintenanceState[]> {
+  if (pools.length === 0) return [];
+
+  const latestItems = await batchGetPoolStateItems({
+    db,
+    tableName,
+    keys: pools.map((pool) => latestClReplayMaintenanceStateKey(pool)),
+  });
+  return latestItems
+    .map(itemToLatestClReplayMaintenanceState)
+    .filter((item): item is FameClReplayMaintenanceState => item !== null);
+}
+
 export async function batchGetLatestClReplayPointers({
   db = defaultDb,
   tableName,
@@ -1578,6 +2337,95 @@ export async function batchGetLatestClReplayStates({
   });
 }
 
+export async function batchGetLatestClReplayCandidatePointers({
+  db = defaultDb,
+  tableName,
+  pools,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  pools: readonly FameClReplayRegistryEntry[];
+}): Promise<FameClReplayCandidateLatestState[]> {
+  if (pools.length === 0) return [];
+
+  const latestItems = await batchGetPoolStateItems({
+    db,
+    tableName,
+    keys: pools.map((pool) => latestClReplayCandidateStateKey(pool)),
+  });
+  return latestItems
+    .map(itemToLatestClReplayCandidateState)
+    .filter((item): item is FameClReplayCandidateLatestState => item !== null)
+    .map((latest) => {
+      assertClReplayCandidateChunkBounds(latest);
+      return latest;
+    });
+}
+
+export async function batchGetClReplayCandidateStateCapsules({
+  db = defaultDb,
+  tableName,
+  latestStates,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  latestStates: readonly FameClReplayCandidateLatestState[];
+}): Promise<FameClReplayCandidateStateCapsule[]> {
+  if (latestStates.length === 0) return [];
+
+  const chunkKeys = latestStates.flatMap((latest) => [
+    ...Array.from({ length: latest.bitmapChunkCount }, (_, chunkIndex) =>
+      clReplayCandidateBitmapChunkKey(latest, latest.candidateId, chunkIndex),
+    ),
+    ...Array.from({ length: latest.tickChunkCount }, (_, chunkIndex) =>
+      clReplayCandidateTickChunkKey(latest, latest.candidateId, chunkIndex),
+    ),
+  ]);
+  const chunkItems =
+    chunkKeys.length === 0
+      ? []
+      : await batchGetPoolStateItems({
+          db,
+          tableName,
+          keys: chunkKeys,
+        });
+  const itemsByKey = new Map(
+    chunkItems.map((item) => [
+      itemDynamoKeyString(item, "CL replay candidate chunk"),
+      item,
+    ]),
+  );
+
+  return latestStates
+    .map((latest) =>
+      completeReplayCandidateCapsuleFromItems({ latest, itemsByKey }),
+    )
+    .filter(
+      (state): state is FameClReplayCandidateStateCapsule => state !== null,
+    );
+}
+
+export async function batchGetLatestClReplayCandidateStates({
+  db = defaultDb,
+  tableName,
+  pools,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  pools: readonly FameClReplayRegistryEntry[];
+}): Promise<FameClReplayCandidateStateCapsule[]> {
+  const latestStates = await batchGetLatestClReplayCandidatePointers({
+    db,
+    tableName,
+    pools,
+  });
+  return batchGetClReplayCandidateStateCapsules({
+    db,
+    tableName,
+    latestStates,
+  });
+}
+
 export async function putLatestPoolState({
   db = defaultDb,
   tableName,
@@ -1646,6 +2494,75 @@ export async function putLatestClReplayState({
   db?: PoolStateDocumentClient;
   tableName: string;
   rows: FameClReplayStateRows;
+}): Promise<PutLatestPoolStateResult> {
+  for (const chunk of [...rows.bitmapChunks, ...rows.tickChunks]) {
+    await db.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: chunk,
+      }),
+    );
+  }
+
+  try {
+    await db.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: rows.latest,
+        ConditionExpression:
+          "attribute_not_exists(pk) OR observedThroughBlock < :observedThroughBlock OR (observedThroughBlock = :observedThroughBlock AND sourceRegistryId = :sourceRegistryId)",
+        ExpressionAttributeValues: {
+          ":observedThroughBlock": rows.latest.observedThroughBlock,
+          ":sourceRegistryId": rows.latest.sourceRegistryId,
+        },
+      }),
+    );
+    return "written";
+  } catch (error) {
+    if (isConditionalCheckFailed(error)) return "ignored";
+    throw error;
+  }
+}
+
+export async function putLatestClReplayMaintenanceState({
+  db = defaultDb,
+  tableName,
+  state,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  state: FameClReplayMaintenanceState;
+}): Promise<PutLatestPoolStateResult> {
+  try {
+    await db.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: state,
+        ConditionExpression:
+          "attribute_not_exists(pk) OR cursorBlock < :cursorBlock OR (cursorBlock = :cursorBlock AND cursorTransactionIndex < :cursorTransactionIndex) OR (cursorBlock = :cursorBlock AND cursorTransactionIndex = :cursorTransactionIndex AND cursorLogIndex < :cursorLogIndex) OR (cursorBlock = :cursorBlock AND cursorTransactionIndex = :cursorTransactionIndex AND cursorLogIndex = :cursorLogIndex AND sourceRegistryId = :sourceRegistryId)",
+        ExpressionAttributeValues: {
+          ":cursorBlock": state.cursorBlock,
+          ":cursorTransactionIndex": state.cursorTransactionIndex,
+          ":cursorLogIndex": state.cursorLogIndex,
+          ":sourceRegistryId": state.sourceRegistryId,
+        },
+      }),
+    );
+    return "written";
+  } catch (error) {
+    if (isConditionalCheckFailed(error)) return "ignored";
+    throw error;
+  }
+}
+
+export async function putLatestClReplayCandidateState({
+  db = defaultDb,
+  tableName,
+  rows,
+}: {
+  db?: PoolStateDocumentClient;
+  tableName: string;
+  rows: FameClReplayCandidateStateRows;
 }): Promise<PutLatestPoolStateResult> {
   for (const chunk of [...rows.bitmapChunks, ...rows.tickChunks]) {
     await db.send(

--- a/src/fame-swap-pool-state/indexer.test.ts
+++ b/src/fame-swap-pool-state/indexer.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect, test } from "@jest/globals";
-import { decodeFunctionResult, encodeAbiParameters } from "viem";
+import {
+  decodeFunctionResult,
+  encodeAbiParameters,
+  encodeEventTopics,
+  isHex,
+} from "viem";
 import type { Address, Hex } from "viem";
 import {
   assertNoClReplaySnapshotFailures,
+  ClReplayBurnEventAbi,
+  ClReplayCollectEventAbi,
+  ClReplayMintEventAbi,
+  ClReplaySwapEventAbi,
+  applyClReplayDeltas,
+  FameClReplayLogNormalizationError,
   FameClReplaySnapshotIndexingError,
   getSlipstreamClReplaySnapshot,
   indexFamePoolStates,
+  normalizeClReplayLogs,
   SlipstreamTicksAbi,
+  type FameClReplayRawLog,
   type FameClHeadSnapshotRead,
   type FameClReplaySnapshotRead,
   type FamePoolStateIndexerClient,
@@ -14,8 +27,11 @@ import {
   type SlipstreamReplayReadClient,
 } from "./indexer.ts";
 import {
+  clReplayStateRowsFromSnapshot,
   cursorKey,
   latestClHeadStateKey,
+  latestClReplayCandidateStateKey,
+  latestClReplayMaintenanceStateKey,
   latestClReplayStateKey,
   latestPoolStateKey,
   type FameClHeadSnapshotRegistryEntry,
@@ -153,6 +169,16 @@ class InMemoryPoolStateDb implements PoolStateDocumentClient {
     return this.items.get(keyFromValue(latestClReplayStateKey(pool)));
   }
 
+  getLatestClReplayCandidate(pool: FameClReplayRegistryEntry) {
+    return this.items.get(keyFromValue(latestClReplayCandidateStateKey(pool)));
+  }
+
+  getLatestClReplayMaintenance(pool: FameClReplayRegistryEntry) {
+    return this.items.get(
+      keyFromValue(latestClReplayMaintenanceStateKey(pool)),
+    );
+  }
+
   getCursor(chainId: number) {
     return this.items.get(keyFromValue(cursorKey(chainId)));
   }
@@ -169,6 +195,7 @@ class FakePoolStateClient implements FamePoolStateIndexerClient {
     string,
     FameClReplaySnapshotRead
   >();
+  public clReplayLogs: readonly FameClReplayRawLog[] = [];
   public failingReserveAddress: Address | null = null;
   public failingClHeadPoolId: string | null = null;
   public failingClReplayPoolId: string | null = null;
@@ -186,11 +213,23 @@ class FakePoolStateClient implements FamePoolStateIndexerClient {
     return this.latestBlock;
   }
 
+  async getBlock(): Promise<{ hash: Hex | null; parentHash: Hex }> {
+    return {
+      hash: "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+    };
+  }
+
   async getSyncLogs(options: {
     pools: readonly (FamePoolStateRegistryEntry & { poolAddress: Address })[];
   }): Promise<readonly FamePoolStateSyncLog[]> {
     this.requestedAddresses = options.pools.map((pool) => pool.poolAddress);
     return this.logs;
+  }
+
+  async getClReplayLogs(): Promise<readonly FameClReplayRawLog[]> {
+    return this.clReplayLogs;
   }
 
   async getReserves(options: {
@@ -484,6 +523,206 @@ function registryWithPools(
   };
 }
 
+const UNIT_ADDRESS_1 = "0x0000000000000000000000000000000000000001";
+const UNIT_ADDRESS_2 = "0x0000000000000000000000000000000000000002";
+
+function strictTopics(topics: ReturnType<typeof encodeEventTopics>): Hex[] {
+  if (!Array.isArray(topics)) {
+    throw new Error("Encoded event topics must be an array.");
+  }
+  return topics.map((topic) => {
+    if (typeof topic !== "string" || !isHex(topic)) {
+      throw new Error("Encoded event topic must be hex.");
+    }
+    return topic;
+  });
+}
+
+function replayLogFixture(
+  pool: FameClReplayRegistryEntry,
+  options: {
+    blockNumber: bigint;
+    transactionIndex: number;
+    logIndex: number;
+    topics: readonly Hex[];
+    data: Hex;
+    address?: Address;
+    blockHash?: Hex | null;
+    removed?: boolean;
+  },
+): FameClReplayRawLog {
+  return {
+    address: options.address ?? pool.poolAddress,
+    blockNumber: options.blockNumber,
+    blockHash:
+      options.blockHash ??
+      "0x1111111111111111111111111111111111111111111111111111111111111111",
+    transactionHash:
+      "0x2222222222222222222222222222222222222222222222222222222222222222",
+    transactionIndex: options.transactionIndex,
+    logIndex: options.logIndex,
+    removed: options.removed ?? false,
+    topics: options.topics,
+    data: options.data,
+  };
+}
+
+function swapReplayLog(
+  pool: FameClReplayRegistryEntry,
+  order: { blockNumber: bigint; transactionIndex: number; logIndex: number },
+): FameClReplayRawLog {
+  return replayLogFixture(pool, {
+    ...order,
+    topics: strictTopics(encodeEventTopics({
+      abi: [ClReplaySwapEventAbi],
+      eventName: "Swap",
+      args: {
+        sender: UNIT_ADDRESS_1,
+        recipient: UNIT_ADDRESS_2,
+      },
+    })),
+    data: encodeAbiParameters(
+      [
+        { name: "amount0", type: "int256" },
+        { name: "amount1", type: "int256" },
+        { name: "sqrtPriceX96", type: "uint160" },
+        { name: "liquidity", type: "uint128" },
+        { name: "tick", type: "int24" },
+      ],
+      [-10n, 20n, 2n ** 96n, 1_234n, 101],
+    ),
+  });
+}
+
+function mintReplayLog(
+  pool: FameClReplayRegistryEntry,
+  order: { blockNumber: bigint; transactionIndex: number; logIndex: number },
+): FameClReplayRawLog {
+  return replayLogFixture(pool, {
+    ...order,
+    topics: strictTopics(encodeEventTopics({
+      abi: [ClReplayMintEventAbi],
+      eventName: "Mint",
+      args: {
+        owner: UNIT_ADDRESS_2,
+        tickLower: -200,
+        tickUpper: 300,
+      },
+    })),
+    data: encodeAbiParameters(
+      [
+        { name: "sender", type: "address" },
+        { name: "amount", type: "uint128" },
+        { name: "amount0", type: "uint256" },
+        { name: "amount1", type: "uint256" },
+      ],
+      [UNIT_ADDRESS_1, 50n, 60n, 70n],
+    ),
+  });
+}
+
+function burnReplayLog(
+  pool: FameClReplayRegistryEntry,
+  order: { blockNumber: bigint; transactionIndex: number; logIndex: number },
+): FameClReplayRawLog {
+  return replayLogFixture(pool, {
+    ...order,
+    topics: strictTopics(encodeEventTopics({
+      abi: [ClReplayBurnEventAbi],
+      eventName: "Burn",
+      args: {
+        owner: UNIT_ADDRESS_2,
+        tickLower: -200,
+        tickUpper: 300,
+      },
+    })),
+    data: encodeAbiParameters(
+      [
+        { name: "amount", type: "uint128" },
+        { name: "amount0", type: "uint256" },
+        { name: "amount1", type: "uint256" },
+      ],
+      [25n, 30n, 35n],
+    ),
+  });
+}
+
+function collectReplayLog(
+  pool: FameClReplayRegistryEntry,
+  order: { blockNumber: bigint; transactionIndex: number; logIndex: number },
+): FameClReplayRawLog {
+  return replayLogFixture(pool, {
+    ...order,
+    topics: strictTopics(encodeEventTopics({
+      abi: [ClReplayCollectEventAbi],
+      eventName: "Collect",
+      args: {
+        owner: UNIT_ADDRESS_1,
+        tickLower: -200,
+        tickUpper: 300,
+      },
+    })),
+    data: encodeAbiParameters(
+      [
+        { name: "recipient", type: "address" },
+        { name: "amount0", type: "uint128" },
+        { name: "amount1", type: "uint128" },
+      ],
+      [UNIT_ADDRESS_2, 10n, 20n],
+    ),
+  });
+}
+
+function clReplaySeedCapsule(pool: FameClReplayRegistryEntry) {
+  const rows = clReplayStateRowsFromSnapshot({
+    pool,
+    sqrtPriceX96: 2n ** 96n,
+    tick: 100,
+    liquidity: 1_000n,
+    fee: 100n,
+    observedThroughBlock: 120,
+    blockHash:
+      "0x1111111111111111111111111111111111111111111111111111111111111111",
+    parentHash:
+      "0x2222222222222222222222222222222222222222222222222222222222222222",
+    snapshotId: "seed-120",
+    stateHash:
+      "0x3333333333333333333333333333333333333333333333333333333333333333",
+    sourceRegistryId: "unit-registry",
+    updatedAt: "2026-05-20T00:00:00.000Z",
+    bitmapWords: [
+      { wordPosition: -1, bitmap: 1n << 254n },
+      { wordPosition: 0, bitmap: 1n << 3n },
+    ],
+    initializedTicks: [
+      { tick: -200, liquidityGross: 500n, liquidityNet: 500n },
+      { tick: 300, liquidityGross: 500n, liquidityNet: -500n },
+    ],
+  });
+  return {
+    latest: rows.latest,
+    bitmapWords: rows.bitmapChunks.flatMap((chunk) => chunk.bitmapWords),
+    initializedTicks: rows.tickChunks.flatMap(
+      (chunk) => chunk.initializedTicks,
+    ),
+  };
+}
+
+function normalizedEventBase(pool: FameClReplayRegistryEntry) {
+  return {
+    poolId: pool.id,
+    venue: pool.venue,
+    poolAddress: pool.poolAddress,
+    blockNumber: 121,
+    blockHash:
+      "0x4444444444444444444444444444444444444444444444444444444444444444",
+    transactionHash:
+      "0x5555555555555555555555555555555555555555555555555555555555555555",
+    transactionIndex: 1,
+    logIndex: 1,
+  } as const;
+}
+
 describe("FAME pool-state indexer", () => {
   test("decodes Aerodrome Slipstream tick state with staked and reward fields", () => {
     const result = decodeFunctionResult({
@@ -542,6 +781,242 @@ describe("FAME pool-state indexer", () => {
     expect(
       client.blockNumbers.every((blockNumber) => blockNumber === 118n),
     ).toBe(true);
+  });
+
+  test("normalizes CL replay Swap, Mint, Burn, and no-op Collect logs in chain order", () => {
+    const pool = clReplayPool();
+
+    const events = normalizeClReplayLogs({
+      pool,
+      logs: [
+        burnReplayLog(pool, {
+          blockNumber: 123n,
+          transactionIndex: 1,
+          logIndex: 2,
+        }),
+        collectReplayLog(pool, {
+          blockNumber: 123n,
+          transactionIndex: 1,
+          logIndex: 3,
+        }),
+        swapReplayLog(pool, {
+          blockNumber: 122n,
+          transactionIndex: 9,
+          logIndex: 9,
+        }),
+        mintReplayLog(pool, {
+          blockNumber: 123n,
+          transactionIndex: 1,
+          logIndex: 1,
+        }),
+      ],
+    });
+
+    expect(events.map((event) => event.kind)).toEqual([
+      "swap",
+      "mint",
+      "burn",
+      "collect",
+    ]);
+    expect(events[0]).toMatchObject({
+      poolId: pool.id,
+      venue: "aerodrome-slipstream",
+      blockNumber: 122,
+      sqrtPriceX96: 2n ** 96n,
+      liquidity: 1_234n,
+      tick: 101,
+    });
+    expect(events[1]).toMatchObject({
+      kind: "mint",
+      tickLower: -200,
+      tickUpper: 300,
+      amount: 50n,
+    });
+    expect(events[2]).toMatchObject({
+      kind: "burn",
+      tickLower: -200,
+      tickUpper: 300,
+      amount: 25n,
+    });
+  });
+
+  test("rejects unsupported, removed, and ambiguous CL replay logs", () => {
+    const pool = clReplayPool();
+    const unsupported = replayLogFixture(pool, {
+      blockNumber: 122n,
+      transactionIndex: 0,
+      logIndex: 0,
+      topics: [
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ],
+      data: "0x",
+    });
+
+    expect(() =>
+      normalizeClReplayLogs({ pool, logs: [unsupported] }),
+    ).toThrow(FameClReplayLogNormalizationError);
+    expect(() =>
+      normalizeClReplayLogs({
+        pool,
+        logs: [
+          {
+            ...swapReplayLog(pool, {
+              blockNumber: 122n,
+              transactionIndex: 0,
+              logIndex: 0,
+            }),
+            removed: true,
+          },
+        ],
+      }),
+    ).toThrow(FameClReplayLogNormalizationError);
+    expect(() =>
+      normalizeClReplayLogs({
+        pool,
+        logs: [
+          {
+            ...swapReplayLog(pool, {
+              blockNumber: 122n,
+              transactionIndex: 0,
+              logIndex: 0,
+            }),
+            blockHash: null,
+          },
+        ],
+      }),
+    ).toThrow(FameClReplayLogNormalizationError);
+  });
+
+  test("applies swap and mint deltas into a deterministic candidate capsule", () => {
+    const pool = clReplayPool();
+    const seed = clReplaySeedCapsule(pool);
+    const base = normalizedEventBase(pool);
+
+    const result = applyClReplayDeltas({
+      pool,
+      seed,
+      events: [
+        {
+          ...base,
+          kind: "swap",
+          sqrtPriceX96: 2n ** 96n + 1n,
+          tick: 100,
+          liquidity: 1_000n,
+        },
+        {
+          ...base,
+          kind: "mint",
+          logIndex: 2,
+          tickLower: -200,
+          tickUpper: 300,
+          amount: 50n,
+        },
+      ],
+      observedThroughBlock: 121,
+      blockHash: base.blockHash,
+      parentHash:
+        "0x6666666666666666666666666666666666666666666666666666666666666666",
+      candidateId: "candidate-121",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:01:00.000Z",
+    });
+
+    expect(result.status).toBe("candidate");
+    if (result.status !== "candidate") throw new Error("Expected candidate.");
+    expect(result.appliedEventCount).toBe(2);
+    expect(result.rows.latest).toMatchObject({
+      sqrtPriceX96: (2n ** 96n + 1n).toString(),
+      tick: 100,
+      liquidity: "1050",
+      candidateId: "candidate-121",
+      observedThroughBlock: 121,
+    });
+    expect(
+      result.rows.tickChunks.flatMap((chunk) => chunk.initializedTicks),
+    ).toEqual([
+      { tick: -200, liquidityGross: "550", liquidityNet: "550" },
+      { tick: 300, liquidityGross: "550", liquidityNet: "-550" },
+    ]);
+  });
+
+  test("applies burn deltas by removing empty initialized ticks and bitmap words", () => {
+    const pool = clReplayPool();
+    const base = normalizedEventBase(pool);
+
+    const result = applyClReplayDeltas({
+      pool,
+      seed: clReplaySeedCapsule(pool),
+      events: [
+        {
+          ...base,
+          kind: "burn",
+          tickLower: -200,
+          tickUpper: 300,
+          amount: 500n,
+        },
+      ],
+      observedThroughBlock: 121,
+      blockHash: base.blockHash,
+      parentHash:
+        "0x6666666666666666666666666666666666666666666666666666666666666666",
+      candidateId: "candidate-121",
+      sourceRegistryId: "unit-registry",
+      updatedAt: "2026-05-20T00:01:00.000Z",
+    });
+
+    expect(result.status).toBe("candidate");
+    if (result.status !== "candidate") throw new Error("Expected candidate.");
+    expect(result.rows.latest).toMatchObject({
+      liquidity: "500",
+      bitmapWordCount: 0,
+      initializedTickCount: 0,
+      bitmapChunkCount: 0,
+      tickChunkCount: 0,
+    });
+    expect(result.rows.bitmapChunks).toEqual([]);
+    expect(result.rows.tickChunks).toEqual([]);
+  });
+
+  test("fails closed when replay reducer has no seed or underflows liquidity", () => {
+    const pool = clReplayPool();
+    const base = normalizedEventBase(pool);
+
+    expect(
+      applyClReplayDeltas({
+        pool,
+        seed: null,
+        events: [],
+        observedThroughBlock: 121,
+        blockHash: base.blockHash,
+        parentHash:
+          "0x6666666666666666666666666666666666666666666666666666666666666666",
+        candidateId: "candidate-121",
+        sourceRegistryId: "unit-registry",
+        updatedAt: "2026-05-20T00:01:00.000Z",
+      }),
+    ).toMatchObject({ status: "warming", reason: "seed-required" });
+    expect(
+      applyClReplayDeltas({
+        pool,
+        seed: clReplaySeedCapsule(pool),
+        events: [
+          {
+            ...base,
+            kind: "burn",
+            tickLower: -200,
+            tickUpper: 300,
+            amount: 501n,
+          },
+        ],
+        observedThroughBlock: 121,
+        blockHash: base.blockHash,
+        parentHash:
+          "0x6666666666666666666666666666666666666666666666666666666666666666",
+        candidateId: "candidate-121",
+        sourceRegistryId: "unit-registry",
+        updatedAt: "2026-05-20T00:01:00.000Z",
+      }),
+    ).toMatchObject({ status: "event-gap", reason: "liquidity-underflow" });
   });
 
   test("writes Sync reserves, k, observed-through block, and cursor", async () => {
@@ -715,6 +1190,19 @@ describe("FAME pool-state indexer", () => {
           stateHash: expect.stringMatching(/^0x[0-9a-f]{64}$/),
         },
       ],
+      clReplayMaintenanceMetrics: [
+        {
+          poolId: replayPool.id,
+          status: "warming",
+          reason: "shadow-not-promoted",
+          fromBlock: 118,
+          toBlock: 118,
+          scannedLogCount: 0,
+          appliedEventCount: 0,
+          candidateWritten: true,
+          stateHash: expect.stringMatching(/^0x[0-9a-f]{64}$/),
+        },
+      ],
     });
     expect(db.getLatestClReplay(replayPool)).toMatchObject({
       stateKind: "cl-replay-v1",
@@ -733,6 +1221,190 @@ describe("FAME pool-state indexer", () => {
     expect(
       stringField(parseItem(db.getLatestClReplay(replayPool)), "snapshotId"),
     ).toContain(result.sourceRegistryId);
+    expect(db.getLatestClReplayCandidate(replayPool)).toMatchObject({
+      stateKind: "cl-replay-candidate-v1",
+      candidateId: expect.stringContaining(replayPool.id),
+      observedThroughBlock: 118,
+    });
+    expect(db.getLatestClReplayMaintenance(replayPool)).toMatchObject({
+      stateKind: "cl-replay-maintenance-v1",
+      status: "warming",
+      reason: "shadow-not-promoted",
+      candidateId: expect.stringContaining(replayPool.id),
+    });
+  });
+
+  test("promotes checkpoint-clean CL replay state and advances it in steady-state without full snapshots", async () => {
+    const replayPool = clReplayPool();
+    const db = new InMemoryPoolStateDb();
+    const seedClient = new FakePoolStateClient([], 120n);
+    seedClient.clReplaySnapshotsByPoolId.set(replayPool.id, {
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 100n,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n << 207n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
+      providerReadCount: 5,
+      durationMs: 12,
+    });
+
+    const seedResult = await indexFamePoolStates({
+      client: seedClient,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:00:00.000Z"),
+    });
+
+    expect(seedResult).toMatchObject({
+      clReplaySnapshots: 1,
+      clReplayMaintenanceMetrics: [
+        {
+          poolId: replayPool.id,
+          status: "trusted",
+          fromBlock: 118,
+          toBlock: 118,
+          scannedLogCount: 0,
+          appliedEventCount: 0,
+          candidateWritten: true,
+        },
+      ],
+    });
+    expect(db.getLatestClReplayMaintenance(replayPool)).toMatchObject({
+      status: "trusted",
+      reason: null,
+      cursorBlock: 118,
+    });
+
+    const deltaClient = new FakePoolStateClient([], 123n);
+    deltaClient.clReplayLogs = [
+      swapReplayLog(replayPool, {
+        blockNumber: 120n,
+        transactionIndex: 2,
+        logIndex: 3,
+      }),
+    ];
+
+    const deltaResult = await indexFamePoolStates({
+      client: deltaClient,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      clReplayMaintenanceMode: "steady-state",
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:01:00.000Z"),
+    });
+
+    expect(deltaResult).toMatchObject({
+      clReplaySnapshots: 0,
+      clReplayMaintenanceMetrics: [
+        {
+          poolId: replayPool.id,
+          status: "trusted",
+          fromBlock: 119,
+          toBlock: 121,
+          scannedLogCount: 1,
+          appliedEventCount: 1,
+          candidateWritten: true,
+        },
+      ],
+    });
+    expect(db.getLatestClReplay(replayPool)).toMatchObject({
+      tick: 101,
+      liquidity: "1234",
+      observedThroughBlock: 121,
+    });
+    expect(db.getLatestClReplayMaintenance(replayPool)).toMatchObject({
+      status: "trusted",
+      cursorBlock: 121,
+      reason: null,
+    });
+  });
+
+  test("marks checkpoint drift failed and repairs from a complete snapshot", async () => {
+    const replayPool = clReplayPool();
+    const db = new InMemoryPoolStateDb();
+    const seedClient = new FakePoolStateClient([], 120n);
+
+    await indexFamePoolStates({
+      client: seedClient,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:00:00.000Z"),
+    });
+
+    const checkpointClient = new FakePoolStateClient([], 120n);
+    checkpointClient.clReplaySnapshotsByPoolId.set(replayPool.id, {
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 2_000n,
+      fee: 100n,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n << 207n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
+      providerReadCount: 5,
+      durationMs: 12,
+    });
+
+    const driftResult = await indexFamePoolStates({
+      client: checkpointClient,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:01:00.000Z"),
+    });
+
+    expect(driftResult.clReplayMaintenanceMetrics).toMatchObject([
+      {
+        poolId: replayPool.id,
+        status: "drift-failed",
+        reason: "checkpoint-state-hash-mismatch",
+      },
+    ]);
+    expect(db.getLatestClReplayMaintenance(replayPool)).toMatchObject({
+      status: "drift-failed",
+    });
+
+    const repairResult = await indexFamePoolStates({
+      client: checkpointClient,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      clReplayMaintenanceMode: "repair",
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:02:00.000Z"),
+    });
+
+    expect(repairResult.clReplayMaintenanceMetrics).toMatchObject([
+      {
+        poolId: replayPool.id,
+        status: "trusted",
+        reason: null,
+      },
+    ]);
+    expect(db.getLatestClReplay(replayPool)).toMatchObject({
+      liquidity: "2000",
+    });
+    expect(db.getLatestClReplayMaintenance(replayPool)).toMatchObject({
+      status: "trusted",
+      reason: null,
+    });
   });
 
   test("records CL replay failures without blocking CL head snapshots", async () => {

--- a/src/fame-swap-pool-state/indexer.test.ts
+++ b/src/fame-swap-pool-state/indexer.test.ts
@@ -197,6 +197,7 @@ class FakePoolStateClient implements FamePoolStateIndexerClient {
     string,
     FameClReplaySnapshotRead
   >();
+  public clReplayFeesByPoolId = new Map<string, bigint>();
   public clReplayLogs: readonly FameClReplayRawLog[] = [];
   public failingReserveAddress: Address | null = null;
   public failingClHeadPoolId: string | null = null;
@@ -295,6 +296,16 @@ class FakePoolStateClient implements FamePoolStateIndexerClient {
         providerReadCount: 5,
         durationMs: 12,
       }
+    );
+  }
+
+  async getClReplayFee(options: {
+    pool: FameClReplayRegistryEntry;
+  }): Promise<bigint> {
+    return (
+      this.clReplayFeesByPoolId.get(options.pool.id) ??
+      this.clReplaySnapshotsByPoolId.get(options.pool.id)?.fee ??
+      100n
     );
   }
 }
@@ -1410,6 +1421,145 @@ describe("FAME pool-state indexer", () => {
       tick: 199_900,
       liquidity: "1000",
       observedThroughBlock: 118,
+    });
+  });
+
+  test("keeps checkpoint trust when the dynamic fee changes without liquidity drift", async () => {
+    const replayPool = clReplayPool();
+    const db = new InMemoryPoolStateDb();
+    const seedClient = new FakePoolStateClient([], 120n);
+    seedClient.clReplaySnapshotsByPoolId.set(replayPool.id, {
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 60n,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n << 207n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
+      providerReadCount: 5,
+      durationMs: 12,
+    });
+
+    await indexFamePoolStates({
+      client: seedClient,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:00:00.000Z"),
+    });
+
+    const checkpointClient = new FakePoolStateClient([], 123n);
+    checkpointClient.clReplaySnapshotsByPoolId.set(replayPool.id, {
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 712n,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n << 207n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
+      providerReadCount: 5,
+      durationMs: 12,
+    });
+
+    const result = await indexFamePoolStates({
+      client: checkpointClient,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:01:00.000Z"),
+    });
+
+    expect(result.clReplayMaintenanceMetrics).toMatchObject([
+      {
+        poolId: replayPool.id,
+        status: "trusted",
+        reason: null,
+        fromBlock: 119,
+        toBlock: 121,
+        scannedLogCount: 0,
+        appliedEventCount: 0,
+        candidateWritten: true,
+      },
+    ]);
+    expect(db.getLatestClReplay(replayPool)).toMatchObject({
+      fee: "712",
+      observedThroughBlock: 121,
+    });
+  });
+
+  test("steady-state refreshes dynamic fee without full replay snapshots", async () => {
+    const replayPool = clReplayPool();
+    const db = new InMemoryPoolStateDb();
+    const seedClient = new FakePoolStateClient([], 120n);
+    seedClient.clReplaySnapshotsByPoolId.set(replayPool.id, {
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 60n,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n << 207n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
+      providerReadCount: 5,
+      durationMs: 12,
+    });
+
+    await indexFamePoolStates({
+      client: seedClient,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:00:00.000Z"),
+    });
+
+    const deltaClient = new FakePoolStateClient([], 123n);
+    deltaClient.clReplayFeesByPoolId.set(replayPool.id, 712n);
+
+    const result = await indexFamePoolStates({
+      client: deltaClient,
+      db,
+      tableName: "PoolState",
+      registry: registryWithPools([replayPool]),
+      clReplayMaintenanceMode: "steady-state",
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:01:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      clReplaySnapshots: 0,
+      clReplayMaintenanceMetrics: [
+        {
+          poolId: replayPool.id,
+          status: "trusted",
+          reason: null,
+          fromBlock: 119,
+          toBlock: 121,
+          scannedLogCount: 0,
+          appliedEventCount: 0,
+          candidateWritten: true,
+        },
+      ],
+    });
+    expect(db.getLatestClReplay(replayPool)).toMatchObject({
+      fee: "712",
+      observedThroughBlock: 121,
     });
   });
 

--- a/src/fame-swap-pool-state/indexer.test.ts
+++ b/src/fame-swap-pool-state/indexer.test.ts
@@ -34,6 +34,8 @@ import {
   latestClReplayMaintenanceStateKey,
   latestClReplayStateKey,
   latestPoolStateKey,
+  putLatestClReplayState,
+  sourceRegistryIdFor,
   type FameClHeadSnapshotRegistryEntry,
   type FameClReplayRegistryEntry,
   type PoolStateDocumentClient,
@@ -1329,10 +1331,108 @@ describe("FAME pool-state indexer", () => {
     });
   });
 
+  test("checkpoint promotion seeds maintenance from a fresh snapshot when a legacy replay pointer has no maintenance row", async () => {
+    const replayPool = clReplayPool();
+    const registry = registryWithPools([replayPool]);
+    const db = new InMemoryPoolStateDb();
+
+    await putLatestClReplayState({
+      db,
+      tableName: "PoolState",
+      rows: clReplayStateRowsFromSnapshot({
+        pool: replayPool,
+        sqrtPriceX96: 2n ** 96n,
+        tick: 199_800,
+        liquidity: 500n,
+        fee: 100n,
+        observedThroughBlock: 110,
+        blockHash:
+          "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        parentHash:
+          "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        snapshotId: "legacy-110",
+        stateHash:
+          "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        sourceRegistryId: sourceRegistryIdFor(registry.source),
+        updatedAt: "2026-05-20T00:00:00.000Z",
+        bitmapWords: [{ wordPosition: 7, bitmap: 1n << 206n }],
+        initializedTicks: [
+          { tick: 199_800, liquidityGross: 10n, liquidityNet: 10n },
+        ],
+      }),
+    });
+
+    const checkpointClient = new FakePoolStateClient([], 120n);
+    checkpointClient.clReplaySnapshotsByPoolId.set(replayPool.id, {
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 100n,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n << 207n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
+      providerReadCount: 5,
+      durationMs: 12,
+    });
+
+    const result = await indexFamePoolStates({
+      client: checkpointClient,
+      db,
+      tableName: "PoolState",
+      registry,
+      clReplayTrustPromotion: true,
+      now: new Date("2026-05-20T00:01:00.000Z"),
+    });
+
+    expect(result.clReplayMaintenanceMetrics).toMatchObject([
+      {
+        poolId: replayPool.id,
+        status: "trusted",
+        reason: null,
+        fromBlock: 118,
+        toBlock: 118,
+        scannedLogCount: 0,
+        appliedEventCount: 0,
+        candidateWritten: true,
+      },
+    ]);
+    expect(db.getLatestClReplayMaintenance(replayPool)).toMatchObject({
+      status: "trusted",
+      reason: null,
+      cursorBlock: 118,
+    });
+    expect(db.getLatestClReplay(replayPool)).toMatchObject({
+      tick: 199_900,
+      liquidity: "1000",
+      observedThroughBlock: 118,
+    });
+  });
+
   test("marks checkpoint drift failed and repairs from a complete snapshot", async () => {
     const replayPool = clReplayPool();
     const db = new InMemoryPoolStateDb();
     const seedClient = new FakePoolStateClient([], 120n);
+    seedClient.clReplaySnapshotsByPoolId.set(replayPool.id, {
+      sqrtPriceX96: 2n ** 96n,
+      tick: 199_900,
+      liquidity: 1_000n,
+      fee: 100n,
+      blockHash:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      parentHash:
+        "0x2222222222222222222222222222222222222222222222222222222222222222",
+      bitmapWords: [{ wordPosition: 7, bitmap: 1n << 207n }],
+      initializedTicks: [
+        { tick: 199_900, liquidityGross: 25n, liquidityNet: 15n },
+      ],
+      providerReadCount: 5,
+      durationMs: 12,
+    });
 
     await indexFamePoolStates({
       client: seedClient,

--- a/src/fame-swap-pool-state/indexer.ts
+++ b/src/fame-swap-pool-state/indexer.ts
@@ -347,6 +347,10 @@ export interface FamePoolStateIndexerClient {
     pool: ClReplayPool;
     blockNumber: bigint;
   }): Promise<FameClReplaySnapshotRead>;
+  getClReplayFee(options: {
+    pool: ClReplayPool;
+    blockNumber: bigint;
+  }): Promise<bigint>;
 }
 
 export interface SlipstreamReplayReadClient {
@@ -1140,6 +1144,7 @@ export function applyClReplayDeltas({
   pool,
   seed,
   events,
+  fee,
   observedThroughBlock,
   blockHash,
   parentHash,
@@ -1150,6 +1155,7 @@ export function applyClReplayDeltas({
   pool: ClReplayPool;
   seed: FameClReplayStateCapsule | null;
   events: readonly FameClReplayNormalizedEvent[];
+  fee?: bigint;
   observedThroughBlock: number;
   blockHash: Hex;
   parentHash: Hex;
@@ -1175,7 +1181,7 @@ export function applyClReplayDeltas({
   let sqrtPriceX96 = BigInt(seed.latest.sqrtPriceX96);
   let tick = seed.latest.tick;
   let liquidity = BigInt(seed.latest.liquidity);
-  const fee = BigInt(seed.latest.fee);
+  const replayFee = fee ?? BigInt(seed.latest.fee);
   const tickStates = new Map(
     seed.initializedTicks.map((initializedTick) => [
       initializedTick.tick,
@@ -1280,7 +1286,7 @@ export function applyClReplayDeltas({
     sqrtPriceX96,
     tick,
     liquidity,
-    fee,
+    fee: replayFee,
     blockHash,
     parentHash,
     bitmapWords,
@@ -1296,7 +1302,7 @@ export function applyClReplayDeltas({
       sqrtPriceX96,
       tick,
       liquidity,
-      fee,
+      fee: replayFee,
       observedThroughBlock,
       blockHash,
       parentHash,
@@ -1785,6 +1791,15 @@ export function createViemPoolStateIndexerClient(
         blockNumber,
       });
     },
+    async getClReplayFee({ pool, blockNumber }) {
+      const fee = await client.readContract({
+        address: requirePoolAddress(pool),
+        abi: SlipstreamFeeAbi,
+        functionName: "fee",
+        blockNumber,
+      });
+      return BigInt(fee);
+    },
   };
 }
 
@@ -2225,10 +2240,15 @@ export async function indexFamePoolStates({
         if (targetBlockIdentity === null) {
           throw new Error("target-block-unavailable");
         }
+        const fee =
+          snapshotRows === undefined
+            ? await client.getClReplayFee({ pool, blockNumber: safeBlock })
+            : BigInt(snapshotRows.latest.fee);
         applyResult = applyClReplayDeltas({
           pool,
           seed,
           events,
+          fee,
           observedThroughBlock,
           blockHash: snapshotRows?.latest.blockHash ?? targetBlockIdentity.blockHash,
           parentHash:

--- a/src/fame-swap-pool-state/indexer.ts
+++ b/src/fame-swap-pool-state/indexer.ts
@@ -2061,7 +2061,8 @@ export async function indexFamePoolStates({
       sourceRegistryId,
     });
     if (
-      clReplayMaintenanceMode === "steady-state" &&
+      (clReplayMaintenanceMode === "checkpoint" ||
+        clReplayMaintenanceMode === "steady-state") &&
       canAdvanceTrustedState &&
       maintenance !== null
     ) {
@@ -2166,12 +2167,22 @@ export async function indexFamePoolStates({
     const snapshotRows = clReplayRowsByPoolId.get(pool.id);
     const latest = latestClReplayByPoolId.get(pool.id) ?? null;
     const maintenance = latestClReplayMaintenanceByPoolId.get(pool.id) ?? null;
+    const canAdvanceTrustedState = clReplayMaintenanceMatchesLatest({
+      maintenance,
+      latest,
+      sourceRegistryId,
+    });
+    const snapshotSeed = snapshotRows
+      ? clReplayCapsuleFromRows(snapshotRows)
+      : null;
     const seed =
-      clReplayMaintenanceMode === "repair" && snapshotRows
-        ? clReplayCapsuleFromRows(snapshotRows)
-        : snapshotRows && !latest
-          ? clReplayCapsuleFromRows(snapshotRows)
-          : latest ?? (snapshotRows ? clReplayCapsuleFromRows(snapshotRows) : null);
+      clReplayMaintenanceMode === "repair" && snapshotSeed
+        ? snapshotSeed
+        : clReplayMaintenanceMode === "checkpoint" &&
+            snapshotSeed &&
+            !canAdvanceTrustedState
+          ? snapshotSeed
+          : latest ?? snapshotSeed;
     const replayFromBlockForPool =
       replayFromBlockByPoolId.get(pool.id) ?? observedThroughBlock + 1;
     const poolLogs = (clReplayRawLogsByPoolId.get(pool.id) ?? []).filter(

--- a/src/fame-swap-pool-state/indexer.ts
+++ b/src/fame-swap-pool-state/indexer.ts
@@ -1,18 +1,31 @@
-import { encodeAbiParameters, keccak256, type Address, type Hex } from "viem";
+import {
+  decodeEventLog,
+  encodeAbiParameters,
+  keccak256,
+  toEventSelector,
+  type Address,
+  type Hex,
+} from "viem";
 import {
   Uint256ReserveSyncEvent,
   UniswapV2PairReserveAbi,
   UniswapV2SyncEvent,
-} from "@/events.ts";
-import type { baseClient } from "@/viem.ts";
+} from "../events.ts";
+import type { baseClient } from "../viem.ts";
 import {
   batchGetLatestClHeadStates,
+  batchGetLatestClReplayMaintenanceStates,
+  batchGetLatestClReplayStates,
   batchGetLatestPoolStates,
+  clReplayCandidateStateRowsFromSnapshot,
   clReplayStateRowsFromSnapshot,
   getPoolStateCursor,
   latestClHeadStateFromSnapshot,
+  latestClReplayMaintenanceStateKey,
   latestStateFromReserves,
   markPoolObservedThroughBlock,
+  putLatestClReplayCandidateState,
+  putLatestClReplayMaintenanceState,
   putLatestClReplayState,
   putLatestClHeadState,
   putLatestPoolState,
@@ -21,6 +34,8 @@ import {
   type FameClHeadSnapshotRegistryEntry,
   type FameClHeadSource,
   type FameClReplayRegistryEntry,
+  type FameClReplayMaintenanceState,
+  type FameClReplayStateCapsule,
   type FameClReplayStateRows,
   type PoolStateDocumentClient,
 } from "./dynamodb/pool-state.ts";
@@ -38,7 +53,8 @@ type FamePoolStateSyncEventKind = "uint112-reserves" | "uint256-reserves";
 const CL_MIN_TICK = -887_272;
 const CL_MAX_TICK = 887_272;
 const CL_TICK_BITMAP_WORD_SIZE = 256;
-const CL_REPLAY_PROVIDER_READ_BATCH_SIZE = 32;
+const CL_REPLAY_PROVIDER_READ_BATCH_SIZE = 4;
+const RPC_GET_LOGS_BLOCK_RANGE = 10n;
 
 const SlipstreamSlot0Abi = [
   {
@@ -94,6 +110,77 @@ const SlipstreamFeeAbi = [
     outputs: [{ name: "fee", type: "uint24" }],
   },
 ] as const;
+
+export const ClReplaySwapEventAbi = {
+  type: "event",
+  anonymous: false,
+  inputs: [
+    { name: "sender", type: "address", indexed: true },
+    { name: "recipient", type: "address", indexed: true },
+    { name: "amount0", type: "int256", indexed: false },
+    { name: "amount1", type: "int256", indexed: false },
+    { name: "sqrtPriceX96", type: "uint160", indexed: false },
+    { name: "liquidity", type: "uint128", indexed: false },
+    { name: "tick", type: "int24", indexed: false },
+  ],
+  name: "Swap",
+} as const;
+
+export const ClReplayMintEventAbi = {
+  type: "event",
+  anonymous: false,
+  inputs: [
+    { name: "sender", type: "address", indexed: false },
+    { name: "owner", type: "address", indexed: true },
+    { name: "tickLower", type: "int24", indexed: true },
+    { name: "tickUpper", type: "int24", indexed: true },
+    { name: "amount", type: "uint128", indexed: false },
+    { name: "amount0", type: "uint256", indexed: false },
+    { name: "amount1", type: "uint256", indexed: false },
+  ],
+  name: "Mint",
+} as const;
+
+export const ClReplayBurnEventAbi = {
+  type: "event",
+  anonymous: false,
+  inputs: [
+    { name: "owner", type: "address", indexed: true },
+    { name: "tickLower", type: "int24", indexed: true },
+    { name: "tickUpper", type: "int24", indexed: true },
+    { name: "amount", type: "uint128", indexed: false },
+    { name: "amount0", type: "uint256", indexed: false },
+    { name: "amount1", type: "uint256", indexed: false },
+  ],
+  name: "Burn",
+} as const;
+
+export const ClReplayCollectEventAbi = {
+  type: "event",
+  anonymous: false,
+  inputs: [
+    { name: "owner", type: "address", indexed: true },
+    { name: "recipient", type: "address", indexed: false },
+    { name: "tickLower", type: "int24", indexed: true },
+    { name: "tickUpper", type: "int24", indexed: true },
+    { name: "amount0", type: "uint128", indexed: false },
+    { name: "amount1", type: "uint128", indexed: false },
+  ],
+  name: "Collect",
+} as const;
+
+const CL_REPLAY_SWAP_TOPIC = toEventSelector(
+  "Swap(address,address,int256,int256,uint160,uint128,int24)",
+);
+const CL_REPLAY_MINT_TOPIC = toEventSelector(
+  "Mint(address,address,int24,int24,uint128,uint256,uint256)",
+);
+const CL_REPLAY_BURN_TOPIC = toEventSelector(
+  "Burn(address,int24,int24,uint128,uint256,uint256)",
+);
+const CL_REPLAY_COLLECT_TOPIC = toEventSelector(
+  "Collect(address,address,int24,int24,uint128,uint128)",
+);
 
 const SlipstreamTickBitmapAbi = [
   {
@@ -163,16 +250,91 @@ export interface FamePoolStateSyncLog {
   };
 }
 
+export interface FameClReplayRawLog {
+  address: Address;
+  blockNumber: bigint;
+  blockHash: Hex | null;
+  transactionHash: Hex;
+  transactionIndex: number;
+  logIndex: number;
+  removed: boolean;
+  topics: readonly Hex[];
+  data: Hex;
+}
+
+export interface FameClReplayEventBase {
+  poolId: string;
+  venue: ClReplayPool["venue"];
+  poolAddress: Address;
+  blockNumber: number;
+  blockHash: Hex;
+  transactionHash: Hex;
+  transactionIndex: number;
+  logIndex: number;
+}
+
+export type FameClReplayNormalizedEvent =
+  | (FameClReplayEventBase & {
+      kind: "swap";
+      sqrtPriceX96: bigint;
+      tick: number;
+      liquidity: bigint;
+    })
+  | (FameClReplayEventBase & {
+      kind: "mint";
+      tickLower: number;
+      tickUpper: number;
+      amount: bigint;
+    })
+  | (FameClReplayEventBase & {
+      kind: "burn";
+      tickLower: number;
+      tickUpper: number;
+      amount: bigint;
+    })
+  | (FameClReplayEventBase & {
+      kind: "collect";
+      tickLower: number;
+      tickUpper: number;
+    });
+
+export type FameClReplayDeltaApplyResult =
+  | {
+      status: "candidate";
+      rows: ReturnType<typeof clReplayCandidateStateRowsFromSnapshot>;
+      appliedEventCount: number;
+    }
+  | {
+      status: "warming" | "event-gap";
+      reason: string;
+      appliedEventCount: number;
+    };
+
+export class FameClReplayLogNormalizationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FameClReplayLogNormalizationError";
+  }
+}
+
 export interface FamePoolStateIndexerClient {
   chain: {
     id: number;
   };
   getBlockNumber(): Promise<bigint>;
+  getBlock(options: {
+    blockNumber: bigint;
+  }): Promise<{ hash: Hex | null; parentHash: Hex }>;
   getSyncLogs(options: {
     pools: readonly QuoteModelPool[];
     fromBlock: bigint;
     toBlock: bigint;
   }): Promise<readonly FamePoolStateSyncLog[]>;
+  getClReplayLogs(options: {
+    pools: readonly ClReplayPool[];
+    fromBlock: bigint;
+    toBlock: bigint;
+  }): Promise<readonly FameClReplayRawLog[]>;
   getReserves(options: {
     poolAddress: Address;
     blockNumber: bigint;
@@ -208,6 +370,11 @@ export interface SlipstreamReplayReadClient {
     wordPosition: number;
     blockNumber: bigint;
   }): Promise<bigint>;
+  getTickBitmaps?(options: {
+    poolAddress: Address;
+    wordPositions: readonly number[];
+    blockNumber: bigint;
+  }): Promise<readonly FameClReplayBitmapWordRead[]>;
   getTick(options: {
     poolAddress: Address;
     tick: number;
@@ -225,6 +392,27 @@ export interface SlipstreamReplayReadClient {
       number,
       boolean,
     ]
+  >;
+  getTicks?(options: {
+    poolAddress: Address;
+    ticks: readonly number[];
+    blockNumber: bigint;
+  }): Promise<
+    readonly {
+      tick: number;
+      state: readonly [
+        bigint,
+        bigint,
+        bigint,
+        bigint,
+        bigint,
+        bigint,
+        bigint,
+        bigint,
+        number,
+        boolean,
+      ];
+    }[]
   >;
 }
 
@@ -280,6 +468,23 @@ export interface FameClReplaySnapshotMetric {
   stateHash: Hex;
 }
 
+export interface FameClReplayMaintenanceMetric {
+  poolId: string;
+  status: "trusted" | "warming" | "drift-failed" | "repairing" | "event-gap";
+  reason: string | null;
+  fromBlock: number;
+  toBlock: number;
+  scannedLogCount: number;
+  appliedEventCount: number;
+  candidateWritten: boolean;
+  stateHash: Hex | null;
+}
+
+export type FameClReplayMaintenanceMode =
+  | "checkpoint"
+  | "steady-state"
+  | "repair";
+
 export interface FamePoolStateIndexerResult {
   chainId: number;
   durationMs: number;
@@ -300,6 +505,7 @@ export interface FamePoolStateIndexerResult {
   clReplayFailedPools: number;
   clReplayFailures: FameClReplaySnapshotFailure[];
   clReplayMetrics: FameClReplaySnapshotMetric[];
+  clReplayMaintenanceMetrics: FameClReplayMaintenanceMetric[];
   sourceRegistryId: string;
 }
 
@@ -381,6 +587,30 @@ function safeHeadBlock(
     : latestBlock;
 }
 
+function boundedBlockRanges({
+  fromBlock,
+  toBlock,
+  maxRange,
+}: {
+  fromBlock: bigint;
+  toBlock: bigint;
+  maxRange: bigint;
+}): { fromBlock: bigint; toBlock: bigint }[] {
+  if (maxRange <= 0n) throw new Error("maxRange must be positive.");
+  if (fromBlock > toBlock) return [];
+  const ranges: { fromBlock: bigint; toBlock: bigint }[] = [];
+  let nextFromBlock = fromBlock;
+  while (nextFromBlock <= toBlock) {
+    const nextToBlock =
+      nextFromBlock + maxRange - 1n < toBlock
+        ? nextFromBlock + maxRange - 1n
+        : toBlock;
+    ranges.push({ fromBlock: nextFromBlock, toBlock: nextToBlock });
+    nextFromBlock = nextToBlock + 1n;
+  }
+  return ranges;
+}
+
 function requirePoolAddress(pool: ClHeadPool): Address {
   if (pool.poolAddress === null) {
     throw new Error(`${pool.id} must have a poolAddress for pool head reads.`);
@@ -455,6 +685,17 @@ async function mapInBatches<Input, Output>(
     );
   }
   return outputs;
+}
+
+function chunkArray<T>(values: readonly T[], chunkSize: number): T[][] {
+  if (!Number.isSafeInteger(chunkSize) || chunkSize <= 0) {
+    throw new Error("chunkSize must be a positive safe integer.");
+  }
+  const chunks: T[][] = [];
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push([...values.slice(index, index + chunkSize)]);
+  }
+  return chunks;
 }
 
 function clReplaySnapshotId({
@@ -564,6 +805,87 @@ function clReplayRowsFromSnapshot({
   });
 }
 
+function clReplayCapsuleFromRows(
+  rows: FameClReplayStateRows,
+): FameClReplayStateCapsule {
+  return {
+    latest: rows.latest,
+    bitmapWords: rows.bitmapChunks.flatMap((chunk) => chunk.bitmapWords),
+    initializedTicks: rows.tickChunks.flatMap((chunk) => chunk.initializedTicks),
+  };
+}
+
+function clReplayRowsFromCandidateRows({
+  pool,
+  rows,
+}: {
+  pool: ClReplayPool;
+  rows: ReturnType<typeof clReplayCandidateStateRowsFromSnapshot>;
+}): FameClReplayStateRows {
+  return clReplayStateRowsFromSnapshot({
+    pool,
+    sqrtPriceX96: BigInt(rows.latest.sqrtPriceX96),
+    tick: rows.latest.tick,
+    liquidity: BigInt(rows.latest.liquidity),
+    fee: BigInt(rows.latest.fee),
+    observedThroughBlock: rows.latest.observedThroughBlock,
+    blockHash: rows.latest.blockHash,
+    parentHash: rows.latest.parentHash,
+    snapshotId: `cl-replay-v1:${pool.id}:${rows.latest.observedThroughBlock.toString()}:${rows.latest.blockHash}:${rows.latest.sourceRegistryId}`,
+    stateHash: rows.latest.stateHash,
+    sourceRegistryId: rows.latest.sourceRegistryId,
+    updatedAt: rows.latest.updatedAt,
+    bitmapWords: rows.bitmapChunks.flatMap((chunk) =>
+      chunk.bitmapWords.map((word) => ({
+        wordPosition: word.wordPosition,
+        bitmap: BigInt(word.bitmap),
+      })),
+    ),
+    initializedTicks: rows.tickChunks.flatMap((chunk) =>
+      chunk.initializedTicks.map((tick) => ({
+        tick: tick.tick,
+        liquidityGross: BigInt(tick.liquidityGross),
+        liquidityNet: BigInt(tick.liquidityNet),
+      })),
+    ),
+  });
+}
+
+function clReplayMaintenanceMatchesLatest({
+  maintenance,
+  latest,
+  sourceRegistryId,
+}: {
+  maintenance: FameClReplayMaintenanceState | null;
+  latest: FameClReplayStateCapsule | null;
+  sourceRegistryId: string;
+}): boolean {
+  return (
+    maintenance !== null &&
+    latest !== null &&
+    maintenance.status === "trusted" &&
+    maintenance.sourceRegistryId === sourceRegistryId &&
+    latest.latest.sourceRegistryId === sourceRegistryId &&
+    maintenance.cursorBlock === latest.latest.observedThroughBlock &&
+    maintenance.cursorBlockHash === latest.latest.blockHash &&
+    maintenance.stateHash === latest.latest.stateHash
+  );
+}
+
+async function readBlockIdentity({
+  client,
+  blockNumber,
+}: {
+  client: FamePoolStateIndexerClient;
+  blockNumber: number;
+}): Promise<{ blockHash: Hex; parentHash: Hex }> {
+  const block = await client.getBlock({ blockNumber: BigInt(blockNumber) });
+  if (block.hash === null) {
+    throw new Error(`Block ${blockNumber.toString()} has no hash.`);
+  }
+  return { blockHash: block.hash, parentHash: block.parentHash };
+}
+
 function sortedLogs(
   logs: readonly FamePoolStateSyncLog[],
 ): FamePoolStateSyncLog[] {
@@ -576,6 +898,417 @@ function sortedLogs(
     }
     return left.logIndex - right.logIndex;
   });
+}
+
+function sortedReplayLogs(
+  logs: readonly FameClReplayRawLog[],
+): FameClReplayRawLog[] {
+  return [...logs].sort((left, right) => {
+    if (left.blockNumber !== right.blockNumber) {
+      return left.blockNumber < right.blockNumber ? -1 : 1;
+    }
+    if (left.transactionIndex !== right.transactionIndex) {
+      return left.transactionIndex - right.transactionIndex;
+    }
+    return left.logIndex - right.logIndex;
+  });
+}
+
+function baseReplayEvent({
+  pool,
+  log,
+}: {
+  pool: ClReplayPool;
+  log: FameClReplayRawLog;
+}): FameClReplayEventBase {
+  if (log.blockHash === null) {
+    throw new FameClReplayLogNormalizationError(
+      `${pool.id} replay log is missing block hash.`,
+    );
+  }
+  return {
+    poolId: pool.id,
+    venue: pool.venue,
+    poolAddress: pool.poolAddress,
+    blockNumber: safeNumber(log.blockNumber, "CL replay log block number"),
+    blockHash: log.blockHash,
+    transactionHash: log.transactionHash,
+    transactionIndex: log.transactionIndex,
+    logIndex: log.logIndex,
+  };
+}
+
+function replayLogTopics(log: FameClReplayRawLog): [Hex, ...Hex[]] {
+  const [topic0, ...topics] = log.topics;
+  if (!topic0) {
+    throw new FameClReplayLogNormalizationError(
+      "CL replay log is missing topic0.",
+    );
+  }
+  return [topic0, ...topics];
+}
+
+function decodeClReplayLog({
+  pool,
+  log,
+}: {
+  pool: ClReplayPool;
+  log: FameClReplayRawLog;
+}): FameClReplayNormalizedEvent {
+  if (log.removed) {
+    throw new FameClReplayLogNormalizationError(
+      `${pool.id} replay log was removed.`,
+    );
+  }
+  if (addressKey(log.address) !== addressKey(pool.poolAddress)) {
+    throw new FameClReplayLogNormalizationError(
+      `Replay log address does not match ${pool.id}.`,
+    );
+  }
+  const topics = replayLogTopics(log);
+  const topic = topics[0];
+
+  const base = baseReplayEvent({ pool, log });
+  if (topic === CL_REPLAY_SWAP_TOPIC) {
+    const decoded = decodeEventLog({
+      abi: [ClReplaySwapEventAbi],
+      eventName: "Swap",
+      topics,
+      data: log.data,
+      strict: true,
+    });
+    return {
+      ...base,
+      kind: "swap",
+      sqrtPriceX96: decoded.args.sqrtPriceX96,
+      tick: decoded.args.tick,
+      liquidity: decoded.args.liquidity,
+    };
+  }
+  if (topic === CL_REPLAY_MINT_TOPIC) {
+    const decoded = decodeEventLog({
+      abi: [ClReplayMintEventAbi],
+      eventName: "Mint",
+      topics,
+      data: log.data,
+      strict: true,
+    });
+    return {
+      ...base,
+      kind: "mint",
+      tickLower: decoded.args.tickLower,
+      tickUpper: decoded.args.tickUpper,
+      amount: decoded.args.amount,
+    };
+  }
+  if (topic === CL_REPLAY_BURN_TOPIC) {
+    const decoded = decodeEventLog({
+      abi: [ClReplayBurnEventAbi],
+      eventName: "Burn",
+      topics,
+      data: log.data,
+      strict: true,
+    });
+    return {
+      ...base,
+      kind: "burn",
+      tickLower: decoded.args.tickLower,
+      tickUpper: decoded.args.tickUpper,
+      amount: decoded.args.amount,
+    };
+  }
+  if (topic === CL_REPLAY_COLLECT_TOPIC) {
+    const decoded = decodeEventLog({
+      abi: [ClReplayCollectEventAbi],
+      eventName: "Collect",
+      topics,
+      data: log.data,
+      strict: true,
+    });
+    return {
+      ...base,
+      kind: "collect",
+      tickLower: decoded.args.tickLower,
+      tickUpper: decoded.args.tickUpper,
+    };
+  }
+
+  throw new FameClReplayLogNormalizationError(
+    `${pool.id} replay log has unsupported topic ${topic}.`,
+  );
+}
+
+export function normalizeClReplayLogs({
+  pool,
+  logs,
+}: {
+  pool: ClReplayPool;
+  logs: readonly FameClReplayRawLog[];
+}): FameClReplayNormalizedEvent[] {
+  return sortedReplayLogs(logs).map((log) => decodeClReplayLog({ pool, log }));
+}
+
+function assertTickAligned({
+  tick,
+  tickSpacing,
+}: {
+  tick: number;
+  tickSpacing: number;
+}): void {
+  if (tick % tickSpacing !== 0) {
+    throw new Error(
+      `CL replay tick ${tick.toString()} is not aligned to spacing ${tickSpacing.toString()}.`,
+    );
+  }
+}
+
+function bitmapWordsFromInitializedTicks({
+  ticks,
+  tickSpacing,
+}: {
+  ticks: readonly number[];
+  tickSpacing: number;
+}): { wordPosition: number; bitmap: bigint }[] {
+  const words = new Map<number, bigint>();
+  for (const tick of ticks) {
+    assertTickAligned({ tick, tickSpacing });
+    const compressedTick = tick / tickSpacing;
+    const wordPosition = floorDiv(compressedTick, CL_TICK_BITMAP_WORD_SIZE);
+    const bit = compressedTick - wordPosition * CL_TICK_BITMAP_WORD_SIZE;
+    const current = words.get(wordPosition) ?? 0n;
+    words.set(wordPosition, current | (1n << BigInt(bit)));
+  }
+  return [...words.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([wordPosition, bitmap]) => ({ wordPosition, bitmap }));
+}
+
+function orderedReplayEvents(
+  events: readonly FameClReplayNormalizedEvent[],
+): FameClReplayNormalizedEvent[] {
+  return [...events].sort((left, right) => {
+    if (left.blockNumber !== right.blockNumber) {
+      return left.blockNumber - right.blockNumber;
+    }
+    if (left.transactionIndex !== right.transactionIndex) {
+      return left.transactionIndex - right.transactionIndex;
+    }
+    return left.logIndex - right.logIndex;
+  });
+}
+
+function currentTickInRange({
+  currentTick,
+  tickLower,
+  tickUpper,
+}: {
+  currentTick: number;
+  tickLower: number;
+  tickUpper: number;
+}): boolean {
+  return currentTick >= tickLower && currentTick < tickUpper;
+}
+
+function applyLiquidityDelta({
+  tickStates,
+  tick,
+  grossDelta,
+  netDelta,
+}: {
+  tickStates: Map<number, { liquidityGross: bigint; liquidityNet: bigint }>;
+  tick: number;
+  grossDelta: bigint;
+  netDelta: bigint;
+}): "applied" | "underflow" {
+  const current = tickStates.get(tick) ?? {
+    liquidityGross: 0n,
+    liquidityNet: 0n,
+  };
+  const liquidityGross = current.liquidityGross + grossDelta;
+  if (liquidityGross < 0n) return "underflow";
+  const liquidityNet = current.liquidityNet + netDelta;
+  if (liquidityGross === 0n) {
+    if (liquidityNet !== 0n) return "underflow";
+    tickStates.delete(tick);
+  } else {
+    tickStates.set(tick, { liquidityGross, liquidityNet });
+  }
+  return "applied";
+}
+
+export function applyClReplayDeltas({
+  pool,
+  seed,
+  events,
+  observedThroughBlock,
+  blockHash,
+  parentHash,
+  candidateId,
+  sourceRegistryId,
+  updatedAt,
+}: {
+  pool: ClReplayPool;
+  seed: FameClReplayStateCapsule | null;
+  events: readonly FameClReplayNormalizedEvent[];
+  observedThroughBlock: number;
+  blockHash: Hex;
+  parentHash: Hex;
+  candidateId: string;
+  sourceRegistryId: string;
+  updatedAt: string;
+}): FameClReplayDeltaApplyResult {
+  if (seed === null) {
+    return {
+      status: "warming",
+      reason: "seed-required",
+      appliedEventCount: 0,
+    };
+  }
+  if (seed.latest.sourceRegistryId !== sourceRegistryId) {
+    return {
+      status: "warming",
+      reason: "source-registry-mismatch",
+      appliedEventCount: 0,
+    };
+  }
+
+  let sqrtPriceX96 = BigInt(seed.latest.sqrtPriceX96);
+  let tick = seed.latest.tick;
+  let liquidity = BigInt(seed.latest.liquidity);
+  const fee = BigInt(seed.latest.fee);
+  const tickStates = new Map(
+    seed.initializedTicks.map((initializedTick) => [
+      initializedTick.tick,
+      {
+        liquidityGross: BigInt(initializedTick.liquidityGross),
+        liquidityNet: BigInt(initializedTick.liquidityNet),
+      },
+    ]),
+  );
+  let appliedEventCount = 0;
+
+  for (const event of orderedReplayEvents(events)) {
+    if (event.poolId !== pool.id) {
+      return {
+        status: "event-gap",
+        reason: "pool-mismatch",
+        appliedEventCount,
+      };
+    }
+
+    if (event.kind === "swap") {
+      sqrtPriceX96 = event.sqrtPriceX96;
+      tick = event.tick;
+      liquidity = event.liquidity;
+      appliedEventCount += 1;
+      continue;
+    }
+
+    if (event.kind === "collect") {
+      continue;
+    }
+
+    if (event.tickLower >= event.tickUpper) {
+      return {
+        status: "event-gap",
+        reason: "invalid-tick-range",
+        appliedEventCount,
+      };
+    }
+    try {
+      assertTickAligned({ tick: event.tickLower, tickSpacing: pool.tickSpacing });
+      assertTickAligned({ tick: event.tickUpper, tickSpacing: pool.tickSpacing });
+    } catch {
+      return {
+        status: "event-gap",
+        reason: "invalid-tick-spacing",
+        appliedEventCount,
+      };
+    }
+
+    const signedAmount = event.kind === "mint" ? event.amount : -event.amount;
+    const lowerResult = applyLiquidityDelta({
+      tickStates,
+      tick: event.tickLower,
+      grossDelta: signedAmount,
+      netDelta: signedAmount,
+    });
+    const upperResult = applyLiquidityDelta({
+      tickStates,
+      tick: event.tickUpper,
+      grossDelta: signedAmount,
+      netDelta: -signedAmount,
+    });
+    if (lowerResult === "underflow" || upperResult === "underflow") {
+      return {
+        status: "event-gap",
+        reason: "liquidity-underflow",
+        appliedEventCount,
+      };
+    }
+    if (
+      currentTickInRange({
+        currentTick: tick,
+        tickLower: event.tickLower,
+        tickUpper: event.tickUpper,
+      })
+    ) {
+      liquidity += signedAmount;
+      if (liquidity < 0n) {
+        return {
+          status: "event-gap",
+          reason: "active-liquidity-underflow",
+          appliedEventCount,
+        };
+      }
+    }
+    appliedEventCount += 1;
+  }
+
+  const initializedTicks = [...tickStates.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([initializedTick, state]) => ({
+      tick: initializedTick,
+      liquidityGross: state.liquidityGross,
+      liquidityNet: state.liquidityNet,
+    }));
+  const bitmapWords = bitmapWordsFromInitializedTicks({
+    ticks: initializedTicks.map((initializedTick) => initializedTick.tick),
+    tickSpacing: pool.tickSpacing,
+  });
+  const snapshot = {
+    sqrtPriceX96,
+    tick,
+    liquidity,
+    fee,
+    blockHash,
+    parentHash,
+    bitmapWords,
+    initializedTicks,
+    providerReadCount: 0,
+    durationMs: 0,
+  } satisfies FameClReplaySnapshotRead;
+
+  return {
+    status: "candidate",
+    rows: clReplayCandidateStateRowsFromSnapshot({
+      pool,
+      sqrtPriceX96,
+      tick,
+      liquidity,
+      fee,
+      observedThroughBlock,
+      blockHash,
+      parentHash,
+      candidateId,
+      stateHash: clReplayStateHash({ snapshot, observedThroughBlock }),
+      sourceRegistryId,
+      updatedAt,
+      bitmapWords,
+      initializedTicks,
+    }),
+    appliedEventCount,
+  };
 }
 
 function reservesDiffer(
@@ -656,18 +1389,33 @@ export async function getSlipstreamClReplaySnapshot({
   ]);
 
   const wordPositions = tickBitmapWordPositions(pool.tickSpacing);
-  const wordReads = await mapInBatches(
-    wordPositions,
-    CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
-    async (wordPosition) => ({
-      wordPosition,
-      bitmap: await client.getTickBitmap({
-        poolAddress,
-        wordPosition,
-        blockNumber,
-      }),
-    }),
-  );
+  const wordReads = client.getTickBitmaps
+    ? (
+        await mapInBatches(
+          chunkArray(wordPositions, CL_REPLAY_PROVIDER_READ_BATCH_SIZE),
+          1,
+          (batch) =>
+            client.getTickBitmaps
+              ? client.getTickBitmaps({
+                  poolAddress,
+                  wordPositions: batch,
+                  blockNumber,
+                })
+              : Promise.resolve([]),
+        )
+      ).flat()
+    : await mapInBatches(
+        wordPositions,
+        CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
+        async (wordPosition) => ({
+          wordPosition,
+          bitmap: await client.getTickBitmap({
+            poolAddress,
+            wordPosition,
+            blockNumber,
+          }),
+        }),
+      );
   const bitmapWords = wordReads.filter((word) => word.bitmap !== 0n);
   const initializedTickIndexes = bitmapWords.flatMap((word) =>
     initializedTicksForBitmapWord({
@@ -676,28 +1424,57 @@ export async function getSlipstreamClReplaySnapshot({
       tickSpacing: pool.tickSpacing,
     }),
   );
-  const initializedTicks = await mapInBatches(
-    initializedTickIndexes,
-    CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
-    async (initializedTick) => {
-      const [liquidityGross, liquidityNet, , , , , , , , initialized] =
-        await client.getTick({
-          poolAddress,
-          tick: initializedTick,
-          blockNumber,
-        });
-      if (!initialized) {
-        throw new Error(
-          `Tick bitmap marked ${initializedTick.toString()} initialized but ticks() did not.`,
-        );
-      }
-      return {
-        tick: initializedTick,
-        liquidityGross,
-        liquidityNet,
-      };
-    },
-  );
+  const initializedTicks = client.getTicks
+    ? (
+        await mapInBatches(
+          chunkArray(
+            initializedTickIndexes,
+            CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
+          ),
+          1,
+          (batch) =>
+            client.getTicks
+              ? client.getTicks({ poolAddress, ticks: batch, blockNumber })
+              : Promise.resolve([]),
+        )
+      )
+        .flat()
+        .map(({ tick: initializedTick, state }) => {
+          const [liquidityGross, liquidityNet, , , , , , , , initialized] =
+            state;
+          if (!initialized) {
+            throw new Error(
+              `Tick bitmap marked ${initializedTick.toString()} initialized but ticks() did not.`,
+            );
+          }
+          return {
+            tick: initializedTick,
+            liquidityGross,
+            liquidityNet,
+          };
+        })
+    : await mapInBatches(
+        initializedTickIndexes,
+        CL_REPLAY_PROVIDER_READ_BATCH_SIZE,
+        async (initializedTick) => {
+          const [liquidityGross, liquidityNet, , , , , , , , initialized] =
+            await client.getTick({
+              poolAddress,
+              tick: initializedTick,
+              blockNumber,
+            });
+          if (!initialized) {
+            throw new Error(
+              `Tick bitmap marked ${initializedTick.toString()} initialized but ticks() did not.`,
+            );
+          }
+          return {
+            tick: initializedTick,
+            liquidityGross,
+            liquidityNet,
+          };
+        },
+      );
 
   const blockAfter = await client.getBlock({ blockNumber });
   if (
@@ -734,6 +1511,9 @@ export function createViemPoolStateIndexerClient(
     getBlockNumber() {
       return client.getBlockNumber();
     },
+    getBlock(options) {
+      return client.getBlock(options);
+    },
     async getSyncLogs({ pools, fromBlock, toBlock }) {
       const uint112Addresses = pools
         .filter((pool) => syncEventKind(pool) === "uint112-reserves")
@@ -741,37 +1521,87 @@ export function createViemPoolStateIndexerClient(
       const uint256Addresses = pools
         .filter((pool) => syncEventKind(pool) === "uint256-reserves")
         .map((pool) => pool.poolAddress);
-      const logsByKind = await Promise.all([
-        uint112Addresses.length === 0
-          ? Promise.resolve([])
-          : client.getLogs({
-              address: uint112Addresses,
-              event: UniswapV2SyncEvent,
-              fromBlock,
-              toBlock,
-              strict: true,
-            }),
-        uint256Addresses.length === 0
-          ? Promise.resolve([])
-          : client.getLogs({
-              address: uint256Addresses,
-              event: Uint256ReserveSyncEvent,
-              fromBlock,
-              toBlock,
-              strict: true,
-            }),
-      ]);
-      return logsByKind.flat().map((log) => ({
-        address: log.address,
-        blockNumber: log.blockNumber,
-        transactionIndex: log.transactionIndex,
-        logIndex: log.logIndex,
-        transactionHash: log.transactionHash,
-        args: {
-          reserve0: log.args.reserve0,
-          reserve1: log.args.reserve1,
-        },
-      }));
+      const logs: FamePoolStateSyncLog[] = [];
+      for (const range of boundedBlockRanges({
+        fromBlock,
+        toBlock,
+        maxRange: RPC_GET_LOGS_BLOCK_RANGE,
+      })) {
+        if (uint112Addresses.length > 0) {
+          const uint112Logs = await client.getLogs({
+            address: uint112Addresses,
+            event: UniswapV2SyncEvent,
+            fromBlock: range.fromBlock,
+            toBlock: range.toBlock,
+            strict: true,
+          });
+          logs.push(
+            ...uint112Logs.map((log) => ({
+              address: log.address,
+              blockNumber: log.blockNumber,
+              transactionIndex: log.transactionIndex,
+              logIndex: log.logIndex,
+              transactionHash: log.transactionHash,
+              args: {
+                reserve0: log.args.reserve0,
+                reserve1: log.args.reserve1,
+              },
+            })),
+          );
+        }
+        if (uint256Addresses.length > 0) {
+          const uint256Logs = await client.getLogs({
+            address: uint256Addresses,
+            event: Uint256ReserveSyncEvent,
+            fromBlock: range.fromBlock,
+            toBlock: range.toBlock,
+            strict: true,
+          });
+          logs.push(
+            ...uint256Logs.map((log) => ({
+              address: log.address,
+              blockNumber: log.blockNumber,
+              transactionIndex: log.transactionIndex,
+              logIndex: log.logIndex,
+              transactionHash: log.transactionHash,
+              args: {
+                reserve0: log.args.reserve0,
+                reserve1: log.args.reserve1,
+              },
+            })),
+          );
+        }
+      }
+      return logs;
+    },
+    async getClReplayLogs({ pools, fromBlock, toBlock }) {
+      if (pools.length === 0) return [];
+      const logs: FameClReplayRawLog[] = [];
+      for (const range of boundedBlockRanges({
+        fromBlock,
+        toBlock,
+        maxRange: RPC_GET_LOGS_BLOCK_RANGE,
+      })) {
+        const rangeLogs = await client.getLogs({
+          address: pools.map((pool) => pool.poolAddress),
+          fromBlock: range.fromBlock,
+          toBlock: range.toBlock,
+        });
+        logs.push(
+          ...rangeLogs.map((log) => ({
+            address: log.address,
+            blockNumber: log.blockNumber,
+            blockHash: log.blockHash,
+            transactionHash: log.transactionHash,
+            transactionIndex: log.transactionIndex,
+            logIndex: log.logIndex,
+            removed: log.removed,
+            topics: log.topics,
+            data: log.data,
+          })),
+        );
+      }
+      return logs;
     },
     getReserves({ poolAddress, blockNumber }) {
       return client.readContract({
@@ -899,6 +1729,29 @@ export function createViemPoolStateIndexerClient(
               blockNumber: readBlockNumber,
             });
           },
+          async getTickBitmaps({
+            poolAddress,
+            wordPositions,
+            blockNumber: readBlockNumber,
+          }) {
+            const results = await client.multicall({
+              contracts: wordPositions.map((wordPosition) => ({
+                address: poolAddress,
+                abi: SlipstreamTickBitmapAbi,
+                functionName: "tickBitmap",
+                args: [wordPosition],
+              })),
+              blockNumber: readBlockNumber,
+              allowFailure: false,
+            });
+            return results.map((bitmap, index) => {
+              const wordPosition = wordPositions[index];
+              if (wordPosition === undefined) {
+                throw new Error("Missing tick bitmap word position.");
+              }
+              return { wordPosition, bitmap };
+            });
+          },
           getTick({ poolAddress, tick, blockNumber: readBlockNumber }) {
             return client.readContract({
               address: poolAddress,
@@ -906,6 +1759,25 @@ export function createViemPoolStateIndexerClient(
               functionName: "ticks",
               args: [tick],
               blockNumber: readBlockNumber,
+            });
+          },
+          async getTicks({ poolAddress, ticks, blockNumber: readBlockNumber }) {
+            const results = await client.multicall({
+              contracts: ticks.map((tick) => ({
+                address: poolAddress,
+                abi: SlipstreamTicksAbi,
+                functionName: "ticks",
+                args: [tick],
+              })),
+              blockNumber: readBlockNumber,
+              allowFailure: false,
+            });
+            return results.map((state, index) => {
+              const tick = ticks[index];
+              if (tick === undefined) {
+                throw new Error("Missing initialized tick index.");
+              }
+              return { tick, state };
             });
           },
         },
@@ -922,6 +1794,9 @@ export async function indexFamePoolStates({
   db,
   registry = famePoolStateRegistry,
   confirmationBlocks = 2,
+  clReplayMaintenanceMode = "checkpoint",
+  clReplayTrustPromotion = false,
+  clReplayMaxRangeBlocks = 1_000,
   now = new Date(),
 }: {
   client: FamePoolStateIndexerClient;
@@ -929,6 +1804,9 @@ export async function indexFamePoolStates({
   db?: PoolStateDocumentClient;
   registry?: FamePoolStateRegistryFile;
   confirmationBlocks?: number;
+  clReplayMaintenanceMode?: FameClReplayMaintenanceMode;
+  clReplayTrustPromotion?: boolean;
+  clReplayMaxRangeBlocks?: number;
   now?: Date;
 }): Promise<FamePoolStateIndexerResult> {
   const startedAtMs = Date.now();
@@ -1152,18 +2030,89 @@ export async function indexFamePoolStates({
     if (result === "written") clHeadWrittenPools += 1;
   }
 
-  const clReplayReads = await Promise.allSettled(
-    replayPools.map(async (pool) => {
-      const snapshot = await client.getClReplaySnapshot({
-        pool,
-        blockNumber: safeBlock,
-      });
-      return {
-        pool,
-        snapshot,
-      };
-    }),
+  const latestClReplayStates = await batchGetLatestClReplayStates({
+    db,
+    tableName,
+    pools: replayPools,
+  });
+  const latestClReplayByPoolId = new Map(
+    latestClReplayStates.map((state) => [state.latest.poolId, state]),
   );
+  const latestClReplayMaintenanceStates =
+    await batchGetLatestClReplayMaintenanceStates({
+      db,
+      tableName,
+      pools: replayPools,
+    });
+  const latestClReplayMaintenanceByPoolId = new Map(
+    latestClReplayMaintenanceStates.map((state) => [state.poolId, state]),
+  );
+  const targetBlockIdentity =
+    replayPools.length === 0
+      ? null
+      : await readBlockIdentity({ client, blockNumber: observedThroughBlock });
+  const replayFromBlockByPoolId = new Map<string, number>();
+  for (const pool of replayPools) {
+    const latest = latestClReplayByPoolId.get(pool.id) ?? null;
+    const maintenance = latestClReplayMaintenanceByPoolId.get(pool.id) ?? null;
+    const canAdvanceTrustedState = clReplayMaintenanceMatchesLatest({
+      maintenance,
+      latest,
+      sourceRegistryId,
+    });
+    if (
+      clReplayMaintenanceMode === "steady-state" &&
+      canAdvanceTrustedState &&
+      maintenance !== null
+    ) {
+      replayFromBlockByPoolId.set(pool.id, maintenance.cursorBlock + 1);
+    } else {
+      replayFromBlockByPoolId.set(pool.id, observedThroughBlock + 1);
+    }
+  }
+  const replayScanFromBlock =
+    replayFromBlockByPoolId.size === 0
+      ? observedThroughBlock + 1
+      : Math.min(...replayFromBlockByPoolId.values());
+  const clReplayRawLogs =
+    replayPools.length === 0 || replayScanFromBlock > observedThroughBlock
+      ? []
+      : await client.getClReplayLogs({
+          pools: replayPools,
+          fromBlock: BigInt(replayScanFromBlock),
+          toBlock: safeBlock,
+        });
+  const replayPoolByAddress = new Map(
+    replayPools.map((pool) => [addressKey(pool.poolAddress), pool]),
+  );
+  const clReplayRawLogsByPoolId = new Map<string, FameClReplayRawLog[]>();
+  for (const log of clReplayRawLogs) {
+    const pool = replayPoolByAddress.get(addressKey(log.address));
+    if (!pool) {
+      throw new Error(
+        `CL replay log came from unregistered pool ${log.address}.`,
+      );
+    }
+    const poolLogs = clReplayRawLogsByPoolId.get(pool.id) ?? [];
+    poolLogs.push(log);
+    clReplayRawLogsByPoolId.set(pool.id, poolLogs);
+  }
+
+  const clReplayReads =
+    clReplayMaintenanceMode !== "steady-state"
+      ? await Promise.allSettled(
+          replayPools.map(async (pool) => {
+            const snapshot = await client.getClReplaySnapshot({
+              pool,
+              blockNumber: safeBlock,
+            });
+            return {
+              pool,
+              snapshot,
+            };
+          }),
+        )
+      : [];
   const clReplaySnapshots: {
     pool: ClReplayPool;
     snapshot: FameClReplaySnapshotRead;
@@ -1184,6 +2133,7 @@ export async function indexFamePoolStates({
 
   let clReplayWrittenPools = 0;
   const clReplayMetrics: FameClReplaySnapshotMetric[] = [];
+  const clReplayRowsByPoolId = new Map<string, FameClReplayStateRows>();
   for (const { pool, snapshot } of clReplaySnapshots) {
     const rows = clReplayRowsFromSnapshot({
       pool,
@@ -1197,6 +2147,7 @@ export async function indexFamePoolStates({
       tableName,
       rows,
     });
+    clReplayRowsByPoolId.set(pool.id, rows);
     if (result === "written") clReplayWrittenPools += 1;
     clReplayMetrics.push({
       poolId: pool.id,
@@ -1207,6 +2158,178 @@ export async function indexFamePoolStates({
       providerReadCount: snapshot.providerReadCount,
       durationMs: snapshot.durationMs,
       stateHash: rows.latest.stateHash,
+    });
+  }
+
+  const clReplayMaintenanceMetrics: FameClReplayMaintenanceMetric[] = [];
+  for (const pool of replayPools) {
+    const snapshotRows = clReplayRowsByPoolId.get(pool.id);
+    const latest = latestClReplayByPoolId.get(pool.id) ?? null;
+    const maintenance = latestClReplayMaintenanceByPoolId.get(pool.id) ?? null;
+    const seed =
+      clReplayMaintenanceMode === "repair" && snapshotRows
+        ? clReplayCapsuleFromRows(snapshotRows)
+        : snapshotRows && !latest
+          ? clReplayCapsuleFromRows(snapshotRows)
+          : latest ?? (snapshotRows ? clReplayCapsuleFromRows(snapshotRows) : null);
+    const replayFromBlockForPool =
+      replayFromBlockByPoolId.get(pool.id) ?? observedThroughBlock + 1;
+    const poolLogs = (clReplayRawLogsByPoolId.get(pool.id) ?? []).filter(
+      (log) =>
+        safeNumber(log.blockNumber, "CL replay log block number") >=
+        replayFromBlockForPool,
+    );
+    const fromBlockForMetric =
+      replayFromBlockForPool > observedThroughBlock
+        ? observedThroughBlock
+        : replayFromBlockForPool;
+
+    let applyResult: FameClReplayDeltaApplyResult;
+    try {
+      if (
+        replayFromBlockForPool <= observedThroughBlock &&
+        observedThroughBlock - replayFromBlockForPool + 1 >
+          clReplayMaxRangeBlocks
+      ) {
+        applyResult = {
+          status: "event-gap",
+          reason: "range-limit",
+          appliedEventCount: 0,
+        };
+      } else {
+        if (
+          clReplayMaintenanceMode === "steady-state" &&
+          maintenance !== null &&
+          replayFromBlockForPool <= observedThroughBlock
+        ) {
+          const cursorIdentity = await readBlockIdentity({
+            client,
+            blockNumber: maintenance.cursorBlock,
+          });
+          if (cursorIdentity.blockHash !== maintenance.cursorBlockHash) {
+            throw new Error("cursor-block-hash-mismatch");
+          }
+        }
+        const events = normalizeClReplayLogs({ pool, logs: poolLogs });
+        if (targetBlockIdentity === null) {
+          throw new Error("target-block-unavailable");
+        }
+        applyResult = applyClReplayDeltas({
+          pool,
+          seed,
+          events,
+          observedThroughBlock,
+          blockHash: snapshotRows?.latest.blockHash ?? targetBlockIdentity.blockHash,
+          parentHash:
+            snapshotRows?.latest.parentHash ?? targetBlockIdentity.parentHash,
+          candidateId: `cl-replay-candidate-v1:${pool.id}:${observedThroughBlock.toString()}:${sourceRegistryId}`,
+          sourceRegistryId,
+          updatedAt,
+        });
+      }
+    } catch (error) {
+      applyResult = {
+        status: "event-gap",
+        reason: errorMessage(error),
+        appliedEventCount: 0,
+      };
+    }
+
+    let candidateWritten = false;
+    let stateHash: Hex | null = null;
+    let maintenanceStatus: FameClReplayMaintenanceMetric["status"] =
+      "event-gap";
+    let reason: string | null = null;
+    let candidateId: string | null = null;
+    let quoteableRows: FameClReplayStateRows | null = null;
+    if (applyResult.status === "candidate") {
+      const writeResult = await putLatestClReplayCandidateState({
+        db,
+        tableName,
+        rows: applyResult.rows,
+      });
+      candidateWritten = writeResult === "written";
+      stateHash = applyResult.rows.latest.stateHash;
+      candidateId = applyResult.rows.latest.candidateId;
+      const driftClean =
+        snapshotRows === undefined ||
+        snapshotRows.latest.stateHash === applyResult.rows.latest.stateHash;
+      if (clReplayTrustPromotion && driftClean) {
+        quoteableRows = clReplayRowsFromCandidateRows({
+          pool,
+          rows: applyResult.rows,
+        });
+        await putLatestClReplayState({
+          db,
+          tableName,
+          rows: quoteableRows,
+        });
+        maintenanceStatus = "trusted";
+        reason = null;
+      } else if (clReplayTrustPromotion) {
+        maintenanceStatus = "drift-failed";
+        reason = "checkpoint-state-hash-mismatch";
+      } else {
+        maintenanceStatus = "warming";
+        reason = "shadow-not-promoted";
+      }
+    } else {
+      maintenanceStatus = applyResult.status;
+      reason = applyResult.reason;
+    }
+
+    await putLatestClReplayMaintenanceState({
+      db,
+      tableName,
+      state: {
+        ...latestClReplayMaintenanceStateKey(pool),
+        stateKind: "cl-replay-maintenance-v1",
+        poolId: pool.id,
+        chainId: pool.chainId,
+        poolAddress: pool.poolAddress,
+        status: maintenanceStatus,
+        cursorBlock: observedThroughBlock,
+        cursorBlockHash:
+          quoteableRows?.latest.blockHash ??
+          snapshotRows?.latest.blockHash ??
+          targetBlockIdentity?.blockHash ??
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+        cursorTransactionIndex: Number.MAX_SAFE_INTEGER,
+        cursorLogIndex: Number.MAX_SAFE_INTEGER,
+        targetBlock: observedThroughBlock,
+        targetBlockHash:
+          targetBlockIdentity?.blockHash ??
+          snapshotRows?.latest.blockHash ??
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+        stateHash:
+          stateHash ??
+          seed?.latest.stateHash ??
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+        sourceRegistryId,
+        updatedAt,
+        lastCheckpointBlock:
+          snapshotRows?.latest.observedThroughBlock ??
+          maintenance?.lastCheckpointBlock ??
+          null,
+        lastCheckpointBlockHash:
+          snapshotRows?.latest.blockHash ??
+          maintenance?.lastCheckpointBlockHash ??
+          null,
+        reason,
+        candidateId,
+      },
+    });
+
+    clReplayMaintenanceMetrics.push({
+      poolId: pool.id,
+      status: maintenanceStatus,
+      reason,
+      fromBlock: fromBlockForMetric,
+      toBlock: observedThroughBlock,
+      scannedLogCount: poolLogs.length,
+      appliedEventCount: applyResult.appliedEventCount,
+      candidateWritten,
+      stateHash,
     });
   }
 
@@ -1230,6 +2353,7 @@ export async function indexFamePoolStates({
     clReplayFailedPools: clReplayFailures.length,
     clReplayFailures,
     clReplayMetrics,
+    clReplayMaintenanceMetrics,
     sourceRegistryId,
   };
 }

--- a/src/fame-swap-pool-state/lambdas/indexer.ts
+++ b/src/fame-swap-pool-state/lambdas/indexer.ts
@@ -1,5 +1,8 @@
 import { baseClient } from "@/viem.ts";
 import {
+  FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE,
+  FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS,
+  FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION,
   FAME_POOL_STATE_CONFIRMATION_BLOCKS,
   FAME_POOL_STATE_TABLE_NAME,
 } from "../config.ts";
@@ -8,6 +11,7 @@ import {
   createViemPoolStateIndexerClient,
   indexFamePoolStates,
   type FamePoolStateIndexerClient,
+  type FameClReplayMaintenanceMode,
   type FamePoolStateIndexerResult,
 } from "../indexer.ts";
 import {
@@ -20,21 +24,33 @@ export type FamePoolStateIndexRunner = (options: {
   client?: FamePoolStateIndexerClient;
   tableName: string;
   confirmationBlocks: number;
+  clReplayMaintenanceMode: FameClReplayMaintenanceMode;
+  clReplayTrustPromotion: boolean;
+  clReplayMaxRangeBlocks: number;
 }) => Promise<FamePoolStateIndexerResult>;
 
 function defaultIndexPools({
   client,
   tableName,
   confirmationBlocks,
+  clReplayMaintenanceMode,
+  clReplayTrustPromotion,
+  clReplayMaxRangeBlocks,
 }: {
   client?: FamePoolStateIndexerClient;
   tableName: string;
   confirmationBlocks: number;
+  clReplayMaintenanceMode: FameClReplayMaintenanceMode;
+  clReplayTrustPromotion: boolean;
+  clReplayMaxRangeBlocks: number;
 }): Promise<FamePoolStateIndexerResult> {
   return indexFamePoolStates({
     client: client ?? createViemPoolStateIndexerClient(baseClient),
     tableName,
     confirmationBlocks,
+    clReplayMaintenanceMode,
+    clReplayTrustPromotion,
+    clReplayMaxRangeBlocks,
   });
 }
 
@@ -83,11 +99,17 @@ export async function handleFamePoolStateIndexer({
   client,
   tableName,
   confirmationBlocks,
+  clReplayMaintenanceMode,
+  clReplayTrustPromotion,
+  clReplayMaxRangeBlocks,
   indexPools = defaultIndexPools,
 }: {
   client?: FamePoolStateIndexerClient;
   tableName: string;
   confirmationBlocks: number;
+  clReplayMaintenanceMode?: FameClReplayMaintenanceMode;
+  clReplayTrustPromotion?: boolean;
+  clReplayMaxRangeBlocks?: number;
   indexPools?: FamePoolStateIndexRunner;
 }): Promise<void> {
   let result: FamePoolStateIndexerResult;
@@ -96,6 +118,12 @@ export async function handleFamePoolStateIndexer({
       client,
       tableName,
       confirmationBlocks,
+      clReplayMaintenanceMode:
+        clReplayMaintenanceMode ?? FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE,
+      clReplayTrustPromotion:
+        clReplayTrustPromotion ?? FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION,
+      clReplayMaxRangeBlocks:
+        clReplayMaxRangeBlocks ?? FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS,
     });
   } catch (error) {
     writePoolStateLog(
@@ -114,5 +142,8 @@ export async function handler(): Promise<void> {
   await handleFamePoolStateIndexer({
     tableName: FAME_POOL_STATE_TABLE_NAME,
     confirmationBlocks: FAME_POOL_STATE_CONFIRMATION_BLOCKS,
+    clReplayMaintenanceMode: FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE,
+    clReplayTrustPromotion: FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION,
+    clReplayMaxRangeBlocks: FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS,
   });
 }

--- a/src/fame-swap-pool-state/lambdas/logging.test.ts
+++ b/src/fame-swap-pool-state/lambdas/logging.test.ts
@@ -129,6 +129,7 @@ function indexerResult(
     clReplayFailedPools: 0,
     clReplayFailures: [],
     clReplayMetrics: [],
+    clReplayMaintenanceMetrics: [],
     sourceRegistryId: "registry",
     ...overrides,
   };

--- a/src/fame-swap-pool-state/lambdas/logging.ts
+++ b/src/fame-swap-pool-state/lambdas/logging.ts
@@ -195,6 +195,19 @@ function indexerResultLogFields(
       durationMs: metric.durationMs,
       stateHash: metric.stateHash,
     })),
+    clReplayMaintenanceMetrics: result.clReplayMaintenanceMetrics.map(
+      (metric) => ({
+        poolId: metric.poolId,
+        status: metric.status,
+        reason: metric.reason,
+        fromBlock: metric.fromBlock,
+        toBlock: metric.toBlock,
+        scannedLogCount: metric.scannedLogCount,
+        appliedEventCount: metric.appliedEventCount,
+        candidateWritten: metric.candidateWritten,
+        stateHash: metric.stateHash,
+      }),
+    ),
     sourceRegistryId: result.sourceRegistryId,
   };
 }

--- a/src/viem.ts
+++ b/src/viem.ts
@@ -14,6 +14,11 @@ export const sepoliaRpcs: string[] = JSON.parse(
 export const sepoliaClient = createPublicClient({
   transport: fallback(sepoliaRpcs.map((rpc) => http(rpc, { batch: true }))),
   chain: sepolia,
+  batch: {
+    multicall: {
+      batchSize: 512,
+    },
+  },
 });
 
 const mainnetRpcs: string[] = JSON.parse(process.env.MAINNET_RPCS_JSON || "[]");
@@ -21,6 +26,11 @@ const mainnetRpcs: string[] = JSON.parse(process.env.MAINNET_RPCS_JSON || "[]");
 export const mainnetClient = createPublicClient({
   transport: fallback(mainnetRpcs.map((rpc) => http(rpc, { batch: true }))),
   chain: mainnet,
+  batch: {
+    multicall: {
+      batchSize: 512,
+    },
+  },
 });
 
 const baseRpcs: string[] = JSON.parse(process.env.BASE_RPCS_JSON || "[]");
@@ -28,20 +38,9 @@ const baseRpcs: string[] = JSON.parse(process.env.BASE_RPCS_JSON || "[]");
 export const baseClient = createPublicClient({
   transport: fallback(baseRpcs.map((rpc) => http(rpc, { batch: true }))),
   chain: base,
+  batch: {
+    multicall: {
+      batchSize: 512,
+    },
+  },
 });
-
-const optimismRpcs: string[] = JSON.parse(
-  process.env.OPTIMISM_RPCS_JSON || "[]",
-);
-
-export const optimismClient = createPublicClient({
-  transport: fallback(optimismRpcs.map((rpc) => http(rpc, { batch: true }))),
-  chain: optimism,
-});
-
-export const createOptimismWallet = (account: Account) =>
-  createWalletClient({
-    account,
-    chain: optimism,
-    transport: http(optimismRpcs[0]),
-  });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -94,7 +94,7 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
-    "rootDir": "./src" /* Specify the root folder within your source files. */,
+    "rootDir": "." /* Specify the root folder within your source files. */,
     "outDir": "dist" /* Specify an output folder for all emitted files. */,
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
## Summary

FAME CL replay state can now move from a full checkpoint into trusted steady-state delta maintenance instead of requiring a full replay snapshot on every indexer wake. The quote API still fails closed unless the producer maintenance row proves the replay pointer is trusted, cursor-current, source-compatible, and state-hash compatible.

## What Changed

- Added a dedicated replay-maintenance lifecycle with trusted, warming, drift-failed, repairing, and event-gap states, plus non-quoteable candidate capsules using chunk-before-pointer publication.
- Added bounded CL log ingestion and deterministic replay reduction for Slipstream `Swap`, `Mint`, `Burn`, and no-op `Collect` events.
- Added checkpoint, steady-state, and repair modes behind Lambda/operator config so drift checks and repairs stay out of bearer-token read helper surfaces.
- Gated compact CL quotes on producer trust and added producer-untrusted unavailable evidence for fallback-safe `www` consumption.
- Added redacted smoke/report tooling, local route-lab helper, and docs for promotion evidence and provider-pressure signals.

## Evidence

| Check | Result |
| --- | --- |
| Local checkpoint seed using Doppler RPC | `status: trusted`, `clReplaySnapshots: 1` |
| Local steady-state delta pass | `status: trusted`, `clReplaySnapshots: 0`, `scannedLogCount: 119`, `appliedEventCount: 68` |
| `www` route lab against local helper | indexed mode reported `cl replay slipstream-usdc-weth-100 fresh block 46649071 ticks 307 hash 0xe4067cac` |
| Full tests | `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn test` passed: 10 suites, 112 tests |
| Types | `TMPDIR=/tmp YARN_CACHE_FOLDER=/tmp/yarn-cache yarn types` passed |

## Rollout Notes

Trust promotion defaults off. Operators can select `checkpoint`, `steady-state`, or `repair` with `FAME_POOL_STATE_CL_REPLAY_MAINTENANCE_MODE`, enable promotion with `FAME_POOL_STATE_CL_REPLAY_TRUST_PROMOTION=true`, and bound scans with `FAME_POOL_STATE_CL_REPLAY_MAX_RANGE_BLOCKS`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
