### PR TITLE
fix(fame): align pool-state registry after depeg route removal

### DIFF
--- a/scripts/fame-pool-state-delta-replay-smoke.test.ts
+++ b/scripts/fame-pool-state-delta-replay-smoke.test.ts
@@ -31,7 +31,6 @@ const ACTIVATION_ROWS: ActivationRow[] = [
     selectedCandidate: true,
     liveRouteDependencies: [LIVE_DEPENDENCY_POOL_ID],
   },
-  unrepresented("slipstream-msusd-usdc-a"),
   unrepresented("slipstream-spx-weth"),
   row("slipstream-usdc-frxusd", "cl-head-only", "present", "none"),
   row(
@@ -46,11 +45,8 @@ const ACTIVATION_ROWS: ActivationRow[] = [
     "producer-unrepresented",
     "none",
   ),
-  unrepresented("slipstream-weth-mseth"),
   row("slipstream-zora-usdc", "cl-head-only", "present", "none"),
   row("slipstream-zora-weth", "cl-head-only", "present", "none"),
-  unrepresented("slipstream2-msusd-mseth"),
-  unrepresented("slipstream2-msusd-usdc-c"),
   activeReserve("uniswap-v2-fame-direct"),
   activeReserve("uniswap-v2-usdc-weth"),
   row("uniswap-v3-usdc-weth-30bps", "cl-head-only", "present", "none"),
@@ -476,13 +472,7 @@ describe("FAME delta replay smoke report", () => {
     });
     expect(report.activationEvidence.nonPromotion).toMatchObject({
       blockedPoolIds: ["slipstream-usdc-weth-migrating-50"],
-      producerUnrepresentedPoolIds: [
-        "slipstream-msusd-usdc-a",
-        "slipstream-spx-weth",
-        "slipstream-weth-mseth",
-        "slipstream2-msusd-mseth",
-        "slipstream2-msusd-usdc-c",
-      ],
+      producerUnrepresentedPoolIds: ["slipstream-spx-weth"],
       trackedOnlyPoolIds: ["scale-equalizer-usdc-frxusd"],
       unsupportedPoolIds: [
         LIVE_DEPENDENCY_POOL_ID,
@@ -587,9 +577,9 @@ describe("FAME delta replay smoke report", () => {
       );
     expect(report.activationEvidence.status).toBe("ready");
     expect(report.activationEvidence.validationErrors).toEqual([]);
-    expect(report.activationEvidence.nonPromotion.unsupportedPoolIds).not.toContain(
-      ZORA_ETH_POOL_ID,
-    );
+    expect(
+      report.activationEvidence.nonPromotion.unsupportedPoolIds,
+    ).not.toContain(ZORA_ETH_POOL_ID);
     expect(zoraEthActivation).toMatchObject({
       poolId: ZORA_ETH_POOL_ID,
       status: "active",
@@ -600,9 +590,9 @@ describe("FAME delta replay smoke report", () => {
       provenanceStatus: "not-applicable",
       directionCoverage: ["ETH->ZORA", "ZORA->ETH"],
     });
-    expect(
-      zoraEthActivation?.poolQuoteGates.every((gate) => gate.passed),
-    ).toBe(true);
+    expect(zoraEthActivation?.poolQuoteGates.every((gate) => gate.passed)).toBe(
+      true,
+    );
     expect(
       zoraEthActivation?.routeEligibilityGates.every((gate) => gate.passed),
     ).toBe(false);
@@ -737,8 +727,6 @@ describe("FAME delta replay smoke report", () => {
     const mutableRows = ACTIVATION_ROWS.map((entry) => {
       if (
         entry.poolId === "scale-equalizer-usdc-frxusd" ||
-        entry.poolId === "slipstream2-msusd-mseth" ||
-        entry.poolId === "slipstream2-msusd-usdc-c" ||
         entry.poolId === LIVE_DEPENDENCY_POOL_ID ||
         entry.poolId === "uniswap-v4-usdc-eth" ||
         entry.poolId === "uniswap-v4-zora-eth"
@@ -773,14 +761,10 @@ describe("FAME delta replay smoke report", () => {
     expect(report.activationEvidence.nonPromotion.blockedPoolIds).toEqual([]);
     expect(
       report.activationEvidence.nonPromotion.producerUnrepresentedPoolIds,
-    ).toEqual(
-      expect.arrayContaining(["slipstream-usdc-weth-migrating-50"]),
-    );
+    ).toEqual(expect.arrayContaining(["slipstream-usdc-weth-migrating-50"]));
     expect(report.activationEvidence.nonPromotion.clHeadOnlyPoolIds).toEqual(
       expect.arrayContaining([
         "scale-equalizer-usdc-frxusd",
-        "slipstream2-msusd-mseth",
-        "slipstream2-msusd-usdc-c",
         LIVE_DEPENDENCY_POOL_ID,
         "uniswap-v4-usdc-eth",
         "uniswap-v4-zora-eth",
@@ -886,7 +870,7 @@ describe("FAME delta replay smoke report", () => {
     const missing = trustedActivationInput({
       activationReport: activationReport(ACTIVATION_ROWS.slice(0, -1)),
     });
-    missing.activationReport!.upstreamPoolCount = 26;
+    missing.activationReport!.upstreamPoolCount = 22;
     const duplicate = trustedActivationInput({
       activationReport: activationReport([
         ...ACTIVATION_ROWS,
@@ -899,7 +883,7 @@ describe("FAME delta replay smoke report", () => {
 
     expect(missingReport.activationEvidence.status).toBe("blocked");
     expect(missingReport.activationEvidence.validationErrors).toContain(
-      "Activation report row count 25 does not match upstreamPoolCount 26.",
+      "Activation report row count 21 does not match upstreamPoolCount 22.",
     );
     expect(duplicateReport.activationEvidence.status).toBe("blocked");
     expect(duplicateReport.activationEvidence.validationErrors).toContain(

--- a/scripts/fame-pool-state-delta-replay-smoke.ts
+++ b/scripts/fame-pool-state-delta-replay-smoke.ts
@@ -20,10 +20,7 @@ const LIVE_ROUTE_DEPENDENCY = "uniswap-v4-basedflick-zora";
 const BASELINE_CL_COMPACT_POOL_ID = "slipstream-usdc-weth-100";
 const DEFAULT_PROVIDER_READ_THRESHOLD = 1_000;
 const V4_REVIEWED_LANE_DIRECTION_COVERAGE: Record<string, readonly string[]> = {
-  [FAME_V4_ZORA_QUOTE_LANE_POOL_ID]: [
-    "BASEDFLICK->ZORA",
-    "ZORA->BASEDFLICK",
-  ],
+  [FAME_V4_ZORA_QUOTE_LANE_POOL_ID]: ["BASEDFLICK->ZORA", "ZORA->BASEDFLICK"],
   [FAME_V4_ZORA_ETH_QUOTE_LANE_POOL_ID]: ["ETH->ZORA", "ZORA->ETH"],
 };
 const FAME_UPSTREAM_POOL_UNIVERSE_POOL_IDS = [
@@ -34,16 +31,12 @@ const FAME_UPSTREAM_POOL_UNIVERSE_POOL_IDS = [
   "scale-equalizer-usdc-scale",
   "scale-equalizer-weth-fame",
   "slipstream-basedflick-fame",
-  "slipstream-msusd-usdc-a",
   "slipstream-spx-weth",
   "slipstream-usdc-frxusd",
   "slipstream-usdc-weth-100",
   "slipstream-usdc-weth-migrating-50",
-  "slipstream-weth-mseth",
   "slipstream-zora-usdc",
   "slipstream-zora-weth",
-  "slipstream2-msusd-mseth",
-  "slipstream2-msusd-usdc-c",
   "uniswap-v2-fame-direct",
   "uniswap-v2-usdc-weth",
   "uniswap-v3-usdc-weth-30bps",
@@ -177,11 +170,7 @@ export interface FameV4ZoraActivationEvidenceInput {
   poolId: string;
   status: "active" | "blocked" | "pending";
   reviewedPoolEvidenceKind?: FameV4ReviewedPoolEvidenceKind;
-  provenanceStatus:
-    | "verified"
-    | "missing"
-    | "mismatch"
-    | "not-applicable";
+  provenanceStatus: "verified" | "missing" | "mismatch" | "not-applicable";
   shapeStatus: "matched" | "mismatch" | "unknown";
   stateStatus: "fresh" | "stale" | "missing" | "incomplete";
   quoteStatus: "quoted" | "unavailable" | "missing";
@@ -592,8 +581,8 @@ function selectedQuoteSourcesFromQuoteApi(
   quoteContext: string | null,
 ): FameRouteLabSelectedQuoteSourceEvidence[] {
   return (
-    quoteApi?.diagnostics?.details
-      ?.flatMap((detail): FameRouteLabSelectedQuoteSourceEvidence[] => {
+    quoteApi?.diagnostics?.details?.flatMap(
+      (detail): FameRouteLabSelectedQuoteSourceEvidence[] => {
         const source = routeLabQuoteApiSource(detail.outcome, quoteContext);
         if (!source) return [];
         return [
@@ -605,7 +594,8 @@ function selectedQuoteSourcesFromQuoteApi(
             amountIn: detail.amountIn,
           },
         ];
-      }) ?? []
+      },
+    ) ?? []
   );
 }
 
@@ -723,7 +713,8 @@ function routeLabRowsValue(
           ? null
           : stringValue(row.routeArtifactId, `${path}.routeArtifactId`),
       selectedCandidateId:
-        row.selectedCandidateId === null || row.selectedCandidateId === undefined
+        row.selectedCandidateId === null ||
+        row.selectedCandidateId === undefined
           ? null
           : stringValue(row.selectedCandidateId, `${path}.selectedCandidateId`),
       materializedRouteHash:
@@ -869,26 +860,27 @@ function v4ZoraActivationValue(
       `${name}.provenanceStatus`,
       ["verified", "missing", "mismatch", "not-applicable"] as const,
     ),
-    shapeStatus: stringEnumValue(
-      input.shapeStatus,
-      `${name}.shapeStatus`,
-      ["matched", "mismatch", "unknown"] as const,
-    ),
-    stateStatus: stringEnumValue(
-      input.stateStatus,
-      `${name}.stateStatus`,
-      ["fresh", "stale", "missing", "incomplete"] as const,
-    ),
-    quoteStatus: stringEnumValue(
-      input.quoteStatus,
-      `${name}.quoteStatus`,
-      ["quoted", "unavailable", "missing"] as const,
-    ),
-    parityStatus: stringEnumValue(
-      input.parityStatus,
-      `${name}.parityStatus`,
-      ["passed", "failed", "missing"] as const,
-    ),
+    shapeStatus: stringEnumValue(input.shapeStatus, `${name}.shapeStatus`, [
+      "matched",
+      "mismatch",
+      "unknown",
+    ] as const),
+    stateStatus: stringEnumValue(input.stateStatus, `${name}.stateStatus`, [
+      "fresh",
+      "stale",
+      "missing",
+      "incomplete",
+    ] as const),
+    quoteStatus: stringEnumValue(input.quoteStatus, `${name}.quoteStatus`, [
+      "quoted",
+      "unavailable",
+      "missing",
+    ] as const),
+    parityStatus: stringEnumValue(input.parityStatus, `${name}.parityStatus`, [
+      "passed",
+      "failed",
+      "missing",
+    ] as const),
     routeSimulationStatus: stringEnumValue(
       input.routeSimulationStatus,
       `${name}.routeSimulationStatus`,
@@ -898,16 +890,11 @@ function v4ZoraActivationValue(
       input.directionCoverage,
       `${name}.directionCoverage`,
     ).map((direction, index) =>
-      stringValue(
-        direction,
-        `${name}.directionCoverage[${index.toString()}]`,
-      ),
+      stringValue(direction, `${name}.directionCoverage[${index.toString()}]`),
     ),
     sourceRegistryId:
-      optionalStringValue(
-        input.sourceRegistryId,
-        `${name}.sourceRegistryId`,
-      ) ?? undefined,
+      optionalStringValue(input.sourceRegistryId, `${name}.sourceRegistryId`) ??
+      undefined,
     evidenceId:
       optionalStringValue(input.evidenceId, `${name}.evidenceId`) ?? undefined,
     providerReadCount:
@@ -927,10 +914,7 @@ function v4ZoraActivationValue(
       ) ?? undefined,
     deferredHardening: Array.isArray(input.deferredHardening)
       ? input.deferredHardening.map((item, index) =>
-          stringValue(
-            item,
-            `${name}.deferredHardening[${index.toString()}]`,
-          ),
+          stringValue(item, `${name}.deferredHardening[${index.toString()}]`),
         )
       : undefined,
   };
@@ -1316,19 +1300,18 @@ function v4ZoraActivationEvidence(
     {
       name: "v4_zora_direction_coverage",
       passed: directionCoveragePassed,
-      detail:
-        directionCoveragePassed
-          ? base.directionCoverage.join(", ")
-          : [
-              missingDirections.length > 0
-                ? `missing ${missingDirections.join(", ")}`
-                : null,
-              unexpectedDirections.length > 0
-                ? `unexpected ${unexpectedDirections.join(", ")}`
-                : null,
-            ]
-              .filter((part): part is string => part !== null)
-              .join("; ") || "missing",
+      detail: directionCoveragePassed
+        ? base.directionCoverage.join(", ")
+        : [
+            missingDirections.length > 0
+              ? `missing ${missingDirections.join(", ")}`
+              : null,
+            unexpectedDirections.length > 0
+              ? `unexpected ${unexpectedDirections.join(", ")}`
+              : null,
+          ]
+            .filter((part): part is string => part !== null)
+            .join("; ") || "missing",
     },
     {
       name: "v4_zora_evidence_id_present",

--- a/src/fame-swap-pool-state/api.test.ts
+++ b/src/fame-swap-pool-state/api.test.ts
@@ -51,7 +51,7 @@ type SentCommand = Parameters<PoolStateDocumentClient["send"]>[0];
 
 const ADDRESS_A = "0x0000000000000000000000000000000000000001" as Address;
 const POOL_QUOTES_V1_FIXTURE_SHA256 =
-  "3218b241ffb1752f824c2eb58fc84dfad876927e3fc8716afc1c13a70a424594";
+  "79568c570c8965404cc994919e66c491850535c8fffcf2d6e8188eb8a8322774";
 
 class BatchStateDb implements PoolStateDocumentClient {
   public readCount = 0;
@@ -263,9 +263,7 @@ function clReplayCandidatePool(): FameClReplayRegistryEntry {
 function v4ClReplayPool(
   poolId = "uniswap-v4-basedflick-zora",
 ): FameV4ClReplayRegistryEntry {
-  const entry = famePoolStateRegistry.pools.find(
-    (pool) => pool.id === poolId,
-  );
+  const entry = famePoolStateRegistry.pools.find((pool) => pool.id === poolId);
   if (
     !entry ||
     entry.venue !== "uniswap-v4" ||

--- a/src/fame-swap-pool-state/cl-reducer-manifests.test.ts
+++ b/src/fame-swap-pool-state/cl-reducer-manifests.test.ts
@@ -79,7 +79,7 @@ describe("FAME CL reducer manifests", () => {
 
     const slipstream2 = {
       ...registryEntry(FAME_SELECTED_CL_REPLAY_CANDIDATE_POOL_ID),
-      id: "slipstream2-msusd-usdc-c",
+      id: "slipstream2-unit-usdc",
       venue: "aerodrome-slipstream2",
       venueFamily: "Slipstream2",
     } satisfies FamePoolStateRegistryEntry;

--- a/src/fame-swap-pool-state/fixtures/pool-quotes-v1.json
+++ b/src/fame-swap-pool-state/fixtures/pool-quotes-v1.json
@@ -15,14 +15,14 @@
       "chainId": 8453,
       "poolAddress": "0xbd7e5bb5a6251f6dde2cf56afa50ed0c8b4c2cdb",
       "observedThroughBlock": 120,
-      "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+      "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
       "maxFreshnessBlocks": 120,
       "producerStatus": "warming",
       "producerReason": "shadow-not-promoted"
     }
   ],
   "response": {
-    "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+    "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
     "currentBlock": 125,
     "producerMaxFreshnessBlocks": 120,
     "effectiveMaxFreshnessBlocks": 120,
@@ -47,7 +47,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+        "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -104,7 +104,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+        "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -161,7 +161,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+        "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -218,7 +218,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+        "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -275,7 +275,7 @@
         "amountIn": "500",
         "amountOut": "827",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+        "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -332,7 +332,7 @@
         "amountIn": "500",
         "amountOut": "165",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+        "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",
@@ -389,7 +389,7 @@
         "amountIn": "500",
         "amountOut": "831",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+        "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "2500000000000000000",
@@ -446,7 +446,7 @@
         "amountIn": "500",
         "amountOut": "166",
         "observedThroughBlock": 120,
-        "sourceRegistryId": "pool-state-registry-v4:0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f",
+        "sourceRegistryId": "pool-state-registry-v4:0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7:0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218:0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842",
         "maxFreshnessBlocks": 120,
         "priceImpact": {
           "preSwapPriceX18": "400000000000000000",

--- a/src/fame-swap-pool-state/registry/base-v1-pools.json
+++ b/src/fame-swap-pool-state/registry/base-v1-pools.json
@@ -5,11 +5,11 @@
     "repo": "www",
     "schemaVersion": 1,
     "pinnedBaseBlock": 45884844,
-    "poolsJsonHash": "0x7867763b3c520edb717f71186f8ee47364fb66871f82b9c8c830e7d911e3839b",
-    "poolsContentHash": "0xcf346fe2875d030a9b5872895e59e044e6e2b01613e3f3072c721c49c2234715",
+    "poolsJsonHash": "0x582b48fdaeb3c88bfc40415ba5a86d1cfd1bd4fe208fa6533f3681c02700f1c7",
+    "poolsContentHash": "0xca5d31d8b6266a075137c83d58b00bce1c763f30b73388719a6e2bce29085fcf",
     "solverRoutesJsonHash": "0x44cd1807a871080e02630714058ccd2545746712c9b382ffe4411223feeaf218",
     "solverRoutesContentHash": "0x053806dd44f7bf3751a0675b628dd4558a155a9608e8635f8cbdb180c48041a8",
-    "activationLedgerHash": "0xb533796d3cec89d202f49e0245c9769cba8aa7c92ad537fe33cfc44597927c0f"
+    "activationLedgerHash": "0x4212d61e225b7504c307c9ea60783147d485ea16e59bd8e0254257b5e6d59842"
   },
   "candidateDirections": [
     {


### PR DESCRIPTION
## Summary
The producer smoke and compact quote fixtures now agree with the route universe that no longer includes msUSD or msETH legs. Registry provenance points at the new upstream pool artifact and activation ledger, so stale pool-state rows and fixtures cannot masquerade as current after the depeg route removal.

## Validation
- `yarn test --runInBand scripts/fame-pool-state-delta-replay-smoke.test.ts src/fame-swap-pool-state/cl-reducer-manifests.test.ts src/fame-swap-pool-state/api.test.ts`
- `yarn types`
- `yarn prettier --check scripts/fame-pool-state-delta-replay-smoke.ts scripts/fame-pool-state-delta-replay-smoke.test.ts src/fame-swap-pool-state/cl-reducer-manifests.test.ts src/fame-swap-pool-state/registry/base-v1-pools.json src/fame-swap-pool-state/fixtures/pool-quotes-v1.json src/fame-swap-pool-state/api.test.ts`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
